### PR TITLE
Adding new Rackspace cloud mac address.

### DIFF
--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -36,7 +36,9 @@ end
 def has_rackspace_mac?
   network[:interfaces].values.each do |iface|
     unless iface[:arp].nil?
-      return true if iface[:arp].value?("00:00:0c:07:ac:01") or iface[:arp].value?("00:00:0c:9f:f0:01")
+      return true if iface[:arp].value?("00:00:0c:07:ac:01") or
+                     iface[:arp].value?("00:00:0c:9f:f0:01") or
+                     iface[:arp].value?("00:15:17:70:1b:1e")
     end
   end
   false


### PR DESCRIPTION
Just ran into this issue, launching servers on Rackspace cloud in the ORD datacenter.  After hitting our limits and engaging in some capacity discussions with Rackspace, they eventually gave us more capacity.  The new servers didn't look like Rackspace servers to Oahi, however.  

I can't be sure what Rackspace is up to (separate email thread going with them) or if this is a new official mac address, but just offering this up.  Thanks!
