### PR TITLE
Handle IPv6 routes better

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -200,8 +200,11 @@ Ohai.plugin(:Network) do
         #    the routing table source field.
         # 3) and since we're at it, let's populate some :routes attributes
         # (going to do that for both inet and inet6 addresses)
-        so = shell_out("ip -f #{family[:name]} route show")
-        so.stdout.lines do |line|
+        #
+        # NOTE: in the v6 world we can have many duplicate routes, so we
+        # slurp them in and then uniqify them.
+        so = shell_out("ip -f #{family[:name]} route show").stdout
+        so.split("\n").sort.uniq do |line|
           if line =~ /^([^\s]+)\s(.*)$/
             route_dest = $1
             route_ending = $2


### PR DESCRIPTION
In IPv6 the linux kernel keeps cached routes in the global routing table. As
such running "ip -f inet6 route show" on a reasonably busy server that talks v6
to the internet will yield 10s or 100s of thousands of routes which ohai cannot
parse in a reasonable time/memory usage.

In reality the only things we should need however are the default route and the
local table.

This diff changes the code to look at the default route as well as the local
table.

Sadly, afaict in Ruby, if a function takes both args and a block, you cannot
pass a named Proc as your block, so I had to refactor a bit.
