### PR TITLE
Fixing filesystem.rb for solaris based operating systems

### DIFF
--- a/lib/ohai/plugins/solaris2/filesystem.rb
+++ b/lib/ohai/plugins/solaris2/filesystem.rb
@@ -21,7 +21,7 @@ provides "filesystem"
 fs = Mash.new
 
 # Grab filesystem data from df
-popen4("df -ka") do |pid, stdin, stdout, stderr|
+popen4("df -Pka") do |pid, stdin, stdout, stderr|
 	stdin.close
 	stdout.each do |line|
 		case line


### PR DESCRIPTION
- Fixing 80 Character limitations without `-P` option

Before the change, the filesystem had a single-space name with incorrect information.  Adding the `-P` option this is fixed.

The relevant diff from ohai before and after the fix.

``` diff
2003,2008c2003,2020
<     " ": {
<       "kb_size": "385390",
<       "kb_used": "359455",
<       "kb_available": "25935",
<       "percent_used": "94%",
<       "mount": "/lib/libc.so.1"

---
>     "zones/260f14a0-1ef6-43bd-8ad1-3fda1a2bb69d": {
>       "kb_size": "786813815",
>       "kb_used": "2222646",
>       "kb_available": "784591169",
>       "percent_used": "1%",
>       "mount": "/",
>       "mount_time": "Wed Apr 25 01:32:00 2012",
>       "mount_options": [
>         "read",
>         "write",
>         "setuid",
>         "devices",
>         "nonbmand",
>         "exec",
>         "xattr",
>         "noatime",
>         "dev=1690022"
>       ]
```
