### PR TITLE
ohai / filesystem.rb blocks on df -P unresponsiveness.

### DIFF
--- a/lib/ohai/plugins/linux/filesystem.rb
+++ b/lib/ohai/plugins/linux/filesystem.rb
@@ -18,6 +18,8 @@
 
 provides "filesystem"
 
+require 'timeout'
+
 fs = Mash.new
 
 # Grab filesystem data from df


### PR DESCRIPTION
When the df -P child process hangs it blocks the entire process.  It also happens from the shell, which will also become unresponsive. This occurs when a remote nfs mount is unreachable. 
