### PR TITLE
Ohai 445

### DIFF
--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -56,18 +56,18 @@ if sshd_config
       end
     end
   end
-else
-  if keys[:ssh][:host_dsa_public].nil? && File.exists?("/etc/ssh/ssh_host_dsa_key.pub")
-    keys[:ssh][:host_dsa_public] = IO.read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
-  end
+end
 
-  if keys[:ssh][:host_rsa_public].nil? && File.exists?("/etc/ssh/ssh_host_rsa_key.pub")
-    keys[:ssh][:host_rsa_public] = IO.read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
-  end
+if keys[:ssh][:host_dsa_public].nil? && File.exists?("/etc/ssh/ssh_host_dsa_key.pub")
+  keys[:ssh][:host_dsa_public] = IO.read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
+end
 
-  if keys[:ssh][:host_ecdsa_public].nil? && File.exists?("/etc/ssh/ssh_host_ecdsa_key.pub")
-    content = IO.read("/etc/ssh/ssh_host_ecdsa_key.pub")
-    keys[:ssh][:host_ecdsa_public] = content.split[1]
-    keys[:ssh][:host_ecdsa_type] = content.split[0]
-  end
+if keys[:ssh][:host_rsa_public].nil? && File.exists?("/etc/ssh/ssh_host_rsa_key.pub")
+  keys[:ssh][:host_rsa_public] = IO.read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
+end
+
+if keys[:ssh][:host_ecdsa_public].nil? && File.exists?("/etc/ssh/ssh_host_ecdsa_key.pub")
+  content = IO.read("/etc/ssh/ssh_host_ecdsa_key.pub")
+  keys[:ssh][:host_ecdsa_public] = content.split[1]
+  keys[:ssh][:host_ecdsa_type] = content.split[0]
 end


### PR DESCRIPTION
This fixes a bug that causes the ohai ssh_host_key plugin to incorrectly populate host_*_public keys when the HostKey directive in sshd_config is commented out.
