### PR TITLE
Untitled

### DIFF
--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -230,7 +230,11 @@ module Ohai
       when Hash,Mash,Array
         JSON.pretty_generate(@data[a])
       when String
-        JSON.pretty_generate(@data[a].to_a)
+        if @data[a].respond_to?(:lines) then
+  	  JSON.pretty_generate(@data[a].lines.to_a)
+        else
+          JSON.pretty_generate(@data[a].to_a)
+	end
       else
         raise ArgumentError, "I can only generate JSON for Hashes, Mashes, Arrays and Strings. You fed me a #{@data[a].class}!"
       end


### PR DESCRIPTION
Fix for OHAI-230: ruby 1.9 can't String.to_a (which breaks ohai platform for instance)
