### PR TITLE
hostname bug

### DIFF
--- a/lib/ohai/plugins/solaris2/hostname.rb
+++ b/lib/ohai/plugins/solaris2/hostname.rb
@@ -30,5 +30,5 @@ if fqdn_lookup.split('.').length > 1
   fqdn fqdn_lookup
 else
   # default to assembling one
-  fqdn(from("hostname") + "." + from("domainname"))
+  fqdn(from("hostname"))
 end


### PR DESCRIPTION
On 'solaris2' the hostname is not good detected.

domainname is always empty by default, and is used for NIS configuration.

The correct hostname and fqdn detection should be just the output of 'hostname'.

Thanks!

PD: this affects smartos too...
