### PR TITLE
Added a small plugin to detect the scopes of network interfaces.

### DIFF
--- a/lib/ohai/plugins/ip_scopes.rb
+++ b/lib/ohai/plugins/ip_scopes.rb
@@ -19,7 +19,7 @@ begin
 
   require 'ipaddr_extensions'
 
-  provides "network_ip_scope"
+  provides "network_ip_scope", "privateaddress"
 
   network Mash.new unless network
   network[:interfaces] = Mash.new unless network[:interfaces]
@@ -31,6 +31,7 @@ begin
     network['interfaces'][ifName]['addresses'].each do |address,attrs|
       begin
         attrs.merge! 'ip_scope' => address.to_ip.scope
+        privateaddress address if address.to_ip.scope =~ /PRIVATE/
       rescue ArgumentError
         # Just silently fail if we can't create an IP from the string.
       end


### PR DESCRIPTION
I've added the ip_scopes.rb plugin that uses the ipaddr_extensions gem to detect the scope of the network interfaces detected on the machine:

```
  "lo0": {
    "number": "0",
    "flags": [
      "UP",
      "LOOPBACK",
      "RUNNING",
      "MULTICAST"
    ],
    "addresses": {
      "::1": {
        "scope": "Node",
        "prefixlen": "128",
        "family": "inet6",
        "ip_scope": "LINK LOCAL LOOPBACK"
      },
      "fe80::1": {
        "scope": "Link",
        "prefixlen": "64",
        "family": "inet6",
        "ip_scope": "LINK LOCAL UNICAST"
      },
      "127.0.0.1": {
        "netmask": "255.0.0.0",
        "family": "inet",
        "ip_scope": "LOOPBACK"
      }
    },
    "mtu": "16384",
    "type": "lo",
    "encapsulation": "Loopback"
  },

  "en0": {
    "number": "0",
    "flags": [
      "UP",
      "BROADCAST",
      "SMART",
      "RUNNING",
      "SIMPLEX",
      "MULTICAST"
    ],
    "addresses": {
      "fe80::cabc:c8ff:fe92:c43a": {
        "scope": "Link",
        "prefixlen": "64",
        "family": "inet6",
        "ip_scope": "LINK LOCAL UNICAST"
      },
      "c8:bc:c8:92:c4:3a": {
        "family": "lladdr"
      },
      "130.216.66.1": {
        "netmask": "255.255.254.0",
        "broadcast": "130.216.67.255",
        "family": "inet",
        "ip_scope": "GLOBAL UNICAST"
      }
    },
    "mtu": "1500",
    "type": "en",
    "encapsulation": "Ethernet"
  },
```
