### PR TITLE
OHAI-354 - Omni-OS support in platforms 

### DIFF
--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -39,6 +39,9 @@ end
 File.open("/etc/release") do |file|
   while line = file.gets
     case line
+    when /^\s*(OmniOS).*r(\d+).*$/
+      platform "omnios"
+      platform_version $2
     when /^\s*(OpenIndiana).*oi_(\d+).*$/
       platform "openindiana"
       platform_version $2


### PR DESCRIPTION
Just a simple addition to plugins/solaris2/platforms.rb to support omni-os and the appropriate version.    
