### PR TITLE
handle case where Eucalyptus metadata API returns 404

### DIFF
--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -77,6 +77,7 @@ module Ohai
       def best_api_version
         response = http_client.get("/")
         unless response.code == '200'
+          return 'latest' if response.code == '404' && response.body == '<?xml version="1.0"?><Response><Errors><Error><Code>404 Not Found</Code><Message>unknown</Message></Error></Errors><RequestID>unknown</RequestID></Response>'
           raise "Unable to determine EC2 metadata version (returned #{response.code} response)"
         end
         # Note: Sorting the list of versions may have unintended consequences in

--- a/spec/unit/mixin/ec2_metadata_spec.rb
+++ b/spec/unit/mixin/ec2_metadata_spec.rb
@@ -68,6 +68,14 @@ describe Ohai::Mixin::Ec2Metadata do
         lambda { mixin.best_api_version}.should raise_error
       end
     end
+
+    context "when the response is from eucalyptus" do
+      let(:response) { double("Net::HTTP Response", :body => "<?xml version=\"1.0\"?><Response><Errors><Error><Code>404 Not Found</Code><Message>unknown</Message></Error></Errors><RequestID>unknown</RequestID></Response>", :code => "404") }
+
+      it "returns 'latest' as the version" do
+        mixin.best_api_version.should == 'latest'
+      end
+    end
   end
 
   context "#metadata_get" do


### PR DESCRIPTION
Eucalyptus 3.3.0 and earlier has http://169.254.169.254/ return a 404.  This will make Ohai work with eucalyptus again like it did in Ohai 6.16.0 and earlier.

Note:  This bug is fixed in a future (unreleased) version of eucalyptus, probably 3.3.1.
