### PR TITLE
Use hostname as fqdn if hostname is a fqdn and hostname --fqdn doesn't work

### DIFF
--- a/lib/ohai/plugins/linux/hostname.rb
+++ b/lib/ohai/plugins/linux/hostname.rb
@@ -24,7 +24,11 @@ Ohai.plugin do
     begin
       fqdn from("hostname --fqdn")
     rescue
-      Ohai::Log.debug("hostname -f returned an error, probably no domain is set")
+      if `hostname`.strip.split('.').count >= 3
+        fqdn from("hostname")
+      else
+        Ohai::Log.debug("hostname -f returned an error, probably no domain is set")
+      end
     end
   end
 end


### PR DESCRIPTION
If a node has a FQDN in /etc/hostname (which some providers, like Digital Ocean do if you use the fqdn as the name when creating the instance):

```
root@gw1:~# cat /etc/hostname
gw1.mydomain.com

root@gw1:~# cat /etc/hosts |head -2
127.0.0.1  localhost gw1

root@gw1:~# 

So therefore the FQDN & domain name don't work:

root@gw1:~# hostname -s
gw1

root@gw1:~# hostname -d
hostname: Name or service not known

root@gw1:~# hostname -f
hostname: Name or service not known

And therefore Ohai doesn't know what's going on:

root@gw1:~# ohai |grep hostname
  "hostname": "gw1",
root@gw1:~# ohai |grep domain
root@gw1:~# ohai |grep fqdn
root@gw1:~#
```

The attached commit fixes that by using hostname as the fqdn if the hostname looks like a FQDN.
