### PR TITLE
[OHAI-531] Regex for getting data from arp -na output is incorrect on Solaris2

### DIFF
--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -117,9 +117,19 @@ Ohai.plugin(:Network) do
       end
     end
 
+    # [root@defiant /opt/chef/lib/ruby/gems/1.9.1/gems/ohai-6.20.0/lib/ohai/plugins/solaris2]# arp -na
+    # Net to Media Table: IPv4
+    # Device   IP Address               Mask      Flags      Phys Addr
+    # ------ -------------------- --------------- -------- ---------------
+    # net0   37.153.96.85         255.255.255.255          90:b8:d0:2a:0a:23
+    # net1   10.224.0.34          255.255.255.255 SPLA     90:b8:d0:6c:08:fa
+    # net0   37.153.96.1          255.255.255.255          00:00:5e:00:01:01
+    # net0   37.153.96.57         255.255.255.255          90:b8:d0:9d:d6:63
+    # net1   10.224.0.1           255.255.255.255          00:00:5e:00:01:01
+    # net0   37.153.96.33         255.255.255.255 SPLA     90:b8:d0:3e:81:c9
     so = shell_out("arp -an")
     so.stdout.lines do |line|
-      if line =~ /([0-9a-zA-Z]+)\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+(\w+)\s+([a-zA-Z0-9\.\:\-]+)/
+      if line =~ /^([0-9a-zA-Z\.\:\-]+)\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+([SPLA]+)?\s+([a-fA-F0-9\:]+)/
         next unless iface[arpname_to_ifname(iface, $1)] # this should never happen, except on solaris because sun hates you.
         iface[arpname_to_ifname(iface, $1)][:arp] = Mash.new unless iface[arpname_to_ifname(iface, $1)][:arp]
         iface[arpname_to_ifname(iface, $1)][:arp][$2] = $5


### PR DESCRIPTION
```

  "network": {
    "interfaces": {
      "lo0": {
        "mtu": "8252",
        "index": "1",
        "flags": [
          "UP",
          "LOOPBACK",
          "RUNNING",
          "MULTICAST",
          "IPv6",
          "VIRTUAL"
        ],
        "type": "lo",
        "number": "0",
        "encapsulation": "Loopback",
        "addresses": {
          "127.0.0.1": {
            "family": "inet",
            "netmask": "255.0.0.0"
          },
          "::1": {
            "family": "inet6",
            "prefixlen": "128"
          }
        }
      },
      "net0": {
        "mtu": "1500",
        "index": "2",
        "flags": [
          "UP",
          "BROADCAST",
          "RUNNING",
          "MULTICAST",
          "IPv4",
          "CoS",
          "L3PROTECT"
        ],
        "type": "net",
        "number": "0",
        "encapsulation": "Ethernet",
        "addresses": {
          "37.153.96.33": {
            "family": "inet",
            "netmask": "255.255.254.0",
            "broadcast": "37.153.97.255"
          },
          "90:b8:d0:3e:81:c9": {
            "family": "lladdr"
          }
        },
        "arp": {
          "37.153.96.85": "90:b8:d0:2a:0a:23",
          "37.153.96.1": "00:00:5e:00:01:01",
          "37.153.96.57": "90:b8:d0:9d:d6:63",
          "37.153.96.33": "90:b8:d0:3e:81:c9"
        }
      },
      "net1": {
        "mtu": "1500",
        "index": "3",
        "flags": [
          "UP",
          "BROADCAST",
          "RUNNING",
          "MULTICAST",
          "IPv4",
          "CoS",
          "L3PROTECT"
        ],
        "type": "net",
        "number": "1",
        "encapsulation": "Ethernet",
        "addresses": {
          "10.224.0.34": {
            "family": "inet",
            "netmask": "255.255.248.0",
            "broadcast": "10.224.7.255"
          },
          "90:b8:d0:6c:08:fa": {
            "family": "lladdr"
          }
        },
        "arp": {
          "10.224.0.34": "90:b8:d0:6c:08:fa",
          "10.224.0.1": "00:00:5e:00:01:01"
        }
      }
    },
    "default_interface": "net0",
    "default_gateway": "37.153.96.1"
  },
```
