### PR TITLE
add explicit require for rspec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'rspec'
 require 'mixlib/config'
 
 $:.unshift(File.dirname(__FILE__) + '/../lib')


### PR DESCRIPTION
This is required for running tests when building a debian package.
