### PR TITLE
[OHAI-503] Fix typo in ip_scopes plugin

### DIFF
--- a/lib/ohai/plugins/ip_scopes.rb
+++ b/lib/ohai/plugins/ip_scopes.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 Ohai.plugin do
-  provides "network_ip_scope", "privateaddres"
+  provides "network_ip_scope", "privateaddress"
 
   depends "domain", "fqdn"
   depends "network", "counters/network"


### PR DESCRIPTION
provides "privateaddress" instead of "privateaddres," a typo that was recently introduced.
