### PR TITLE
Better way to get php language info (builddate broken)

### DIFF
--- a/lib/ohai/plugins/php.rb
+++ b/lib/ohai/plugins/php.rb
@@ -20,8 +20,6 @@ provides "languages/php"
 
 require_plugin "languages"
 
-output = nil
-
 php = Mash.new
 
 status, stdout, stderr = run_command(:no_status_check => true, :command => "php -i | head -10")


### PR DESCRIPTION
http://tickets.opscode.com/browse/OHAI-358
