### PR TITLE
[OHAI-439] Add OpenVZ plugin to parse data from /proc/user_beancounters

### DIFF
--- a/lib/ohai/plugins/openvz.rb
+++ b/lib/ohai/plugins/openvz.rb
@@ -1,0 +1,53 @@
+provides "openvz"
+# Sample output
+#Version: 2.5
+#       uid  resource                     held              maxheld              barrier                limit              failcnt
+#   852638:  kmemsize                 16595303             21577728             67108864             75497472                    0
+#            lockedpages                     0                    0                   64                   64                    0
+#            privvmpages                239894               258143               393216               442368                  161
+#            shmpages                      653                 1005               262144               262144                    0
+#            dummy                           0                    0                    0                    0                    0
+#            numproc                       106                  168                 1024                 1024                    0
+#            physpages                   96664               216508               262144  9223372036854775807                    0
+#            vmguarpages                     0                    0               393216  9223372036854775807                    0
+#            oomguarpages                80857                82836               262144  9223372036854775807                    0
+#            numtcpsock                      5                    7                 5120                 5120                    0
+#            numflock                        1                    7                 1024                 1024                    0
+#            numpty                          1                    3                   64                   64                    0
+#            numsiginfo                      0                   69                  512                  512                    0
+#            tcpsndbuf                  146192               338032             10485760             15728640                    0
+#            tcprcvbuf                   81920              7541904             10485760             15728640                    0
+#            othersockbuf                25432                65760              4194304              8388608                    0
+#            dgramrcvbuf                     0                 2312              1048576              1048576                    0
+#            numothersock                   95                  105                 1024                 1024                    0
+#            dcachesize                6900492              9437184              8388608              9437184                    0
+#            numfile                       348                  520                10240                10240                    0
+#            dummy                           0                    0                    0                    0                    0
+#            dummy                           0                    0                    0                    0                    0
+#            dummy                           0                    0                    0                    0                    0
+#            numiptent                      20                   20                 2048                 2048                    0
+
+
+openvz Mash.new
+
+if File.exists?("/proc/user_beancounters")
+  Ohai::Log.debug("OpenVZ: user_beancounters detected")
+
+  File.open("/proc/user_beancounters").each do |line|
+    line =~ /\s(\w+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)/
+    resource, held, maxheld, barrier, limit, failcnt = $1, $2, $3, $4, $5, $6
+
+    next if ["dummy",nil].include? resource # skip header line and dummy resources
+
+    openvz[resource] = Mash.new
+    openvz[resource]["held"]    = held.to_i
+    openvz[resource]["maxheld"] = maxheld.to_i
+    openvz[resource]["barrier"] = barrier.to_i
+    openvz[resource]["limit"]   = limit.to_i
+    openvz[resource]["failcnt"] = failcnt.to_i
+  end
+
+  openvz["memory"] = Mash.new
+
+  openvz["memory"]["total"] = openvz["oomguarpages"]["barrier"] * 4 #kb // sizeof(page)
+end


### PR DESCRIPTION
http://tickets.opscode.com/browse/OHAI-439

output looks like

```
root@block852638-iap:~# ohai openvz
[2013-01-28T22:52:41+00:00] WARN: [inet] no ip on venet0
[2013-01-28T22:52:41+00:00] WARN: unable to detect ipaddress
[2013-01-28T22:52:41+00:00] WARN: unable to detect macaddress
{
  "othersockbuf": {
    "maxheld": 65760,
    "failcnt": 0,
    "barrier": 4194304,
    "limit": 8388608,
    "held": 25432
  },
  "oomguarpages": {
    "maxheld": 82836,
    "failcnt": 0,
    "barrier": 262144,
    "limit": 9223372036854775807,
    "held": 80387
  },
  "numothersock": {
    "maxheld": 105,
    "failcnt": 0,
    "barrier": 1024,
    "limit": 1024,
    "held": 95
  },
  "numsiginfo": {
    "maxheld": 69,
    "failcnt": 0,
    "barrier": 512,
    "limit": 512,
    "held": 0
  },
  "physpages": {
    "maxheld": 216508,
    "failcnt": 0,
    "barrier": 262144,
    "limit": 9223372036854775807,
    "held": 103851
  },
  "lockedpages": {
    "maxheld": 0,
    "failcnt": 0,
    "barrier": 64,
    "limit": 64,
    "held": 0
  },
  "memory": {
    "total": 1048576
  },
  "tcprcvbuf": {
    "maxheld": 7541904,
    "failcnt": 0,
    "barrier": 10485760,
    "limit": 15728640,
    "held": 81920
  },
  "numtcpsock": {
    "maxheld": 7,
    "failcnt": 0,
    "barrier": 5120,
    "limit": 5120,
    "held": 5
  },
  "kmemsize": {
    "maxheld": 21643264,
    "failcnt": 0,
    "barrier": 67108864,
    "limit": 75497472,
    "held": 18798700
  },
  "dgramrcvbuf": {
    "maxheld": 2312,
    "failcnt": 0,
    "barrier": 1048576,
    "limit": 1048576,
    "held": 0
  },
  "tcpsndbuf": {
    "maxheld": 464472,
    "failcnt": 0,
    "barrier": 10485760,
    "limit": 15728640,
    "held": 87200
  },
  "vmguarpages": {
    "maxheld": 0,
    "failcnt": 0,
    "barrier": 393216,
    "limit": 9223372036854775807,
    "held": 0
  },
  "shmpages": {
    "maxheld": 1005,
    "failcnt": 0,
    "barrier": 262144,
    "limit": 262144,
    "held": 653
  },
  "numiptent": {
    "maxheld": 20,
    "failcnt": 0,
    "barrier": 2048,
    "limit": 2048,
    "held": 20
  },
  "numpty": {
    "maxheld": 3,
    "failcnt": 0,
    "barrier": 64,
    "limit": 64,
    "held": 1
  },
  "numflock": {
    "maxheld": 7,
    "failcnt": 0,
    "barrier": 1024,
    "limit": 1024,
    "held": 1
  },
  "numproc": {
    "maxheld": 168,
    "failcnt": 0,
    "barrier": 1024,
    "limit": 1024,
    "held": 104
  },
  "privvmpages": {
    "maxheld": 260691,
    "failcnt": 207,
    "barrier": 393216,
    "limit": 442368,
    "held": 241239
  },
  "numfile": {
    "maxheld": 520,
    "failcnt": 0,
    "barrier": 10240,
    "limit": 10240,
    "held": 322
  },
  "dcachesize": {
    "maxheld": 9437184,
    "failcnt": 0,
    "barrier": 8388608,
    "limit": 9437184,
    "held": 9407477
  }
}
```

Take special note of `ohai openvz/memory/total`
