### PR TITLE
OHAI-537: Require the os plugin in the hostname plugin

### DIFF
--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -18,6 +18,7 @@
 
 provides "fqdn", "domain"
 
+require_plugin "os"
 require_plugin "#{os}::hostname"
 
 # Domain is everything after the first dot

--- a/spec/unit/plugins/hostname_spec.rb
+++ b/spec/unit/plugins/hostname_spec.rb
@@ -35,5 +35,15 @@ describe Ohai::System, "hostname plugin" do
     @ohai._require_plugin("hostname")
     @ohai.domain.should == nil
   end
-    
+
+  it "should require the os plugin" do
+    @ohai.should_receive(:require_plugin).with("os").and_return(true)
+    @ohai._require_plugin("hostname")
+  end
+
+  it "should load a platform specific hostname plugin" do
+    @ohai[:os] = "linux"
+    @ohai.should_receive(:require_plugin).with("linux::hostname").and_return(true)
+    @ohai._require_plugin("hostname")
+  end
 end


### PR DESCRIPTION
The hostname plugin uses the os plugin, so it needs to be loaded first.
In a normal run it happens to be loaded but if you're only running the
hostname plugin it will fail without the os plugin.
