### PR TITLE
Fix stderr redirection in Java plugin

### DIFF
--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -23,7 +23,7 @@ java = Mash.new
 
 status, stdout, stderr = nil
 if RUBY_PLATFORM.downcase.include?("darwin") 
-  if system("/usr/libexec/java_home 2&>1 >/dev/null")
+  if system("/usr/libexec/java_home 2>&1 >/dev/null")
     status, stdout, stderr = run_command(:no_status_check => true, :command => "java -version")
   end
 else


### PR DESCRIPTION
It was piping to a file called '1', rather than redirecting to stdout.
