### PR TITLE
Clean up `jenkins_run_tests.bat`

### DIFF
--- a/ci/jenkins_run_tests.bat
+++ b/ci/jenkins_run_tests.bat
@@ -1,9 +1,16 @@
-set PATH=C:\Ruby192\bin;%PATH%
-
 ruby -v
-call bundle install --binstubs --without docgen --path vendor/bundle || ( call rm Gemfile.lock && call bundle install --binstubs --path vendor/bundle )
-ruby bin\rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation spec/functional spec/unit spec/stress
+
+call bundle check
+
+if %ERRORLEVEL% NEQ 0 (
+   call rm Gemfile.lock
+   call bundle install --without docgen --path vendor/bundle
+)
+
+bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation spec
+
 set RSPEC_ERRORLVL=%ERRORLEVEL%
 
+set RSPEC_ERRORLVL=%ERRORLEVEL%
 REM Return the error level from rspec
 exit /B %RSPEC_ERRORLVL%


### PR DESCRIPTION
This change ensures the bat file is in sync with what we have in 
opscode/chef.

/cc @sersut @danielsdeleo 
