### PR TITLE
[OHAI-499] If the public IP is nil, don't attempt to set a cloud-ips.com based hostname.

### DIFF
--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -104,7 +104,11 @@ Ohai.plugin do
       # public_ip + private_ip are deprecated in favor of public_ipv4 and local_ipv4 to standardize.
       rackspace[:public_ipv4] = rackspace[:public_ip]
       get_global_ipv6_address(:public_ipv6, :eth0)
-      rackspace[:public_hostname] = "#{rackspace[:public_ip].gsub('.','-')}.static.cloud-ips.com"
+      if rackspace[:public_ip].nil?
+        rackspace[:public_hostname] = nil
+      else
+        rackspace[:public_hostname] = "#{rackspace[:public_ip].gsub('.','-')}.static.cloud-ips.com"
+      end
       rackspace[:local_ipv4] = rackspace[:private_ip]
       get_global_ipv6_address(:local_ipv6, :eth1)
       rackspace[:local_hostname] = hostname


### PR DESCRIPTION
The public_hostname attribute is populated based on the detected public IP. Since the IP is manipulated with gsub, it throws an exception.

Expected `rackspace` attribute value:

```
{
  "private_ip": "xxx.xxx.xxx.xxx",
 "region": "ord",
 "public_ipv4": null,
 "public_hostname: null,
 "local_ipv4": "xxx.xxx.xxx.xxx",
 "local_hostname": "xxxxx" 
}
```

Actual `rackspace` attribute value:

```
{
  "private_ip": "xxx.xxx.xxx.xxx",
  "region": "ord",
 "public_ipv4": null 
}
```

Stack trace:

```
[2013-08-14T10:42:10-05:00] DEBUG: Plugin rackspace threw exception #<NoMethodError: undefined method `gsub' for nil:NilClass> /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/plugins/rackspace.rb:106:in `from_file'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/mixin/from_file.rb:29:in `instance_eval'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/mixin/from_file.rb:29:in `from_file'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/system.rb:216:in `block in require_plugin'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/system.rb:211:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/system.rb:211:in `require_plugin'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/system.rb:140:in `block (2 levels) in all_plugins'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/system.rb:133:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/system.rb:133:in `block in all_plugins'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/system.rb:131:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/system.rb:131:in `all_plugins'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/application.rb:97:in `run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/lib/ohai/application.rb:75:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.18.0/bin/ohai:51:in `<top (required)>'
/usr/bin/ohai:23:in `load'
/usr/bin/ohai:23:in `<main>'
```
