### PR TITLE
Work around EC2 bug

### DIFF
--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -118,7 +118,7 @@ module Ohai
                 metadata_get(key, api_version).body.split("\n")
               else
                 metadata_get(key, api_version).body
-              end
+              end rescue nil
           elsif not key.eql?(id) and not key.eql?('/')
             name = key[0..-2]
             sym = metadata_key(name)


### PR DESCRIPTION
Added a rescue clause since ec2 may return a 404 for a resource it has
said it can provide. This is an ec2 bug which I have reported to them,
but while we wait for them to fix it this patch is needed since it
gets chef working again.

Without this patch ohai returns no ec2 data at all when one of the
resources return 404.
