### PR TITLE
Fixed parsing of network interface type/number beyond number 9 (e.g., eth10)

### DIFF
--- a/lib/ohai/plugins/darwin/network.rb
+++ b/lib/ohai/plugins/darwin/network.rb
@@ -108,7 +108,7 @@ popen4("ifconfig -a") do |pid, stdin, stdout, stderr|
         flags = Array.new
       end
       iface[cint][:flags] = flags.flatten
-      if cint =~ /^(\w+)(\d+.*)/
+      if cint =~ /^(\w+?)(\d+.*)/
         iface[cint][:type] = $1
         iface[cint][:number] = $2
         iface[cint][:encapsulation] = encaps_lookup($1)

--- a/lib/ohai/plugins/freebsd/network.rb
+++ b/lib/ohai/plugins/freebsd/network.rb
@@ -37,7 +37,7 @@ popen4("/sbin/ifconfig -a") do |pid, stdin, stdout, stderr|
     if line =~ /^([0-9a-zA-Z\.]+):\s+/
       cint = $1
       iface[cint] = Mash.new
-      if cint =~ /^(\w+)(\d+.*)/
+      if cint =~ /^(\w+?)(\d+.*)/
         iface[cint][:type] = $1
         iface[cint][:number] = $2
       end

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -50,7 +50,7 @@ popen4("ifconfig -a") do |pid, stdin, stdout, stderr|
     if line =~ /^([0-9a-zA-Z\.\:\-_]+)\s+/
       cint = $1
       iface[cint] = Mash.new
-      if cint =~ /^(\w+)(\d+.*)/
+      if cint =~ /^(\w+?)(\d+.*)/
         iface[cint][:type] = $1
         iface[cint][:number] = $2
       end

--- a/lib/ohai/plugins/netbsd/network.rb
+++ b/lib/ohai/plugins/netbsd/network.rb
@@ -37,7 +37,7 @@ popen4("/sbin/ifconfig -a") do |pid, stdin, stdout, stderr|
     if line =~ /^([0-9a-zA-Z\.]+):\s+/
       cint = $1
       iface[cint] = Mash.new
-      if cint =~ /^(\w+)(\d+.*)/
+      if cint =~ /^(\w+?)(\d+.*)/
         iface[cint][:type] = $1
         iface[cint][:number] = $2
       end

--- a/lib/ohai/plugins/openbsd/network.rb
+++ b/lib/ohai/plugins/openbsd/network.rb
@@ -37,7 +37,7 @@ popen4("/sbin/ifconfig -a") do |pid, stdin, stdout, stderr|
     if line =~ /^([0-9a-zA-Z\.]+):\s+/
       cint = $1
       iface[cint] = Mash.new
-      if cint =~ /^(\w+)(\d+.*)/
+      if cint =~ /^(\w+?)(\d+.*)/
         iface[cint][:type] = $1
         iface[cint][:number] = $2
       end

--- a/lib/ohai/plugins/sigar/network.rb
+++ b/lib/ohai/plugins/sigar/network.rb
@@ -46,7 +46,7 @@ net_counters = Mash.new
 
 sigar.net_interface_list.each do |cint|
   iface[cint] = Mash.new
-  if cint =~ /^(\w+)(\d+.*)/
+  if cint =~ /^(\w+?)(\d+.*)/
     iface[cint][:type] = $1
     iface[cint][:number] = $2
   end

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -88,7 +88,7 @@ popen4("ifconfig -a") do |pid, stdin, stdout, stderr|
         flags = Array.new
       end
       iface[cint][:flags] = flags.flatten
-      if cint =~ /^(\w+)(\d+.*)/
+      if cint =~ /^(\w+?)(\d+.*)/
         iface[cint][:type] = $1
         iface[cint][:number] = $2
         iface[cint][:encapsulation] = encaps_lookup($1)


### PR DESCRIPTION
Fixed greedy match that interfered with proper parsing of network interfaces beyond number 9.  Since \w matches numbers and letters, it would match "eth1" from "eth10", so "type" would be "eth1" and "number" would be "0" -- clearly the wrong thing.  I made \w+ non-greedy, so all the numbers get grouped together appropriately.
