### PR TITLE
Please update dependency on systemu 2.2.0 -> 2.4.2

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -12,8 +12,13 @@ spec = Gem::Specification.new do |s|
   s.email = "adam@opscode.com"
   s.homepage = "http://wiki.opscode.com/display/chef/Ohai"
 
+  if s.platform.to_s == 'x86-mswin32'
+    s.add_dependency "systemu", "~> 2.2.0"
+  else
+    s.add_dependency "systemu"
+  end
+
   s.add_dependency "yajl-ruby"
-  s.add_dependency "systemu", "~> 2.4.2"
   s.add_dependency "mixlib-cli"
   s.add_dependency "mixlib-config"
   s.add_dependency "mixlib-log"


### PR DESCRIPTION
Please merge this as soon as possible. The deprecation warning thrown by systemu 2.2.0 makes it inconvenient to implement a nagios check for chef freshness as nagios doesn't like more than one line of output in its given format.

All specs pass both at head and the 0.6.10 tag.

This relates to https://github.com/opscode/ohai/pull/49 and http://tickets.opscode.com/browse/OHAI-311 .. I'll take ownership of that ticket as soon as you acknowledge that I've completed the requirements of How To Contribute and give me privs in Jira.
