### PR TITLE
OHAI-398: use the ruby version that was used to run ohai

### DIFF
--- a/lib/ohai/plugins/ruby.rb
+++ b/lib/ohai/plugins/ruby.rb
@@ -20,9 +20,11 @@ provides "languages/ruby"
 
 require_plugin "languages"
 
+require 'rbconfig'
 
 def run_ruby(command)
-  cmd = "ruby -e \"require 'rbconfig'; #{command}\""
+  ruby = ::File.join(::Config::CONFIG['bindir'], ::Config::CONFIG['ruby_install_name'])
+  cmd = %{#{ruby} -e "require 'rbconfig'; #{command}"}
   status, stdout, stderr = run_command(:no_status_check => true, :command => cmd)
   stdout.strip
 end


### PR DESCRIPTION
this fixes (spec) issues when multiple ruby versions are installed in
the system and the user can switch between them.

in gentoo specs are automatically run for all installed ruby versions,
but the global /usr/bin/ruby symlink points to the version the user has
selected.

if the user has selected ruby18 as default the ruby plugin will detect
ruby18 even if ohai is called with ruby19 explicitly.
