### PR TITLE
Patched Solaris platform plugin to use Solaris uname instead of GNU uname on OpenIndiana/OpenSolaris..

### DIFF
--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -28,12 +28,29 @@ popen4("#{uname_exec} -X") do |pid, stdin, stdout, stderr|
   stdin.close
   stdout.each do |line|
     case line
-    when /^System =\s+(.+)$/
-      platform = ($1.eql?("SunOS") ? "solaris2" : $1.downcase)
     when /^Release =\s+(.+)$/
       platform_version $1
     when /^KernelID =\s+(.+)$/
       platform_build $1
+    end
+  end
+end
+
+File.open("/etc/release") do |file|
+  while line = file.gets
+    case line
+    when /^\s*(OpenIndiana).*oi_(\d+).*$/
+      platform "openindiana"
+      platform_version $2
+    when /^\s*(OpenSolaris).*snv_(\d+).*$/
+      platform "opensolaris"
+      platform_version $2
+    when /^\s*(Oracle Solaris) (\d+)\s.*$/
+      platform "solaris2"
+    when /^\s*(Solaris)\s.*$/
+      platform "solaris2"
+    when /^\s*(NexentaCore)\s.*$/
+      platform "nexentacore"
     end
   end
 end


### PR DESCRIPTION
Patched Solaris platform plugin to use Solaris uname instead of GNU uname on OpenIndiana.

When using OpenIndiana (or OpenSolaris) the default uname is GNU uname which does not support the -X argument. However, the Solaris uname is still available under /sbin/uname. This patch uses /sbin/uname if it's available or falls back to just 'uname' if it isn't.
