### PR TITLE
[OHAI-410] Make ipv6 address available in rackspace and cloud plugins if available for rackspace cloud servers

### DIFF
--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -73,11 +73,15 @@ end
 
 # Fill cloud hash with rackspace values
 def get_rackspace_values 
-  cloud[:public_ips] << rackspace['public_ip']
-  cloud[:private_ips] << rackspace['private_ip']
+  cloud[:public_ips] << rackspace['public_ipv4'] if rackspace['public_ipv4']
+  cloud[:public_ips] << rackspace['public_ipv6'] if rackspace['public_ipv6']
+  cloud[:private_ips] << rackspace['local_ipv4'] if rackspace['local_ipv4']
+  cloud[:private_ips] << rackspace['local_ipv6'] if rackspace['local_ipv6']
   cloud[:public_ipv4] = rackspace['public_ipv4']
+  cloud[:public_ipv6] = rackspace['public_ipv6']
   cloud[:public_hostname] = rackspace['public_hostname']
   cloud[:local_ipv4] = rackspace['local_ipv4']
+  cloud[:local_ipv6] = rackspace['local_ipv6']
   cloud[:local_hostname] = rackspace['local_hostname']
   cloud[:provider] = "rackspace"
 end

--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -56,9 +56,27 @@ end
 # === Parameters
 # name<Symbol>:: Use :public_ip or :private_ip
 # eth<Symbol>:: Interface name of public or private ip
-def get_ip_address(name, eth)
+def get_ip_address(name, eth, family = 'inet')
   network[:interfaces][eth][:addresses].each do |key, info|
-    rackspace[name] = key if info['family'] == 'inet'
+    if info['family'] == 'inet'
+      rackspace[name] = key 
+      break # break when we found an address
+    end
+  end
+end
+
+# Names rackspace ipv6 address for interface
+#
+# === Parameters
+# name<Symbol>:: Use :public_ip or :private_ip
+# eth<Symbol>:: Interface name of public or private ip
+def get_global_ipv6_address(name, eth, family = 'inet')
+  network[:interfaces][eth][:addresses].each do |key, info|
+    # check if we got an ipv6 address and if its in global scope
+    if info['family'] == 'inet6' && info['scope'] == 'Global'
+      rackspace[name] = key 
+      break # break when we found an address
+    end
   end
 end
 
@@ -69,7 +87,9 @@ if looks_like_rackspace?
   get_ip_address(:private_ip, :eth1)
   # public_ip + private_ip are deprecated in favor of public_ipv4 and local_ipv4 to standardize.
   rackspace[:public_ipv4] = rackspace[:public_ip]
+  get_global_ipv6_address(:public_ipv6, :eth0)
   rackspace[:public_hostname] = "#{rackspace[:public_ip].gsub('.','-')}.static.cloud-ips.com"
   rackspace[:local_ipv4] = rackspace[:private_ip]
+  get_global_ipv6_address(:local_ipv6, :eth1)
   rackspace[:local_hostname] = hostname
 end

--- a/spec/ohai/plugins/cloud_spec.rb
+++ b/spec/ohai/plugins/cloud_spec.rb
@@ -64,21 +64,39 @@ describe Ohai::System, "plugin cloud" do
     end  
     
     it "should populate cloud public ip" do
-      @ohai[:rackspace]['public_ip'] = "174.129.150.8"
+      @ohai[:rackspace][:public_ipv4] = "174.129.150.8"
       @ohai._require_plugin("cloud")
-      @ohai[:cloud][:public_ips][0].should == @ohai[:rackspace][:public_ip]
-    end
-        
-    it "should populate cloud private ip" do
-      @ohai[:rackspace]['private_ip'] = "10.252.42.149"
-      @ohai._require_plugin("cloud")
-      @ohai[:cloud][:private_ips][0].should == @ohai[:rackspace][:private_ip]
+      @ohai[:cloud][:public_ipv4].should == @ohai[:rackspace][:public_ipv4]
     end
     
-     it "should populate first cloud public ip" do
-      @ohai[:rackspace]['public_ip'] = "174.129.150.8"
+    it "should populate cloud public ipv6" do
+      @ohai[:rackspace][:public_ipv6] = "2a00:1a48:7805:111:e875:efaf:ff08:75"
       @ohai._require_plugin("cloud")
-      @ohai[:cloud][:public_ips].first.should == @ohai[:rackspace][:public_ip]
+      @ohai[:cloud][:public_ipv6].should == @ohai[:rackspace][:public_ipv6]
+    end
+    
+    it "should populate cloud private ip" do
+      @ohai[:rackspace][:local_ipv4] = "10.252.42.149"
+      @ohai._require_plugin("cloud")
+      @ohai[:cloud][:local_ipv4].should == @ohai[:rackspace][:local_ipv4]
+    end
+    
+    it "should populate cloud private ipv6" do
+      @ohai[:rackspace][:local_ipv6] = "2a00:1a48:7805:111:e875:efaf:ff08:75"
+      @ohai._require_plugin("cloud")
+      @ohai[:cloud][:local_ipv6].should == @ohai[:rackspace][:local_ipv6]
+    end
+    
+    it "should populate first cloud public ip" do
+      @ohai[:rackspace][:public_ipv4] = "174.129.150.8"
+      @ohai._require_plugin("cloud")
+      @ohai[:cloud][:public_ips].first.should == @ohai[:rackspace][:public_ipv4]
+    end
+    
+    it "should populate first cloud local ip" do
+      @ohai[:rackspace][:local_ipv4] = "174.129.150.8"
+      @ohai._require_plugin("cloud")
+      @ohai[:cloud][:private_ips].first.should == @ohai[:rackspace][:local_ipv4]
     end
         
     it "should populate cloud provider" do

--- a/spec/ohai/plugins/rackspace_spec.rb
+++ b/spec/ohai/plugins/rackspace_spec.rb
@@ -27,6 +27,11 @@ describe Ohai::System, "plugin rackspace" do
         "netmask"=> "255.255.255.0",
         "family"=> "inet"
       },
+      "2a00:1a48:7805:111:e875:efaf:ff08:75"=> {
+        "family"=> "inet6",
+        "prefixlen"=> "64",
+        "scope"=> "Global"
+      },
       "fe80::4240:95ff:fe47:6eed"=> {
         "scope"=> "Link",
         "prefixlen"=> "64",
@@ -74,12 +79,19 @@ describe Ohai::System, "plugin rackspace" do
       @ohai._require_plugin("rackspace")
       @ohai[:rackspace][:public_ip].should_not be_nil
       @ohai[:rackspace][:private_ip].should_not be_nil
+      @ohai[:rackspace][:public_ipv4].should_not be_nil
+      @ohai[:rackspace][:local_ipv4].should_not be_nil
+      @ohai[:rackspace][:public_ipv6].should_not be_nil
+      @ohai[:rackspace][:local_ipv6].should be_nil
     end
 
     it "should have correct values for all attributes" do
       @ohai._require_plugin("rackspace")
       @ohai[:rackspace][:public_ip].should == "1.2.3.4"
       @ohai[:rackspace][:private_ip].should == "5.6.7.8"
+      @ohai[:rackspace][:public_ipv4].should == "1.2.3.4"
+      @ohai[:rackspace][:local_ipv4].should == "5.6.7.8"
+      @ohai[:rackspace][:public_ipv6].should == "2a00:1a48:7805:111:e875:efaf:ff08:75"
     end
 
   end


### PR DESCRIPTION
This patch adds rackspace['public_ipv6'], rackspace['local_ipv6'] as well as cloud['public_ipv6'] and cloud['local_ipv6']. Fields will only be populated if an ipv6 address is available. cloud['public_ips'] and cloud['private_ips'] may contain more than one address if ipv6 addresses are available. Updated tests are included.
