### PR TITLE
Detect KVM guests using dmesg

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -71,6 +71,14 @@ Ohai.plugin(:Virtualization) do
       end
     end
 
+    # Detect KVM guest from demsg
+    if File.exists?("/bin/dmesg")
+      if `/bin/dmesg`.scan(/Booting paravirtualized kernel on KVM/)
+        virtualization[:system] = "kvm"
+        virtualization[:role] = "guest"
+      end
+    end
+
     # Detect OpenVZ / Virtuozzo.
     # http://wiki.openvz.org/BC_proc_entries
     if File.exists?("/proc/bc/0")

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -33,6 +33,7 @@ describe Ohai::System, "Linux virtualization platform" do
     File.stub(:exists?).with("/proc/self/status").and_return(false)
     File.stub(:exists?).with("/proc/bc/0").and_return(false)
     File.stub(:exists?).with("/proc/vz").and_return(false)
+    File.stub(:exists?).with("/bin/dmesg").and_return(false)
   end
 
   describe "when we are checking for xen" do
@@ -97,6 +98,16 @@ describe Ohai::System, "Linux virtualization platform" do
     it "should set kvm guest if /proc/cpuinfo contains Common 32-bit KVM processor" do
       File.should_receive(:exists?).with("/proc/cpuinfo").and_return(true)
       File.stub(:read).with("/proc/cpuinfo").and_return("Common 32-bit KVM processor")
+      @plugin.run
+      @plugin[:virtualization][:system].should == "kvm"
+      @plugin[:virtualization][:role].should == "guest"
+    end
+
+    it "should set kvm guest if dmesg contains Booting paravirtualized kernel on KVM" do
+      File.should_receive(:exists?).with("/bin/dmesg").and_return(true)
+      @plugin.stub(:shell_out).with("dmesg").and_return(
+        mock_shell_out(0, "[    0.000000] Booting paravirtualized kernel on KVM", "")
+      )
       @plugin.run
       @plugin[:virtualization][:system].should == "kvm"
       @plugin[:virtualization][:role].should == "guest"


### PR DESCRIPTION
`ohai` cannot detect KVM guests if KVM/QEMU is running with `-cpu` option. Even if so, we still can detect them by searching for "Booting paravirtualized kernel on KVM" in `dmesg` output.