### PR TITLE
Remove self-dependency in libvirt plugin

### DIFF
--- a/lib/ohai/plugins/virtualization.rb
+++ b/lib/ohai/plugins/virtualization.rb
@@ -21,8 +21,6 @@ Ohai.plugin(:VirtualizationInfo) do
     provides "virtualization/#{info}"
   end
 
-  depends "virtualization"
-
   collect_data do
     unless virtualization.nil? || !(virtualization[:role].eql?("host"))
       begin


### PR DESCRIPTION
We're tracking the larger issues that this bug exposes internally as OC-10244, but for now I just want to get ohai to a state where I can successfully run it and have it print out my system data like Ohai 6 does.
