### PR TITLE
Fix Mac OS X stub java workaround

### DIFF
--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -22,17 +22,12 @@ Ohai.plugin(:Java) do
   depends "languages"
 
   collect_data do
+    get_java_info if has_real_java?
+  end
+
+  def get_java_info
     java = Mash.new
-
-    so = nil
-    if RUBY_PLATFORM.downcase.include?("darwin") 
-      if File.executable?("#{ Ohai.abs_path( "/usr/libexec/java_home" )}")
-        so = shell_out("java -version")
-      end
-    else
-      so = shell_out("java -version")
-    end
-
+    so = shell_out("java -version")
     if so.exitstatus == 0
       so.stderr.split(/\r?\n/).each do |line|
         case line
@@ -48,4 +43,31 @@ Ohai.plugin(:Java) do
       languages[:java] = java if java[:version]
     end
   end
+
+  # On Mac OS X, the development tools include "stubs" for JVM executables that
+  # prompt the user to install the JVM if they desire. In our case we simply
+  # wish to detect if the JVM is there and do not want to trigger a popup
+  # window. As a workaround, we can run the java_home executable and check its
+  # exit status to determine if the `java` executable is the real one or the OS
+  # X stub. In the terminal, it looks like this:
+  #
+  #   $ /usr/libexec/java_home
+  #   Unable to find any JVMs matching version "(null)".
+  #   No Java runtime present, try --request to install.
+  #
+  #   $ echo $?
+  #   1
+  #
+  # This check always returns true when not on darwin because it is just a
+  # workaround for this particular annoyance.
+  def has_real_java?
+    return true unless on_darwin?
+    shell_out("/usr/libexec/java_home").status.success?
+  end
+
+  def on_darwin?
+    RUBY_PLATFORM.downcase.include?("darwin")
+  end
+
+
 end

--- a/spec/unit/plugins/java_spec.rb
+++ b/spec/unit/plugins/java_spec.rb
@@ -23,91 +23,147 @@ describe Ohai::System, "plugin java (Java5 Client VM)" do
   before(:each) do
     @plugin = get_plugin("java")
     @plugin[:languages] = Mash.new
-    @stderr = "java version \"1.5.0_16\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_16-b06-284)\nJava HotSpot(TM) Client VM (build 1.5.0_16-133, mixed mode, sharing)"
-    @plugin.stub(:shell_out).with("java -version").and_return(mock_shell_out(0, "", @stderr))
   end
 
-  it "should run java -version" do
-    @plugin.should_receive(:shell_out).with("java -version").and_return(mock_shell_out(0, "", @stderr))
-    @plugin.run
+  shared_examples_for "when the JRE is installed" do
+    before do
+      @stderr = "java version \"1.5.0_16\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_16-b06-284)\nJava HotSpot(TM) Client VM (build 1.5.0_16-133, mixed mode, sharing)"
+      @plugin.stub(:shell_out).with("java -version").and_return(mock_shell_out(0, "", @stderr))
+    end
+
+    it "should run java -version" do
+      @plugin.should_receive(:shell_out).with("java -version").and_return(mock_shell_out(0, "", @stderr))
+      @plugin.run
+    end
+
+    it "should set java[:version]" do
+      @plugin.run
+      @plugin[:languages][:java][:version].should eql("1.5.0_16")
+    end
+
+    it "should set java[:runtime][:name] to runtime name" do
+      @plugin.run
+      @plugin[:languages][:java][:runtime][:name].should eql("Java(TM) 2 Runtime Environment, Standard Edition")
+    end
+
+    it "should set java[:runtime][:build] to runtime build" do
+      @plugin.run
+      @plugin[:languages][:java][:runtime][:build].should eql("1.5.0_16-b06-284")
+    end
+
+    it "should set java[:hotspot][:name] to hotspot name" do
+      @plugin.run
+      @plugin[:languages][:java][:hotspot][:name].should eql("Java HotSpot(TM) Client VM")
+    end
+
+    it "should set java[:hotspot][:build] to hotspot build" do
+      @plugin.run
+      @plugin[:languages][:java][:hotspot][:build].should eql("1.5.0_16-133, mixed mode, sharing")
+    end
+
+    it "should not set the languages[:java] tree up if java command fails" do
+      @stderr = "Some error output here"
+      @plugin.stub(:shell_out).with("java -version").and_return(mock_shell_out(1, "", @stderr))
+      @plugin.run
+      @plugin[:languages].should_not have_key(:java)
+    end
   end
 
-  it "should set java[:version]" do
-    @plugin.run
-    @plugin[:languages][:java][:version].should eql("1.5.0_16")
+  shared_examples_for "when the Server JRE is installed" do
+
+    before(:each) do
+      @stderr = "java version \"1.6.0_22\"\nJava(TM) 2 Runtime Environment (build 1.6.0_22-b04)\nJava HotSpot(TM) Server VM (build 17.1-b03, mixed mode)"
+      @plugin.stub(:shell_out).with("java -version").and_return(mock_shell_out(0, "", @stderr))
+    end
+
+    it "should run java -version" do
+      @plugin.should_receive(:shell_out).with("java -version").and_return(mock_shell_out(0, "", @stderr))
+      @plugin.run
+    end
+
+    it "should set java[:version]" do
+      @plugin.run
+      @plugin[:languages][:java][:version].should eql("1.6.0_22")
+    end
+
+    it "should set java[:runtime][:name] to runtime name" do
+      @plugin.run
+      @plugin[:languages][:java][:runtime][:name].should eql("Java(TM) 2 Runtime Environment")
+    end
+
+    it "should set java[:runtime][:build] to runtime build" do
+      @plugin.run
+      @plugin[:languages][:java][:runtime][:build].should eql("1.6.0_22-b04")
+    end
+
+    it "should set java[:hotspot][:name] to hotspot name" do
+      @plugin.run
+      @plugin[:languages][:java][:hotspot][:name].should eql("Java HotSpot(TM) Server VM")
+    end
+
+    it "should set java[:hotspot][:build] to hotspot build" do
+      @plugin.run
+      @plugin[:languages][:java][:hotspot][:build].should eql("17.1-b03, mixed mode")
+    end
+
+    it "should not set the languages[:java] tree up if java command fails" do
+      @stderr = "Some error output here"
+      @plugin.stub(:shell_out).with("java -version").and_return(mock_shell_out(0, "", @stderr))
+      @plugin.run
+      @plugin[:languages].should_not have_key(:java)
+    end
   end
 
-  it "should set java[:runtime][:name] to runtime name" do
-    @plugin.run
-    @plugin[:languages][:java][:runtime][:name].should eql("Java(TM) 2 Runtime Environment, Standard Edition")
+  context "when not on Mac OS X" do
+    before do
+      stub_const("RUBY_PLATFORM", "x86_64-linux")
+    end
+
+    context "and the client JRE is installed" do
+      include_examples "when the JRE is installed"
+    end
+    context "and the server JRE is installed" do
+      include_examples "when the Server JRE is installed"
+    end
   end
 
-  it "should set java[:runtime][:build] to runtime build" do
-    @plugin.run
-    @plugin[:languages][:java][:runtime][:build].should eql("1.5.0_16-b06-284")
-  end
+  context "when on Mac OS X with Java installed" do
+    before do
+      stub_const("RUBY_PLATFORM", "x86_64-darwin12.3.0")
+    end
 
-  it "should set java[:hotspot][:name] to hotspot name" do
-    @plugin.run
-    @plugin[:languages][:java][:hotspot][:name].should eql("Java HotSpot(TM) Client VM")
-  end
+    it "detects that it is on a darwin platform" do
+      @plugin.should be_on_darwin
+    end
 
-  it "should set java[:hotspot][:build] to hotspot build" do
-    @plugin.run
-    @plugin[:languages][:java][:hotspot][:build].should eql("1.5.0_16-133, mixed mode, sharing")
-  end
+    context "and real Java is installed" do
+      before do
+        java_home_status = double(Process::Status, :success? => true)
+        java_home_cmd = double(Mixlib::ShellOut, :status => java_home_status)
+        @plugin.should_receive(:shell_out).with("/usr/libexec/java_home").and_return(java_home_cmd)
+      end
 
-  it "should not set the languages[:java] tree up if java command fails" do
-    @stderr = "Some error output here"
-    @plugin.stub(:shell_out).with("java -version").and_return(mock_shell_out(1, "", @stderr))
-    @plugin.run
-    @plugin[:languages].should_not have_key(:java)
-  end
-end
+      context "and the client JRE is installed" do
+        include_examples "when the JRE is installed"
+      end
+      context "and the server JRE is installed" do
+        include_examples "when the Server JRE is installed"
+      end
+    end
 
-describe Ohai::System, "plugin java (Java6 Server VM)" do
-  before(:each) do
-    @plugin = get_plugin("java")
-    @plugin[:languages] = Mash.new
-    @stderr = "java version \"1.6.0_22\"\nJava(TM) 2 Runtime Environment (build 1.6.0_22-b04)\nJava HotSpot(TM) Server VM (build 17.1-b03, mixed mode)"
-    @plugin.stub(:shell_out).with("java -version").and_return(mock_shell_out(0, "", @stderr))
-  end
+    context "and the JVM stubs are installed" do
+      before do
+        java_home_status = double(Process::Status, :success? => false)
+        java_home_cmd = double(Mixlib::ShellOut, :status => java_home_status)
+        @plugin.should_receive(:shell_out).with("/usr/libexec/java_home").and_return(java_home_cmd)
+      end
 
-  it "should run java -version" do
-    @plugin.should_receive(:shell_out).with("java -version").and_return(mock_shell_out(0, "", @stderr))
-    @plugin.run
-  end
-
-  it "should set java[:version]" do
-    @plugin.run
-    @plugin[:languages][:java][:version].should eql("1.6.0_22")
-  end
-
-  it "should set java[:runtime][:name] to runtime name" do
-    @plugin.run
-    @plugin[:languages][:java][:runtime][:name].should eql("Java(TM) 2 Runtime Environment")
-  end
-
-  it "should set java[:runtime][:build] to runtime build" do
-    @plugin.run
-    @plugin[:languages][:java][:runtime][:build].should eql("1.6.0_22-b04")
-  end
-
-  it "should set java[:hotspot][:name] to hotspot name" do
-    @plugin.run
-    @plugin[:languages][:java][:hotspot][:name].should eql("Java HotSpot(TM) Server VM")
-  end
-
-  it "should set java[:hotspot][:build] to hotspot build" do
-    @plugin.run
-    @plugin[:languages][:java][:hotspot][:build].should eql("17.1-b03, mixed mode")
-  end
-
-  it "should not set the languages[:java] tree up if java command fails" do
-    @stderr = "Some error output here"
-    @plugin.stub(:shell_out).with("java -version").and_return(mock_shell_out(0, "", @stderr))
-    @plugin.run
-    @plugin[:languages].should_not have_key(:java)
+      it "does not attempt to get java info" do
+        @plugin.should_not_receive(:shell_out).with("java -version")
+        @plugin.run
+        @plugin[:languages].should_not have_key(:java)
+      end
+    end
   end
 
 


### PR DESCRIPTION
- Fixes https://tickets.opscode.com/browse/OHAI-514
- I've tested manually on a mac w/o any JDK/JRE present, could use a sanity check on a system that has a JRE/JDK
- Refactor Java plugin tests to use shared example groups so no duplication is needed when testing the Mac/Not-Mac case.
