### PR TITLE
Test for LANG=C and input contains UTF-8

### DIFF
--- a/lib/ohai/mixin/command.rb
+++ b/lib/ohai/mixin/command.rb
@@ -128,12 +128,12 @@ module Ohai
       #
       # Thanks Ara!
       def popen4(cmd, args={}, &b)
-	
+
 	## Disable garbage collection to work around possible bug in MRI
   # Ruby 1.8 suffers from intermittent segfaults believed to be due to GC while IO.select
   # See OHAI-330 / CHEF-2916 / CHEF-1305
 	GC.disable
-	
+
         # Waitlast - this is magic.
         #
         # Do we wait for the child process to die before we yield
@@ -329,9 +329,10 @@ module Ohai
               # have encoding methods.
               if "".respond_to?(:force_encoding) && defined?(Encoding)
                 o.string.force_encoding(Encoding.default_external)
+                o.string.encode!('UTF-8', :invalid => :replace, :undef => :replace, :replace => '?')
                 e.string.force_encoding(Encoding.default_external)
+                e.string.encode!('UTF-8', :invalid => :replace, :undef => :replace, :replace => '?')
               end
-
               b[cid, pi[0], o, e]
               results.last
             end

--- a/spec/unit/mixin/command_spec.rb
+++ b/spec/unit/mixin/command_spec.rb
@@ -50,17 +50,17 @@ describe Ohai::Mixin::Command, "popen4" do
         Encoding.default_internal = @saved_default_internal
       end
 
-      it "should force encode the string to US_ASCII" do
+      it "should force encode the string to UTF-8" do
         extend Ohai::Mixin::Command
         snowy = run_command(:command => ("echo '" + ('☃' * 8096) + "'"))[1]
-        snowy.encoding.should == Encoding::US_ASCII
+        snowy.encoding.should == Encoding::UTF_8
       end
     end
 
-    it "[OHAI-275] should mark strings as in the default external encoding" do
+    it "should force encode the string to UTF-8" do
       extend Ohai::Mixin::Command
       snowy = run_command(:command => ("echo '" + ('☃' * 8096) + "'"))[1]
-      snowy.encoding.should == Encoding.default_external
+      snowy.encoding.should == Encoding::UTF_8
     end
   end
 


### PR DESCRIPTION
- currently we bomb with "invalid byte sequence in US-ASCII"
