### PR TITLE
[Ohai 336] - Running ohai (and chef-client) on OSX without Java prompts user

### DIFF
--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -21,7 +21,14 @@ require_plugin "languages"
 
 java = Mash.new
 
-status, stdout, stderr = run_command(:no_status_check => true, :command => "java -version")
+status, stdout, stderr = nil
+if RUBY_PLATFORM.downcase.include?("darwin") 
+  if system("/usr/libexec/java_home 2&>1 >/dev/null")
+    status, stdout, stderr = run_command(:no_status_check => true, :command => "java -version")
+  end
+else
+  status, stdout, stderr = run_command(:no_status_check => true, :command => "java -version")
+end
 
 if status == 0
   stderr.split("\n").each do |line|


### PR DESCRIPTION
Added code to check for 'java' in ENV['PATH'] on OS X only.
