### PR TITLE
OHAI-485 Enable block device size given in bytes

### DIFF
--- a/lib/ohai/plugins/linux/block_device.rb
+++ b/lib/ohai/plugins/linux/block_device.rb
@@ -33,6 +33,14 @@ if File.exists?("/sys/block")
         File.open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
       end
     end
+    %w{logical_block_size}.each do |check|
+      if File.exists?("/sys/block/#{dir}/queue/#{check}")
+        File.open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip     }
+      end
+    end
+    unless block[dir]["size"].nil? or block[dir]["logical_block_size"].nil?
+      block[dir]["size_bytes"] = block[dir]["size"].to_i * block[dir]["logical_block_size"].to_i
+    end
   end
   block_device block
 end


### PR DESCRIPTION
The current size we have is the size in blocks, which is not too helpful
for most people. What people usually want is the size in bytes.
Patch originally written by Vincent Untz vuntz@suse.com