### PR TITLE
Add option to only run plugins providing requested attributes

### DIFF
--- a/lib/ohai/provides_map.rb
+++ b/lib/ohai/provides_map.rb
@@ -61,20 +61,27 @@ module Ohai
           raise Ohai::Exceptions::AttributeNotFound, "Cannot find plugin providing attribute \'#{attribute}\'" unless attrs[part]
           attrs = attrs[part]
         end
-        plugins << attrs[:_plugins]
-        plugins.flatten!
+        plugins += collect_plugins_in(attrs, [])
       end
       plugins.uniq
     end
 
 
-    def all_plugins
-      collected = []
-      collect_plugins_in(map, collected).uniq
+    def all_plugins(attribute_filter=nil)
+      if attribute_filter.nil?
+        collected = []
+        collect_plugins_in(map, collected).uniq
+      else
+        find_providers_for(Array(attribute_filter))
+      end
     end
 
     private
 
+    # Takes a section of the map, recursively searches for a `_plugins` key
+    # to find all the plugins in that section of the map. If given the whole
+    # map, it will find all of the plugins that have at least one provided
+    # attribute.
     def collect_plugins_in(provides_map, collected)
       provides_map.keys.each do |plugin|
         if plugin.eql?("_plugins")

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -58,9 +58,9 @@ module Ohai
     #=============================================
     #  Version 7 system commands
     #=============================================
-    def all_plugins
+    def all_plugins(attribute_filter=nil)
       load_plugins
-      run_plugins(true)
+      run_plugins(true, false, attribute_filter)
     end
 
     def load_plugins
@@ -84,8 +84,8 @@ module Ohai
         end
       end
     end
-    
-    def run_plugins(safe = false, force = false)
+
+    def run_plugins(safe = false, force = false, attribute_filter = nil)
       # collect and run version 6 plugins
       v6plugins = []
       @v6_dependency_solver.each { |plugin_name, plugin| v6plugins << plugin if plugin.version.eql?(:version6) }
@@ -96,7 +96,7 @@ module Ohai
       end
 
       # collect and run version 7 plugins
-      plugins = @provides_map.all_plugins
+      plugins = @provides_map.all_plugins(attribute_filter)
 
       begin
         plugins.each { |plugin| @runner.run_plugin(plugin, force) }

--- a/spec/unit/provides_map_spec.rb
+++ b/spec/unit/provides_map_spec.rb
@@ -85,6 +85,10 @@ describe Ohai::ProvidesMap do
     it "should collect the provider" do
       expect(provides_map.find_providers_for(["top/middle/bottom"])).to eq([plugin_1])
     end
+
+    it "should collect the provider" do
+      expect(provides_map.find_providers_for(["top/middle"])).to eq([plugin_1])
+    end
   end
 
   describe "when listing all plugins" do
@@ -103,6 +107,21 @@ describe Ohai::ProvidesMap do
       expect(all_plugins).to include(plugin_2)
       expect(all_plugins).to include(plugin_3)
       expect(all_plugins).to include(plugin_4)
+    end
+
+    describe "with an attribute filter" do
+      it "finds plugins with a single level of attribute" do
+        expect(provides_map.all_plugins("one")).to eq([plugin_1])
+      end
+
+      it "finds plugins with an exact match for multiple levels of attribute" do
+        expect(provides_map.all_plugins("stub/three")).to eq([plugin_3])
+      end
+
+      it "finds plugins that provide subattributes of the requested path" do
+        expect(provides_map.all_plugins("stub")).to eq([plugin_3])
+        expect(provides_map.all_plugins("foo/bar")).to eq([plugin_4])
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- `Ohai::System#all_plugins` takes an option whitelist filter
- `Ohai::ProvidesMap#find_providers_for` now finds all plugins at the
  specified nesting or deeper. For example, if a plugin provides
  "virtualization/networks" and no plugin provides "virtualization",
  then find_providers_for(["virtualization"]) would return `[nil]`. It
  now finds all providers deeper than the specified level in the map.
## Remaining

Since several of us are making changes in similar places simultaneously, I want to share this now. To complete the PBI, I think ohai's command line attribute selector (e.g., `ohai network`) needs to be integrated with this, which will help 3rd party plugin development by improving feedback time.
