### PR TITLE
Support for HP Cloud

### DIFF
--- a/lib/ohai/plugins/hpcloud.rb
+++ b/lib/ohai/plugins/hpcloud.rb
@@ -1,0 +1,68 @@
+#
+# Author:: Matthew Macdonald-Wallace (mmw@greenandsecure.co.uk)
+# Copyright:: Copyright (c) 2012 Green and Secure IT Limited
+#
+# Shamelessly based on the ec2 plugin by:
+# 
+# Author:: Tim Dysinger (<tim@dysinger.net>)
+# Author:: Benjamin Black (<bb@opscode.com>)
+# Author:: Christopher Brown (<cb@opscode.com>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+provides "hpcloud"
+
+require 'ohai/mixin/ec2_metadata'
+
+require_plugin "hostname"
+require_plugin "kernel"
+require_plugin "network"
+
+extend Ohai::Mixin::Ec2Metadata
+
+def get_mac_address(addresses)
+  detected_addresses = addresses.detect { |address, keypair| keypair == {"family"=>"lladdr"} }
+  if detected_addresses
+    return detected_addresses.first
+  else
+    return ""
+  end
+end
+
+def has_hpc_mac?
+  network[:interfaces].values.each do |iface|
+    has_mac = (get_mac_address(iface[:addresses]) =~ /^02:16:/)
+    Ohai::Log.debug("has_hpc_mac? == #{!!has_mac}")
+    return true if has_mac
+  end
+
+  Ohai::Log.debug("has_hpc_mac? == false")
+  false
+end
+
+def looks_like_hpcloud?
+  # Try non-blocking connect so we don't "block" if 
+  # the Xen environment is *not* EC2
+  has_hpc_mac? && can_metadata_connect?(EC2_METADATA_ADDR,80)
+end
+
+if looks_like_hpcloud?
+  Ohai::Log.debug("looks_like_hpcloud? == true")
+  hpcloud Mash.new
+  self.fetch_metadata.each {|k, v| hpcloud[k] = v }
+  hpcloud[:userdata] = self.fetch_userdata
+else
+  Ohai::Log.debug("looks_like_hpcloud? == false")
+  false
+end


### PR DESCRIPTION
This plugin enables the ohai attributes for HP Cloud in the same way as the EC2 plugin.

HP Cloud is currently in private beta, however the relevant output is follows:

  "hpcloud": {
    "public_hostname": "xxxxx.xxx.xxx",
    "placement_availability_zone": "nova",
    "block_device_mapping_root": "/dev/vda",
    "mpi_base": "10.4.8.216 slots=1\n10.4.8.215 slots=1\n10.4.8.213 slots=1\n10.4.7.55 slots=2\n10.4.7.50 slots=4\n10.4.6.62 slots=2\n10.4.6.75 slots=1",
    "instance_action": "none",
    "public_keys_0_openssh_key": "ssh-rsa AAAAB3Nz...",
    "instance_id": "i-nnnnnnnn",
    "instance_type": "standard.medium",
    "local_ipv4": "nnn.nnn.nnn.nnn",
    "block_device_mapping_ephemeral0": "/dev/vdb",
    "local_hostname": "xxxxx.xxx.xxx",
    "kernel_id": "aki-000004d7",
    "public_ipv4": "nnn.nnn.nnn.nnn",
    "reservation_id": "xxnnnnn",
    "hostname": "xxxxx.xxx.xxx",
    "ami_id": "ami-000004d8",
    "userdata": "",
    "block_device_mapping_ami": "vda",
    "ami_launch_index": "0",
    "security_groups": [
      "default"
    ],
    "ami_manifest_path": "FIXME"
  }

This has been tested across multiple nodes including after distribution with Chef
