### PR TITLE
OHAI-442: Use default ssh_host_keys paths when no HostKey set

### DIFF
--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -52,12 +52,12 @@ if sshd_config
       end
     end
   end
-else
-  if keys[:ssh][:host_dsa_public].nil? && File.exists?("/etc/ssh/ssh_host_dsa_key.pub")
-    keys[:ssh][:host_dsa_public] = IO.read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
-  end
+end
 
-  if keys[:ssh][:host_rsa_public].nil? && File.exists?("/etc/ssh/ssh_host_rsa_key.pub")
-    keys[:ssh][:host_rsa_public] = IO.read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
-  end
+if keys[:ssh][:host_dsa_public].nil? && File.exists?("/etc/ssh/ssh_host_dsa_key.pub")
+  keys[:ssh][:host_dsa_public] = IO.read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
+end
+
+if keys[:ssh][:host_rsa_public].nil? && File.exists?("/etc/ssh/ssh_host_rsa_key.pub")
+  keys[:ssh][:host_rsa_public] = IO.read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
 end

--- a/spec/unit/plugins/ssh_host_keys_spec.rb
+++ b/spec/unit/plugins/ssh_host_keys_spec.rb
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -55,7 +55,7 @@ EOS
       @ohai._require_plugin("ssh_host_key")
       @ohai[:keys][:ssh][:host_dsa_public].should eql(@dsa_key.split[1])
     end
-  
+
     it "reads the key and sets the rsa attribute correctly" do
       @ohai._require_plugin("ssh_host_key")
       @ohai[:keys][:ssh][:host_rsa_public].should eql(@rsa_key.split[1])
@@ -63,6 +63,14 @@ EOS
   end
 
   context "when an sshd_config exists" do
+    it_behaves_like "loads keys"
+  end
+
+  context "when an sshd_config exists but contains no HostKeys" do
+    before do
+      File.stub(:open).with("/etc/ssh/sshd_config").and_yield('')
+    end
+
     it_behaves_like "loads keys"
   end
 


### PR DESCRIPTION
This just changes the logic slightly so that it will fall back to the
default paths if there is no sshd_config (as before) OR if the
sshd_config does not set any HostKey.

Regression spec included.
