### PR TITLE
Commit related to issue OHAI-472

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -83,7 +83,7 @@ elsif lsb[:id] =~ /ScientificSL/i
   platform "scientific"
   platform_version lsb[:release]
 elsif lsb[:id] =~ /XenServer/i
-  platform " xenserver"
+  platform "xenserver"
   platform_version lsb[:release]
 elsif lsb[:id] # LSB can provide odd data that changes between releases, so we currently fall back on it rather than dealing with its subtleties 
   platform lsb[:id].downcase
@@ -96,7 +96,7 @@ case platform
     platform_family "debian"
   when /fedora/
     platform_family "fedora"
-  when /oracle/, /centos/, /redhat/, /scientific/, /enterprise/, /amazon/, /xenserver/
+  when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /amazon/, /xenserver/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
     platform_family "rhel"
   when /suse/
     platform_family "suse"


### PR DESCRIPTION
XenServer is recognized correctly using LSB, but is not assigned to a platform_family. It also fixes a type where 'enterprise' was typed twice in a row.
