### PR TITLE
Use module functions to avoid method name conflict

### DIFF
--- a/lib/ohai/mixin/gce_metadata.rb
+++ b/lib/ohai/mixin/gce_metadata.rb
@@ -21,6 +21,8 @@ module Ohai
   module Mixin
     module GCEMetadata
 
+      extend self
+
       GCE_METADATA_ADDR = "metadata.google.internal" unless defined?(GCE_METADATA_ADDR)
       GCE_METADATA_URL = "/0.1/meta-data" unless defined?(GCE_METADATA_URL)
 

--- a/lib/ohai/plugins/gce.rb
+++ b/lib/ohai/plugins/gce.rb
@@ -18,7 +18,7 @@ provides "gce"
 
 require 'ohai/mixin/gce_metadata'
 
-extend Ohai::Mixin::GCEMetadata
+
 GOOGLE_SYSFS_DMI = '/sys/firmware/dmi/entries/1-0/raw'
 
 #https://developers.google.com/compute/docs/instances#dmi
@@ -27,13 +27,13 @@ def has_google_dmi?
 end
 
 def looks_like_gce?
-  hint?('gce') || has_google_dmi? && can_metadata_connect?(GCE_METADATA_ADDR,80)
+  hint?('gce') || (has_google_dmi? && Ohai::Mixin::GCEMetadata.can_metadata_connect?(Ohai::Mixin::GCEMetadata::GCE_METADATA_ADDR,80))
 end
 
 if looks_like_gce?
   Ohai::Log.debug("looks_like_gce? == true")
   gce Mash.new
-  fetch_metadata.each {|k, v| gce[k] = v }
+  Ohai::Mixin::GCEMetadata.fetch_metadata.each {|k, v| gce[k] = v }
 else
   Ohai::Log.debug("looks_like_gce? == false")
   false

--- a/spec/unit/plugins/gce_spec.rb
+++ b/spec/unit/plugins/gce_spec.rb
@@ -16,7 +16,7 @@
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper.rb')
-require 'open-uri'
+require 'ohai/mixin/gce_metadata'
 
 describe Ohai::System, "plugin gce" do
   before(:each) do
@@ -26,7 +26,7 @@ describe Ohai::System, "plugin gce" do
 
   shared_examples_for "!gce" do
     it "should NOT attempt to fetch the gce metadata" do
-      @ohai.should_not_receive(:http_client)
+      Ohai::Mixin::GCEMetadata.should_not_receive(:http_client)
       @ohai._require_plugin("gce")
     end
   end
@@ -34,7 +34,7 @@ describe Ohai::System, "plugin gce" do
   shared_examples_for "gce" do
     before(:each) do
       @http_client = mock("Net::HTTP client")
-      @ohai.stub!(:http_client).and_return(@http_client)
+      Ohai::Mixin::GCEMetadata.stub(:http_client).and_return(@http_client)
       IO.stub!(:select).and_return([[],[1],[]])
       t = mock("connection")
       t.stub!(:connect_nonblock).and_raise(Errno::EINPROGRESS)


### PR DESCRIPTION
Fixes OHAI-489: http://tickets.opscode.com/browse/OHAI-489

Fixes conflict over method names `fetch_metadata` and `http_client` in
the Ohai::System instance by modifying the GCE mixin to define these as
module functions and changing the plugin to call them as module
functions.
