### PR TITLE
OHAI-495: Detect Virtualbox guests using dmidecode data which works even when

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -54,9 +54,6 @@ if File.exists?("/proc/modules")
   elsif modules =~ /^vboxdrv/
     virtualization[:system] = "vbox"
     virtualization[:role] = "host"
-  elsif modules =~ /^vboxguest/
-    virtualization[:system] = "vbox"
-    virtualization[:role] = "guest"
   end
 end
 
@@ -103,10 +100,12 @@ if File.exists?("/usr/sbin/dmidecode")
         virtualization[:system] = "xen"
         virtualization[:role] = "guest"
       end
+    when /Product Name: VirtualBox/
+      virtualization[:system] = "vbox"
+      virtualization[:role] = "guest"
     else
       nil
     end
-
   end
 end
 


### PR DESCRIPTION
guest additions package has not been installed
