### PR TITLE
Added languages[:ruby][:gem_bin_dir]

### DIFF
--- a/lib/ohai/plugins/ruby.rb
+++ b/lib/ohai/plugins/ruby.rb
@@ -71,5 +71,6 @@ gem_binaries = [
 gem_binary = gem_binaries.find {|bin| ::File.exists? bin }
 if gem_binary
   languages[:ruby][:gems_dir] = run_ruby "puts %x{#{ruby_bin} #{gem_binary} env gemdir}.chomp!"
+  languages[:ruby][:gems_bin_dir] = run_ruby("require 'rubygems'; puts ::Gem.bindir")
   languages[:ruby][:gem_bin] = gem_binary
 end


### PR DESCRIPTION
Recipes like bluepill, and others that rely on installed gem locations often contain lines like:

default["bluepill"]["bin"] = "#{languages[:ruby][:bin_dir]}/bluepill"

yet languages[:ruby][:bin_dir] is the directory that the `ruby` executable is in which may on some systems be different than the directories in which gems are installed to, this adds an additional path that includes the ruby gem executable directory, the same one which gets displayed by `gem env` so that new and existing recipes can be better designed to run on more systems.
