### PR TITLE
Add cpu check for solaris2

### DIFF
--- a/lib/ohai/plugins/solaris2/cpu.rb
+++ b/lib/ohai/plugins/solaris2/cpu.rb
@@ -1,33 +1,41 @@
-#$ psrinfo -v
-#Status of virtual processor 0 as of: 01/11/2009 23:31:55
-#  on-line since 05/29/2008 15:05:28.
-#  The i386 processor operates at 2660 MHz,
-#        and has an i387 compatible floating point processor.
-#Status of virtual processor 1 as of: 01/11/2009 23:31:55
-#  on-line since 05/29/2008 15:05:30.
-#  The i386 processor operates at 2660 MHz,
-#        and has an i387 compatible floating point processor.
-#Status of virtual processor 2 as of: 01/11/2009 23:31:55
-#  on-line since 05/29/2008 15:05:30.
-#  The i386 processor operates at 2660 MHz,
-#        and has an i387 compatible floating point processor.
-#Status of virtual processor 3 as of: 01/11/2009 23:31:55
-#  on-line since 05/29/2008 15:05:30.
-#  The i386 processor operates at 2660 MHz,
-#        and has an i387 compatible floating point processor.
-#Status of virtual processor 4 as of: 01/11/2009 23:31:55
-#  on-line since 05/29/2008 15:05:30.
-#  The i386 processor operates at 2660 MHz,
-#        and has an i387 compatible floating point processor.
-#Status of virtual processor 5 as of: 01/11/2009 23:31:55
-#  on-line since 05/29/2008 15:05:30.
-#  The i386 processor operates at 2660 MHz,
-#        and has an i387 compatible floating point processor.
-#Status of virtual processor 6 as of: 01/11/2009 23:31:55
-#  on-line since 05/29/2008 15:05:30.
-#  The i386 processor operates at 2660 MHz,
-#        and has an i387 compatible floating point processor.
-#Status of virtual processor 7 as of: 01/11/2009 23:31:55
-#  on-line since 05/29/2008 15:05:30.
-#  The i386 processor operates at 2660 MHz,
-#        and has an i387 compatible floating point processor.
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin do
+  provides "cpu"
+
+  collect_data do
+    cpu Mash.new
+    cpu[:total] = from("psrinfo | wc -l").to_i
+    cpu[:real] = from("psrinfo -p").to_i
+
+    processor_info = from("psrinfo -v -p | grep Hz")
+    processors = processor_info.split(/^    [^\s]/)
+    processors.each_with_index do |processor, i|
+      cpu_info, model_name = processor.split("\n      ")
+      cpu_info = cpu_info.tr("()","").split
+
+      index = i.to_s
+      cpu[index] = Mash.new
+      cpu[index]['vendor_id'] = cpu_info[1]
+      cpu[index]['family'] = cpu_info[4]
+      cpu[index]['model'] = cpu_info[6]
+      cpu[index]['stepping'] = cpu_info[8]
+      cpu[index]['model_name'] = model_name.strip
+      cpu[index]['mhz'] = cpu_info[10]
+    end
+  end
+end

--- a/spec/unit/plugins/solaris2/cpu_spec.rb
+++ b/spec/unit/plugins/solaris2/cpu_spec.rb
@@ -1,0 +1,81 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper.rb')
+
+describe Ohai::System, "Solaris2.X cpu plugin" do
+  before(:each) do
+    @plugin = get_plugin("solaris2/cpu")
+    @plugin[:os] = "solaris2"
+    @plugin.stub(:from).with("psrinfo | wc -l").and_return("32")
+    @plugin.stub(:from).with("psrinfo -p").and_return("4")
+
+    @plugin.stub(:from).with('psrinfo -v -p | grep Hz').and_return(<<-END.strip)
+    x86 (GenuineIntel 206D7 family 6 model 45 step 7 clock 2600 MHz)
+      Intel(r) Xeon(r) CPU E5-2670 0 @ 2.60GHz
+    x86 (CrazyTown 206D7 family 12 model 93 step 9 clock 2900 MHz)
+      Intel(r) Xeon(r) CPU E5-2690 0 @ 2.90GHz
+END
+  end
+  
+  it "should get the total virtual processor count" do
+    @plugin.run
+    @plugin['cpu']['total'].should eql(32)
+  end
+
+  it 'should get the total processor count' do
+    @plugin.run
+    @plugin['cpu']['real'].should eql(4)
+  end
+
+  describe 'per-cpu information' do
+    it "should include vendor_id for processors" do
+      @plugin.run
+      @plugin['cpu']['0']['vendor_id'].should eql('GenuineIntel')
+      @plugin['cpu']['1']['vendor_id'].should eql('CrazyTown')
+    end
+
+    it "should include family for processors" do
+      @plugin.run
+      @plugin['cpu']["0"]["family"].should eql("6")
+      @plugin['cpu']["1"]["family"].should eql("12")
+    end
+
+    it "should include model for processors" do
+      @plugin.run
+      @plugin['cpu']["0"]["model"].should eql("45")
+      @plugin['cpu']["1"]["model"].should eql("93")
+    end
+
+    it "should include stepping for processors" do
+      @plugin.run
+      @plugin['cpu']["0"]["stepping"].should eql("7")
+      @plugin['cpu']["1"]["stepping"].should eql("9")
+    end
+
+    it "should include model name for processors" do
+      @plugin.run
+      @plugin['cpu']["0"]["model_name"].should eql("Intel(r) Xeon(r) CPU E5-2670 0 @ 2.60GHz")
+      @plugin['cpu']["1"]["model_name"].should eql("Intel(r) Xeon(r) CPU E5-2690 0 @ 2.90GHz")
+    end
+
+    it "should include mhz name for processors" do
+      @plugin.run
+      @plugin['cpu']["0"]["mhz"].should eql("2600")
+      @plugin['cpu']["1"]["mhz"].should eql("2900")
+    end
+  end
+end


### PR DESCRIPTION
This is tested on SmartOS and should work on other Illumos derivatives (as well as Oracle Solaris, though we do not have a host to test on).

/cc @sax @bixu
