### PR TITLE
openstack plugin: Change METADATA_URL

### DIFF
--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -22,7 +22,7 @@ require 'ohai/mixin/ec2_metadata'
 extend Ohai::Mixin::Ec2Metadata
 
 # does it matter that it's not hitting latest?
-#Ec2Metadata::EC2_METADATA_URL = "/latest/meta-data"
+Ec2Metadata::EC2_METADATA_URL = "/latest/meta-data"
 
 # Adds openstack Mash
 if hint?('openstack') || hint?('hp')


### PR DESCRIPTION
This makes things work on the openstack install I'm using.
I didn't had a deep look at `ohai/mixin/ec2_metadata` which has a `best_api_version` method, I can provide you with some debugging. I can also add a `set_debug_output`on Net::HTTP stuff somewhere ...
I'm also wondering if we shouldn't use "1.0" rather than "latest" which my be subject to schema changes.
