### PR TITLE
[OHAI-423] Add development dependency on rake gem

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -24,6 +24,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency "mixlib-log"
   s.add_dependency "mixlib-shellout"
   s.add_dependency "ipaddress"
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core"
   s.add_development_dependency "rspec-expectations"
   s.add_development_dependency "rspec-mocks"


### PR DESCRIPTION
See [OHAI-423](http://tickets.opscode.com/browse/OHAI-423).
