### PR TITLE
OHAI-277 fix, use ruby_bin instead of "ruby" as binary name

### DIFF
--- a/lib/ohai/plugins/ruby.rb
+++ b/lib/ohai/plugins/ruby.rb
@@ -22,7 +22,8 @@ require_plugin "languages"
 
 
 def run_ruby(command)
-  cmd = "ruby -e \"require 'rbconfig'; #{command}\""
+  ruby_bin = File.join(::Config::CONFIG['bindir'], ::Config::CONFIG['ruby_install_name'])
+  cmd = "#{ruby_bin} -e \"require 'rbconfig'; #{command}\""
   status, stdout, stderr = run_command(:no_status_check => true, :command => cmd)
   stdout.strip
 end

--- a/spec/ohai/plugins/ruby_spec.rb
+++ b/spec/ohai/plugins/ruby_spec.rb
@@ -52,4 +52,12 @@ describe Ohai::System, "plugin ruby" do
     end
   end
   
+  it "[OHAI-277] should use ruby_bin in run_ruby" do
+    @ohai.should_receive(:run_command).with(
+      :no_status_check=>true,
+      :command=>"#{ruby_bin} -e \"require 'rbconfig'; puts %Q(platform=\#{RUBY_PLATFORM},version=\#{RUBY_VERSION},release_date=\#{RUBY_RELEASE_DATE},target=\#{::Config::CONFIG['target']},target_cpu=\#{::Config::CONFIG['target_cpu']},target_vendor=\#{::Config::CONFIG['target_vendor']},target_os=\#{::Config::CONFIG['target_os']},host=\#{::Config::CONFIG['host']},host_cpu=\#{::Config::CONFIG['host_cpu']},host_os=\#{::Config::CONFIG['host_os']},host_vendor=\#{::Config::CONFIG['host_vendor']},bin_dir=\#{::Config::CONFIG['bindir']},ruby_bin=\#{::File.join(::Config::CONFIG['bindir'], ::Config::CONFIG['ruby_install_name'])},)\""
+    )
+    @ohai._require_plugin("ruby")
+  end
+  
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/OHAI-277
