### PR TITLE
[OHAI-263] Fix to add placement_availability_zone, public_keys, block_dev

### DIFF
--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -71,7 +71,7 @@ module Ohai
                 http_client.get("#{EC2_METADATA_URL}/#{key}").body
               end
           else
-            next
+            fetch_metadata(key).each{|k,v| metadata[k] = v}
           end
         end
         metadata


### PR DESCRIPTION
[OHAI-263] Fix to add placement_availability_zone, public_keys, block_device_mapping, etc back into ohai ec2 output
