### PR TITLE
The stderr-to-stdout redirection syntax in the Java plugin is wrong

### DIFF
--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -23,7 +23,7 @@ java = Mash.new
 
 status, stdout, stderr = nil
 if RUBY_PLATFORM.downcase.include?("darwin") 
-  if system("/usr/libexec/java_home 2&>1 >/dev/null")
+  if system("/usr/libexec/java_home 2>&1 >/dev/null")
     status, stdout, stderr = run_command(:no_status_check => true, :command => "java -version")
   end
 else


### PR DESCRIPTION
Per ticket http://tickets.opscode.com/browse/OHAI-393, there is a shell syntax bug in the Java plugin.
