### PR TITLE
Disable root_group on Windows

### DIFF
--- a/lib/ohai/plugins/root_group.rb
+++ b/lib/ohai/plugins/root_group.rb
@@ -19,12 +19,10 @@ provides 'root_group'
 
 case ::RbConfig::CONFIG['host_os']
 when /mswin|mingw32|windows/
-  # Per http://support.microsoft.com/kb/243330 SID: S-1-5-32-544 is the
-  # internal name for the Administrators group, which lets us work
-  # properly in environments with a renamed or localized name for the
-  # Administrators group
-  group = WMI::Win32_Group.find(:first, :conditions => {:SID => 'S-1-5-32-544'})
-  root_group group['Name']
+  # TODO: OHAI-491
+  # http://tickets.opscode.com/browse/OHAI-491
+  # The windows implementation of this plugin has been removed because of
+  # performance considerations (see: OHAI-490).
 else
   root_group Etc.getgrgid(Etc.getpwnam('root').gid).name
 end

--- a/spec/unit/plugins/root_group_spec.rb
+++ b/spec/unit/plugins/root_group_spec.rb
@@ -79,53 +79,12 @@ describe Ohai::System, 'root_group' do
   end
 
   describe 'windows', :windows_only do
-    before(:each) do
-      ::RbConfig::CONFIG['host_os'] = 'windows'
 
-      # fake out WMI::Win32_Group#find
-      unless defined?(WMI)
-        module WMI
-          unless defined?(WMI::Win32_Group)
-            class Win32_Group; end
-          end
-        end
-      end
+    # TODO: Not implemented on windows.
+    # See also:
+    #
+    # http://tickets.opscode.com/browse/OHAI-490
+    # http://tickets.opscode.com/browse/OHAI-491
 
-      @group = Object.new
-      WMI::Win32_Group.
-        stub!(:find).
-        with(:first, :conditions => {:SID => 'S-1-5-32-544'}).
-        and_return(@group)
-    end
-
-    after do
-      ::RbConfig::CONFIG['host_os'] = ORIGINAL_CONFIG_HOST_OS
-    end
-
-    describe 'with administrator group' do
-      before(:each) do
-        @group.
-          stub!(:[]).
-          with('Name').
-          and_return('Administrator')
-      end
-      it 'should have a root_group of system' do
-        @ohai._require_plugin('root_group')
-        @ohai[:root_group].should == 'Administrator'
-      end
-    end
-
-    describe 'with renamed administrator group' do
-      before(:each) do
-        @group.
-          stub!(:[]).
-          with('Name').
-          and_return('BOFH')
-      end
-      it 'should have a root_group of system' do
-        @ohai._require_plugin('root_group')
-        @ohai[:root_group].should == 'BOFH'
-      end
-    end
   end
 end


### PR DESCRIPTION
Fixes OHAI-490: http://tickets.opscode.com/browse/OHAI-490

Implementation of root_group for windows has been found to have poor
performance when the host is joined to an AD domain. Opting to disable
on Windows since large changes will be required for a performant
implementation.

Cherry-picked from master for 6-stable.

Conflicts:
    spec/unit/plugins/root_group_spec.rb
