### PR TITLE
Being that Python print command is now a function in 3.2, we need to enc...

### DIFF
--- a/lib/ohai/plugins/python.rb
+++ b/lib/ohai/plugins/python.rb
@@ -24,7 +24,7 @@ output = nil
 
 python = Mash.new
 
-status, stdout, stderr = run_command(:no_status_check => true, :command => "python -c \"import sys; print sys.version\"")
+status, stdout, stderr = run_command(:no_status_check => true, :command => "python -c \"import sys; print (sys.version)\"")
 
 if status == 0
   output = stdout.split


### PR DESCRIPTION
...apsulate the system and version in parenthesis. Since most current distributions have a version of Python that accepts the new format (starting with Python 2.4.x), it would make sense to have use this print statement default to this.
