### PR TITLE
Make Ohai JRuby compatible

### DIFF
--- a/lib/ohai/json_parser.rb
+++ b/lib/ohai/json_parser.rb
@@ -1,0 +1,31 @@
+module Ohai
+  class JsonParser
+    # Choose the right json library based on whether we are in JRuby or not.
+    if RUBY_PLATFORM == "java"
+      require 'rubygems'
+      require 'json'
+
+      # Serialize this object as a hash
+      def to_json(data)
+        JSON[data]
+      end
+
+      # Pretty Print this object as JSON
+      def json_pretty_print(data)
+        JSON.pretty_generate(data)
+      end
+    else
+      require 'yajl'
+
+      # Serialize this object as a hash
+      def to_json(data)
+        Yajl::Encoder.new.encode(data)
+      end
+
+      # Pretty Print this object as JSON
+      def json_pretty_print(data)
+        Yajl::Encoder.new(:pretty => true).encode(data)
+      end
+    end
+  end
+end

--- a/lib/ohai/mixin/command.rb
+++ b/lib/ohai/mixin/command.rb
@@ -23,6 +23,8 @@ require 'tmpdir'
 require 'fcntl'
 require 'etc'
 require 'systemu'
+require 'ohai/mixin/jruby_command'
+require 'timeout'
 
 module Ohai
   module Mixin
@@ -77,6 +79,18 @@ module Ohai
 
       module_function :run_command
 
+      def run_command_jruby(command, timeout)
+        begin
+          Timeout.timeout(timeout) do
+            return JrubyCommand.new(command).execute
+          end
+        rescue Timeout::Error => e
+          Ohai::Log.error("#{command} exceeded timeout #{timeout}")
+          raise(e)
+        end
+        return JrubyCommand.new(command).execute
+      end
+
       def run_command_unix(command, timeout)
         stderr_string, stdout_string, status = "", "", nil
 
@@ -116,6 +130,8 @@ module Ohai
 
       if RUBY_PLATFORM =~ /mswin|mingw32|windows/
         alias :run_command_backend :run_command_windows
+      elsif RUBY_PLATFORM =~ /java/
+        alias :run_command_backend :run_command_jruby
       else
         alias :run_command_backend :run_command_unix
       end

--- a/lib/ohai/mixin/command_splitter.rb
+++ b/lib/ohai/mixin/command_splitter.rb
@@ -1,0 +1,49 @@
+module Ohai
+  module Mixin
+
+    # This module helps in splitting a given command on spaces. Since Java's ProcessBuilder expects an array of command and arguments
+    # we need to take care of splitting the command that the Ohai plugins pass.
+    module CommandSplitter
+      def quoted_command_parts(command)
+        in_quote = false
+        original_command = ""
+        all_quoted_word = []
+        word = ""
+        command.chars.each do |char|
+          if char == "\""
+            in_quote = !in_quote
+            if !in_quote
+              all_quoted_word << word
+              word = ""
+              original_command = original_command + "__SOMETHING_THAT_MOST_LIKELY_IS_NOT_IN_THE_ARGUMENTS__"
+            end
+          else
+            if in_quote
+              word = word + char.to_s
+            else
+              original_command = original_command + char.to_s
+            end
+          end
+        end
+        return original_command, all_quoted_word
+      end
+
+      # This splits the command on a space. Whatever is in a quote is treated as a sinle entity and is not splitted
+      # For example: ruby -e "puts 'hello world'" would become: [ruby, -e, puts 'hello world']. Note that the double quotes
+      # are not retained
+      def split_command(command)
+        command, quoted = quoted_command_parts(command)
+        quote_replaced_command = command.split
+        command_parts = []
+        quote_replaced_command.each do |t|
+          if t == "__SOMETHING_THAT_MOST_LIKELY_IS_NOT_IN_THE_ARGUMENTS__"
+            command_parts << quoted.delete_at(0)
+          else
+            command_parts << t
+          end
+        end
+        command_parts
+      end
+    end
+  end
+end

--- a/lib/ohai/mixin/jruby_command.rb
+++ b/lib/ohai/mixin/jruby_command.rb
@@ -1,0 +1,103 @@
+module Ohai
+  module Mixin
+    require 'tempfile'
+    require 'ohai/mixin/command_splitter'
+
+    # This class understands how to execute a command using the Java's ProcessBuilder. Since Java does not support
+    # fork, we cannot use the usual open4 library. We need to use this instead. Refer to the documentation of
+    # java.lang.ProcessBuilder for more information on how this works.
+    class JrubyCommand
+
+      include Ohai::Mixin::CommandSplitter
+
+      def initialize command
+        @command = command
+      end
+
+      def execute
+        pumper_type, out, err  = start(@command)
+        @out_file = Tempfile.new("out_file")
+        @err_file = Tempfile.new("err_file")
+        @out_pumper = pumper_type.new(out, @out_file)
+        @err_pumper = pumper_type.new(err, @err_file)
+        status = @process.waitFor
+        die
+        @out_file.rewind
+        @err_file.rewind
+        out = @out_file.read
+        err = @err_file.read
+        return Class.new() do
+
+          def initialize(status)
+            @status = status
+          end
+
+          def exitstatus
+            @status
+          end
+        end.new(status), out, err
+      end
+
+      private
+
+      def start(command)
+        require 'java'
+        pb = java.lang.ProcessBuilder.new(split_command(command))
+        ENV.each do |key, val|
+          pb.environment[key] = val
+        end
+        @process = pb.start()
+        return Class.new(StreamPumper) do
+          def data_available?
+            @stream.ready
+          end
+
+          def read
+            @stream.read_line
+          end
+
+          def stop_pumping!
+            super
+            @stream.close
+          end
+        end, buf_reader(@process.input_stream), buf_reader(@process.error_stream)
+      end
+
+      def buf_reader stream
+        java.io.BufferedReader.new(java.io.InputStreamReader.new(stream))
+      end
+
+      def die
+        @out_pumper.stop_pumping!
+        @err_pumper.stop_pumping!
+      end
+
+      # We need to consume the out and error streams of the started process. If not, the process hangs for them to be consumes once the buffer
+      # fills up. So, we read them out and store them in a file so that it can consumed later
+      class StreamPumper
+        def initialize stream, file
+          @stream, @file = stream,file
+          @thd = Thread.new { pump }
+        end
+
+        def pump
+          loop do
+            data_available? && flush_stream
+            Thread.current[:stop_pumping] && break
+            sleep 0.001
+          end
+        end
+
+        def flush_stream
+          @file.write(read)
+          @file.flush
+        end
+
+        def stop_pumping!
+          @thd[:stop_pumping] = true
+          @thd.join
+        end
+      end
+    end
+  end
+end

--- a/lib/ohai/plugins/ruby.rb
+++ b/lib/ohai/plugins/ruby.rb
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,7 +48,7 @@ values = {
 
 # Create a query string from above hash
 env_string = ""
-values.keys.each do |v| 
+values.keys.each do |v|
   env_string << "#{v}=\#{#{values[v]}},"
 end
 
@@ -64,7 +64,7 @@ end
 # Perform one more (conditional) query
 bin_dir = languages[:ruby][:bin_dir]
 ruby_bin = languages[:ruby][:ruby_bin]
-gem_binaries = [ 
+gem_binaries = [
   run_ruby("require 'rubygems'; puts ::Gem.default_exec_format % 'gem'"),
   "gem"
 ].map {|bin| ::File.join(bin_dir, bin)}

--- a/lib/ohai/plugins/solaris2/hostname.rb
+++ b/lib/ohai/plugins/solaris2/hostname.rb
@@ -23,7 +23,13 @@ provides "hostname", "fqdn"
 
 hostname from("hostname")
 
-fqdn_lookup = Socket.getaddrinfo(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first[2]
+# AI_CANONNAME is a native flag which is not available in the Java environment. Instead, use AI_PASSIVE. This is not exactly the same,
+# but there is no other way of achieving this.
+if RUBY_PLATFORM =~ /java/
+  fqdn_lookup = Socket.getaddrinfo(hostname, nil, nil, nil, nil, Socket::AI_PASSIVE).first[2]
+else
+  fqdn_lookup = Socket.getaddrinfo(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first[2]
+end
 
 if fqdn_lookup.split('.').length > 1
   # we recieved an fqdn

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -21,8 +21,7 @@ require 'ohai/log'
 require 'ohai/mixin/from_file'
 require 'ohai/mixin/command'
 require 'ohai/mixin/string'
-
-require 'yajl'
+require 'ohai/json_parser'
 
 module Ohai
   class System
@@ -92,7 +91,7 @@ module Ohai
         return md[1]
       end
     end
-    
+
     def set_attribute(name, *values)
       @data[name] = Array18(*values)
       @data[name]
@@ -205,12 +204,12 @@ module Ohai
 
     # Serialize this object as a hash
     def to_json
-      Yajl::Encoder.new.encode(@data)
+      Ohai::JsonParser.new.to_json(@data)
     end
 
     # Pretty Print this object as JSON
     def json_pretty_print(item=nil)
-      Yajl::Encoder.new(:pretty => true).encode(item || @data)
+      Ohai::JsonParser.new.json_pretty_print(item || @data)
     end
 
     def attributes_print(a)
@@ -240,7 +239,7 @@ module Ohai
     end
 
     private
-    
+
     def Array18(*args)
       return nil if args.empty?
       return args.first if args.length == 1

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -5,7 +5,7 @@ require 'ohai/version'
 spec = Gem::Specification.new do |s|
   s.name = "ohai"
   s.version = Ohai::VERSION
-  s.platform = Gem::Platform::RUBY
+  s.platform = RUBY_PLATFORM =~ /java/ ? "java" : Gem::Platform::RUBY
   s.has_rdoc = true
   s.summary = "Ohai profiles your system and emits JSON"
   s.description = s.summary
@@ -13,7 +13,11 @@ spec = Gem::Specification.new do |s|
   s.email = "adam@opscode.com"
   s.homepage = "http://wiki.opscode.com/display/ohai"
 
-  s.add_dependency "yajl-ruby"
+  if RUBY_PLATFORM =~ /java/
+    s.add_dependency "json"
+  else
+    s.add_dependency "yajl-ruby"
+  end
   s.add_dependency "systemu"
   s.add_dependency "mixlib-cli"
   s.add_dependency "mixlib-config"

--- a/spec/ohai/mixin/command_spec.rb
+++ b/spec/ohai/mixin/command_spec.rb
@@ -20,7 +20,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper.rb')
 
 describe Ohai::Mixin::Command, "popen4" do
-  break if RUBY_PLATFORM =~ /(win|w)32$/
+  break if RUBY_PLATFORM =~ /(win|w)32$/ || RUBY_PLATFORM =~ /java/
 
   it "should default all commands to be run in the POSIX standard C locale" do
     Ohai::Mixin::Command.popen4("echo $LC_ALL") do |pid, stdin, stdout, stderr|

--- a/spec/ohai/mixin/command_splitter_spec.rb
+++ b/spec/ohai/mixin/command_splitter_spec.rb
@@ -1,0 +1,19 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper.rb')
+require 'ohai/mixin/command_splitter'
+describe Ohai::Mixin::CommandSplitter do
+
+  include Ohai::Mixin::CommandSplitter
+
+  it "should split based on space" do
+    split_command("ruby hello_world.rb").should == ["ruby", "hello_world.rb"]
+  end
+
+  it "should consider quoted strings as a single arg" do
+    split_command("ruby -e \"hello world\"").should == ["ruby", "-e", "hello world"]
+  end
+
+  it "should consider many quoted strings as a single arg" do
+    split_command("ruby \"second arg\" -e \"hello world\"").should == ["ruby", "second arg","-e", "hello world"]
+  end
+
+end

--- a/spec/ohai/plugins/ruby_spec.rb
+++ b/spec/ohai/plugins/ruby_spec.rb
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,7 @@ describe Ohai::System, "plugin ruby" do
 
   before(:each) do
     @ohai = Ohai::System.new
-    @ohai[:languages] = Mash.new    
+    @ohai[:languages] = Mash.new
     @ohai.stub!(:require_plugin).and_return(true)
   end
 
@@ -33,14 +33,14 @@ describe Ohai::System, "plugin ruby" do
     :platform => RUBY_PLATFORM,
     :version => RUBY_VERSION,
     :release_date => RUBY_RELEASE_DATE,
-    :target => ::Config::CONFIG['target'],
-    :target_cpu => ::Config::CONFIG['target_cpu'],
-    :target_vendor => ::Config::CONFIG['target_vendor'],
-    :target_os => ::Config::CONFIG['target_os'],
-    :host => ::Config::CONFIG['host'],
-    :host_cpu => ::Config::CONFIG['host_cpu'],
-    :host_os => ::Config::CONFIG['host_os'],
-    :host_vendor => ::Config::CONFIG['host_vendor'],
+    :target => ::Config::CONFIG['target'] || "",
+    :target_cpu => ::Config::CONFIG['target_cpu'] || "",
+    :target_vendor => ::Config::CONFIG['target_vendor'] || "",
+    :target_os => ::Config::CONFIG['target_os'] || "",
+    :host => ::Config::CONFIG['host'] || "",
+    :host_cpu => ::Config::CONFIG['host_cpu'] || "",
+    :host_os => ::Config::CONFIG['host_os'] || "",
+    :host_vendor => ::Config::CONFIG['host_vendor'] || "",
     :gems_dir => %x{#{ruby_bin} #{::Config::CONFIG['bindir']}/gem env gemdir}.chomp!,
     :gem_bin => [ ::Gem.default_exec_format % 'gem', 'gem' ].map{|bin| "#{::Config::CONFIG['bindir']}/#{bin}"
       }.find{|bin| ::File.exists? bin},
@@ -51,5 +51,5 @@ describe Ohai::System, "plugin ruby" do
       @ohai[:languages][:ruby][attribute].should eql(value)
     end
   end
-  
+
 end


### PR DESCRIPTION
Right now, Ohai depends on yajl to do the JSON parsing. This has native dependencies and hence does not work in JRuby. The second problem is that JRuby does not support fork and hence open4 cannot be used to execute commands by the plugins.

In this patch, I use "json" gem if we are in JRuby. I also use java.lang.ProcessBuilder instead of open4 to execute the plugin commands when in JRuby environment. Tweaked a few tests to make sure they do the right things in both MRI and JRuby.

Fix the gem spec so that we get a ohai-jruby gem or a ohai-gem based on which ruby we use to generate the gem.
