### PR TITLE
Ensure cpu[:real] is not 0. Add real_cores attribute. OHAI-292

### DIFF
--- a/lib/ohai/plugins/linux/cpu.rb
+++ b/lib/ohai/plugins/linux/cpu.rb
@@ -57,4 +57,8 @@ end
 
 cpu cpuinfo
 cpu[:total] = cpu_number
-cpu[:real] = real_cpu.keys.length
+cpu[:real] = ( real_cpu.keys.length == 0 ? 1 : real_cpu.keys.length )
+
+cores_per_cpu = ( cpu['0']['cores'].nil? ? cpu[:total] : cpu['0']['cores'] )
+cpu[:real_cores] = cores_per_cpu * cpu[:real]
+


### PR DESCRIPTION
Using an AWS instance with one CPU as a test case, /proc/cpuinfo does not return a 'physical id' or 'cpu cores'. As a result, cpu[:real] is set to 0. Line 60 ensures that cpu[:real] will default to 1 in this case.

cpu[:real_cores] is a new attribute that satisfies http://tickets.opscode.com/browse/OHAI-292. This provides a total of the real cores available to a system, ignoring the inflated count of cpu[:total] that results from hyperthreading.
