### PR TITLE
[OHAI-508] Detect CloudLinux as RHEL platform_family

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -105,7 +105,7 @@ Ohai.plugin do
       platform_family "debian"
     when /fedora/
       platform_family "fedora"
-    when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /amazon/, /xenserver/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
+    when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /amazon/, /xenserver/, /cloudlinux/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
       platform_family "rhel"
     when /suse/
       platform_family "suse"


### PR DESCRIPTION
This is a fix for https://tickets.opscode.com/browse/OHAI-508
