### PR TITLE
Incorrect rackspace detection

### DIFF
--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -48,6 +48,7 @@ end
 # true:: If the rackspace cloud can be identified
 # false:: Otherwise
 def looks_like_rackspace?
+  return false if network[:interfaces][:eth1].nil?
   hint?('rackspace') || has_rackspace_mac? || has_rackspace_kernel?
 end
 


### PR DESCRIPTION
My OVH server is detected as a server from rackspace.
As rackspace servers have 2 network interfaces. It seems a good fix to check wether eth1 exists.
