### PR TITLE
Fix: cycle detection

### DIFF
--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -41,12 +41,11 @@ module Ohai
       visited = [plugin]
       while !visited.empty?
         p = visited.pop
-        unless force
-          next if p.has_run?
-        end
+
+        next if p.has_run? unless force
 
         if visited.include?(p)
-          raise DependencyCycleError, "Dependency cycle detected. Please examine the following plugin files: #{cycle_sources(visited, p).join(", ")}"
+          raise DependencyCycleError, "Dependency cycle detected. Please refer to the following plugin files: #{cycle_sources(visited, p).join(", ") }"
         end
 
         dependency_providers = fetch_providers(p.dependencies)
@@ -55,8 +54,7 @@ module Ohai
         if dependency_providers.empty?
           @safe_run ? p.safe_run : p.run
         else
-          visited << p << dependency_providers
-          visited.flatten!
+          visited << p << dependency_providers.first
         end
       end
     end


### PR DESCRIPTION
I found that Ohai::Runner was reporting a cycle in the case where plugin A requires plugins B and C, plugin B requires plugin C, and plugin C has no dependencies. It was possible to have a stack that looked like [bottom] A C B [top], then when B gets popped off and has its dependences added to the stack we'd have [bottom] A C B C [top], which would be counted as a cycle. This was due to all the dependencies being pushed to the stack at once.

Looking for review, @danielsdeleo @lamont-granquist @adamedx. :)
