### PR TITLE
OHAI-445: Detect ecdsa ssh host keys

### DIFF
--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -21,14 +21,16 @@ require_plugin "keys"
 
 keys[:ssh] = Mash.new
 
-def is_dsa_or_rsa?(file)
-  case IO.read(file).split[0]
+def extract_keytype?(content)
+  case content[0]
   when "ssh-dss"
-    "dsa"
+    [ "dsa", nil ]
   when "ssh-rsa"
-    "rsa"
+    [ "rsa", nil ]
+  when /^ecdsa/
+    [ "ecdsa", content[0] ]
   else
-    nil
+    [ nil, nil ]
   end
 end
 
@@ -47,8 +49,10 @@ if sshd_config
     conf.each_line do |line|
       if line.match(/^hostkey\s/i)
         pub_file = "#{line.split[1]}.pub"
-        key_type = is_dsa_or_rsa?(pub_file)
-        keys[:ssh]["host_#{key_type}_public"] = IO.read(pub_file).split[1] unless key_type.nil?
+        content = IO.read(pub_file).split
+        key_type, key_subtype = extract_keytype?(content)
+        keys[:ssh]["host_#{key_type}_public"] = content[1] unless key_type.nil?
+        keys[:ssh]["host_#{key_type}_type"] = key_subtype unless key_subtype.nil?
       end
     end
   end
@@ -59,5 +63,11 @@ else
 
   if keys[:ssh][:host_rsa_public].nil? && File.exists?("/etc/ssh/ssh_host_rsa_key.pub")
     keys[:ssh][:host_rsa_public] = IO.read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
+  end
+
+  if keys[:ssh][:host_ecdsa_public].nil? && File.exists?("/etc/ssh/ssh_host_ecdsa_key.pub")
+    content = IO.read("/etc/ssh/ssh_host_ecdsa_key.pub")
+    keys[:ssh][:host_ecdsa_public] = content.split[1]
+    keys[:ssh][:host_ecdsa_type] = content.split[0]
   end
 end

--- a/spec/unit/plugins/ssh_host_keys_spec.rb
+++ b/spec/unit/plugins/ssh_host_keys_spec.rb
@@ -33,11 +33,13 @@ describe Ohai::System, "ssh_host_key plugin" do
 # HostKeys for protocol version 2
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
 EOS
     File.stub(:open).with("/etc/ssh/sshd_config").and_yield(sshd_config_file)
     File.stub(:exists?).and_return(true)
     File.stub(:exists?).with("/etc/ssh/ssh_host_dsa_key.pub").and_return(true)
     File.stub(:exists?).with("/etc/ssh/ssh_host_rsa_key.pub").and_return(true)
+    File.stub(:exists?).with("/etc/ssh/ssh_host_ecdsa_key.pub").and_return(true)
 
     # Ensure we can still use IO.read
     io_read = IO.method(:read)
@@ -46,19 +48,29 @@ EOS
     # Return fake public key files so we don't have to go digging for them in unit tests
     @dsa_key = "ssh-dss AAAAB3NzaC1kc3MAAACBAMHlT02xN8kietxPfhcb98xHueTzKCOTz6dZlP/dmKILHrQOAExuSEeNiA2uvmhHNVQvs/cBsRiDxgSKux3ie2q8+MB6vHCiSpSkoPjrL75iT57YDilCB4/sytt6IJpj+H42wRDWTX0/QRybMHUvmnmEL0cwZXykSvrIum0BKB6hAAAAFQDsi6WUCClhtZIiTY9uh8eAre+SbQAAAIEAgNnuw0uEuqtcVif+AYd/bCZvL9FPqg7DrmTkamNEcVinhUGwsPGJTLJf+o5ens1X4RzQoi1R6Y6zCTL2FN/hZgINJNO0z9BN402wWrZmQd+Vb1U5DyDtveuvipqyQS+fm9neRwdLuv36Fc9f9nkZ7YHpkGPJp+yJpG4OoeREhwgAAACBAIf9kKLf2XiXnlByzlJ2Naa55d/hp2E059VKCRsBS++xFKYKvSqjnDQBFiMtAUhb8EdTyBGyalqOgqogDQVtwHfTZWZwqHAhry9aM06y92Eu/xSey4tWjKeknOsnRe640KC4zmKDBRTrjjkuAdrKPN9k3jl+OCc669JHlIfo6kqf oppa"
     @rsa_key = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAuhcVXV+nNapkyUC5p4TH1ymRxUjtMBKqYWmwyI29gVFnUNeHkKFHWon0KFeGJP2Rm8BfTiZa9ER9e8pRr4Nd+z1C1o0kVoxEEfB9tpSdTlpk1GG83D94l57fij8THRVIwuCEosViUlg1gDgC4SpxbqfdBkUN2qyf6JDOh7t2QpYh7berpDEWeBpb7BKdLEDT57uw7ijKzSNyaXqq8KkB9I+UFrRwpuos4W7ilX+PQ+mWLi2ZZJfTYZMxxVS+qJwiDtNxGCRwTOQZG03kI7eLBZG+igupr0uD4o6qeftPOr0kxgjoPU4nEKvYiGq8Rqd2vYrhiaJHLk9QB6xStQvS3Q== oppa"
+    @ecdsa_key = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBx8VgvxmHxs/sIn/ATh0iUcuz1I2Xc0e1ejXCGHBMZ98IE3FBt1ezlqCpNMcHVV2skQQ8vyLbKxzweyZuNSDU8= oppa"
     IO.stub(:read).with("/etc/ssh/ssh_host_dsa_key.pub").and_return(@dsa_key)
     IO.stub(:read).with("/etc/ssh/ssh_host_rsa_key.pub").and_return(@rsa_key)
+    IO.stub(:read).with("/etc/ssh/ssh_host_ecdsa_key.pub").and_return(@ecdsa_key)
   end
 
   shared_examples "loads keys" do
     it "reads the key and sets the dsa attribute correctly" do
       @ohai._require_plugin("ssh_host_key")
       @ohai[:keys][:ssh][:host_dsa_public].should eql(@dsa_key.split[1])
+      @ohai[:keys][:ssh][:host_dsa_type].should be_nil
     end
   
     it "reads the key and sets the rsa attribute correctly" do
       @ohai._require_plugin("ssh_host_key")
       @ohai[:keys][:ssh][:host_rsa_public].should eql(@rsa_key.split[1])
+      @ohai[:keys][:ssh][:host_rsa_type].should be_nil
+    end
+
+    it "reads the key and sets the ecdsa attribute correctly" do
+      @ohai._require_plugin("ssh_host_key")
+      @ohai[:keys][:ssh][:host_ecdsa_public].should eql(@ecdsa_key.split[1])
+      @ohai[:keys][:ssh][:host_ecdsa_type].should eql(@ecdsa_key.split[0])
     end
   end
 


### PR DESCRIPTION
Current versions of (Open)SSH supports in addition to dsa and rsa ecdsa (elliptic curve) keys. Ohai should extract this host keys, too.

(Open)SSH supports 3 types of elliptic curve keys: `ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384` and `ecdsa-sha2-nistp521`. To be consistent with the file name and the normal abbreviation the key itself is stored as `[:keys][:ssh][:host_ecdsa_public]`. `[:keys][:ssh][:host_ecdsa_type]` specify the subtype of ecdsa. This field is needed, to generate known_hosts files.
