### PR TITLE
Newer versions of OpenVZ assign the 127.0.0.2 address to venet0.  We sho...

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -21,7 +21,7 @@ provides "network", "counters/network"
 begin
   route_result = from("route -n \| grep -m 1 ^0.0.0.0").split(/[ \t]+/)
   if route_result.last =~ /(venet\d+)/
-    network[:default_interface] = from("ip addr show dev #{$1} | grep -v 127.0.0.1 | grep -m 1 inet").split(/[ \t]+/).last
+    network[:default_interface] = from("ip addr show dev #{$1} | grep -v 127.0.0. | grep -m 1 inet").split(/[ \t]+/).last
     network[:default_gateway] = route_result[1]
   else
     network[:default_gateway], network[:default_interface] = route_result.values_at(1,7)


### PR DESCRIPTION
...uld technically be ignoring anything in the 127.0.0.0/8 subnet, but ignoring 127.0.0.X should at least solve the problem for the forseeable future.
