### PR TITLE
Added simple pear language plugin.

### DIFF
--- a/lib/ohai/plugins/pear.rb
+++ b/lib/ohai/plugins/pear.rb
@@ -10,7 +10,7 @@ status, stdout, stderr = run_command(:no_status_check => true, :command => "pear
 
 if status == 0
   output = stdout
-  pear[:version] = output.grep(/Release Version/).to_s.chomp.split[2]
-  pear[:builddate] = output.grep(/Release Date/).to_s.chomp.split[2]
+  pear[:version] = output.grep(/Release Version/).to_s.split[2]
+  pear[:builddate] = output.grep(/Release Date/).to_s.split[2..3].join(' ')
   languages[:pear] = pear if pear[:version]
 end


### PR DESCRIPTION
Uses `pear info PEAR` to get info on PEAR itself.

``` json
  "languages": {
    "php": {
      "version": "5.2.10-2ubuntu6.5",
      "builddate": "May 21 2010 06:28:46"
    },
    "perl": {
      "version": "5.10.1",
      "archname": "x86_64-linux-gnu-thread-multi"
    },
    "python": {
      "version": "2.6.5",
      "builddate": "Apr 16 2010, 13:57:41"
    },
    "pear": {
      "version": "1.6.1",
      "builddate": "2007-06-23 18:11:06"
    },
    "ruby": {
      // blah
  },
```
