### PR TITLE
[OHAI-126] [OHAI-231] : dealing with trailing slashes in plugin_path

### DIFF
--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -129,6 +129,7 @@ module Ohai
       require_plugin('os')
 
       Ohai::Config[:plugin_path].each do |path|
+        path.chomp!(File::SEPARATOR)
         [
           Dir[File.join(path, '*')],
           Dir[File.join(path, @data[:os], '**', '*')]


### PR DESCRIPTION
This pull adds in a check and removal of any trailing File::SEPARATORs at the end of any paths in the plugin_paths array to allow passing in an ohai parameter like "--directory /foo/bar/"

I've tested this out and it works. Feel free to test and merge if you like it.
