### PR TITLE
Pin version of systemu to the same version included in chef.

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -12,15 +12,7 @@ spec = Gem::Specification.new do |s|
   s.email = "adam@opscode.com"
   s.homepage = "http://wiki.opscode.com/display/chef/Ohai"
 
-  # This only helps with bundler because otherwise we make a dependency based
-  # on what platform we are building a gem on, not what platform we are
-  # installing it on.
-  if RUBY_PLATFORM =~ /mswin|mingw|windows/
-    s.add_dependency "systemu", "~> 2.2.0"
-  else
-    s.add_dependency "systemu"
-  end
-
+  s.add_dependency "systemu", "~> 2.5.2"
   s.add_dependency "yajl-ruby"
   s.add_dependency "mixlib-cli"
   s.add_dependency "mixlib-config"


### PR DESCRIPTION
systemu versions between chef and ohai is conflicting on windows now: 

C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/specification.rb:1637:in `raise_if_conflicts': Unable to act
vate ohai-6.20.0.rc.0, because systemu-2.5.2 conflicts with systemu (~> 2.2.0) (Gem::LoadError)
        from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/specification.rb:746:in`activate'
        from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:51:in `block in require'
        from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:50:in`each'
        from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:50:in `require'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.8.0.rc.0-x86-mingw32/lib/chef/http/http_request.
b:32:in`rescue in <top (required)>'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.8.0.rc.0-x86-mingw32/lib/chef/http/http_request.
b:29:in `<top (required)>'
        from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:55:in`require'
        from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.8.0.rc.0-x86-mingw32/lib/chef/http/basic_client.
b:26:in`<top (required)>'
        from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
        from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:55:in`require'
        from C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.8.0.rc.0-x86-mingw32/lib/chef/http.rb:26:in `<to
 (required)>'
