### PR TITLE
Modified linux/virtualization to look for /proc/xen and then /dev/xen/evt

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -22,11 +22,12 @@ virtualization Mash.new
 
 # if it is possible to detect paravirt vs hardware virt, it should be put in
 # virtualization[:mechanism]
-if File.exists?("/proc/xen/capabilities")
-  virtualization[:system] = "xen"
-  if File.read("/proc/xen/capabilities") =~ /control_d/i
+if File.exists?("/proc/xen")
+  if File.exists?("/dev/xen/evtchn")
+    virtualization[:system] = "xen"
     virtualization[:role] = "host"
   else
+    virtualization[:system] = "xen"
     virtualization[:role] = "guest"
   end
 end

--- a/spec/ohai/plugins/linux/virtualization_spec.rb
+++ b/spec/ohai/plugins/linux/virtualization_spec.rb
@@ -26,26 +26,27 @@ describe Ohai::System, "Linux virtualization platform" do
     @ohai.extend(SimpleFromFile)
 
     # default to all requested Files not existing
-    File.stub!(:exists?).with("/proc/xen/capabilities").and_return(false)
+    File.stub(:exists?).with("/proc/xen").and_return(false)
+    File.stub(:exists?).with("/dev/xen/evtchn").and_return(false)
     File.stub!(:exists?).with("/proc/modules").and_return(false)
     File.stub!(:exists?).with("/proc/cpuinfo").and_return(false)
     File.stub!(:exists?).with("/usr/sbin/dmidecode").and_return(false)
     File.stub!(:exists?).with("/proc/self/status").and_return(false)
-		File.stub!(:exists?).with("/proc/user_beancounters").and_return(false)
+    File.stub!(:exists?).with("/proc/user_beancounters").and_return(false)
   end
 
   describe "when we are checking for xen" do
-    it "should set xen host if /proc/xen/capabilities contains control_d" do
-      File.should_receive(:exists?).with("/proc/xen/capabilities").and_return(true)
-      File.stub!(:read).with("/proc/xen/capabilities").and_return("control_d")
+    it "should set xen host if /proc/xen " do
+      File.should_receive(:exists?).with("/proc/xen").and_return(true)
+      File.should_receive(:exists?).with("/dev/xen/evtchn").and_return(true)
       @ohai._require_plugin("linux::virtualization")
       @ohai[:virtualization][:system].should == "xen"
       @ohai[:virtualization][:role].should == "host"
     end
 
-    it "should set xen guest if /proc/xen/capabilities exists" do
-      File.should_receive(:exists?).with("/proc/xen/capabilities").and_return(true)
-      File.stub!(:read).with("/proc/xen/capabilities").and_return("")
+    it "should set xen guest if no /dev/xen/evtchn" do
+      File.should_receive(:exists?).with("/proc/xen").and_return(true)
+      File.should_receive(:exists?).with("/dev/xen/evtchn").and_return(false)
       @ohai._require_plugin("linux::virtualization")
       @ohai[:virtualization][:system].should == "xen"
       @ohai[:virtualization][:role].should == "guest"


### PR DESCRIPTION
Currently Xen detection is implemented by looking for /proc/xen/capabilities, and then setting the machine as a host if capabilities contains control_d, and a guest if it doesn't. 

However some guests do not have a capabilities file and therefore will not be registered as a guest or a host. Alternatively the plugin has relied on a /proc/sys/xen/independent_wallclock in conjunction with the capabilities file. Independent_wallclock has been removed in newer pvops kernels.

 A more reliable way is to check to see if xen is loaded into /proc and then check /dev/xen/ for evtchn, which all xen hosts must have. 
