### PR TITLE
ohai-314: rbconfig/config warning for ruby 1.9.3

### DIFF
--- a/lib/ohai/plugins/os.rb
+++ b/lib/ohai/plugins/os.rb
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ require 'rbconfig'
 
 require_plugin 'kernel'
 
-case ::Config::CONFIG['host_os']
+case Object.const_get(defined?(RbConfig) ? :RbConfig : :Config)::CONFIG['host_os']
 when /aix(.+)$/
   os "aix"
 when /darwin(.+)$/
@@ -47,7 +47,7 @@ when /mswin|mingw32|windows/
   # subsystems.
   os "windows"
 else
-  os ::Config::CONFIG['host_os']
+  Object.const_get(defined?(RbConfig) ? :RbConfig : :Config)::CONFIG['host_os']
 end
 
 os_version kernel[:release]


### PR DESCRIPTION
Small fix, hopefully this approach allows backward compatibility with older rubies
