### PR TITLE
More liberal support for SmartOS detection

### DIFF
--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -39,6 +39,8 @@ end
 File.open("/etc/release") do |file|
   while line = file.gets
     case line
+    when /^.*(SmartOS).*$/
+      platform "smartos"
     when /^\s*(OmniOS).*r(\d+).*$/
       platform "omnios"
       platform_version $2
@@ -54,8 +56,6 @@ File.open("/etc/release") do |file|
       platform "solaris2"
     when /^\s*(NexentaCore)\s.*$/
       platform "nexentacore"
-    when /^\s*(SmartOS)\s.*$/
-      platform "smartos"
     end
   end
 end


### PR DESCRIPTION
SmartOS's /etc/release file has undergone several changes on both SmartOS and in SmartMachines (SmartOS Zones) over the last year.  As a result, Ohai detection is hit or miss and confuses users and breaks Chef for many SmartOS Users.
