### PR TITLE
patch for lsb issue on rhel w/ redhat-lsb package installed

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -27,9 +27,12 @@ provides "platform", "platform_version"
 
 require_plugin 'linux::lsb'
 
-if lsb[:id]
-  platform lsb[:id].downcase
-  platform_version lsb[:release]
+if lsb[:id] =~ /RedHat/i
+	platform "redhat"
+    platform_version lsb[:release]
+elsif lsb[:id]	
+    platform lsb[:id].downcase
+    platform_version lsb[:release]
 elsif File.exists?("/etc/debian_version")
   platform "debian"
   platform_version File.read("/etc/debian_version").chomp


### PR DESCRIPTION
patched to handle lsb id for rhel w/ redhat-lsb package installed, see http://tickets.opscode.com/browse/OHAI-301
