### PR TITLE
Pass user-requested attributes from CLI to whitelist

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -77,6 +77,7 @@ class Ohai::Application
 
   def configure_ohai
     @attributes = parse_options
+    @attributes = nil if @attributes.empty?
 
     Ohai::Config.merge!(config)
     if Ohai::Config[:directory]
@@ -94,9 +95,9 @@ class Ohai::Application
     if Ohai::Config[:file]
       ohai.from_file(Ohai::Config[:file])
     else
-      ohai.all_plugins
+      ohai.all_plugins(@attributes)
     end
-    if @attributes.length > 0
+    if @attributes
       @attributes.each do |a|
         puts ohai.attributes_print(a)
       end


### PR DESCRIPTION
This greatly speeds up running ohai from the command line when given a
set of attributes to display (like `ohai ec2`). Prior to this patch,
ohai would run all plugins and then filter out the data. With this
patch, ohai only runs relevant plugins.

As an unscientific test `bin/ohai network` on my laptop takes ~4s
without this patch compared to ~1.1s with the patch.

Note that the `Ohai::Application` class doesn't have any tests at the moment, but I verified the behavior in the following cases:
- simple one-level attribute: `ohai network`
- multi-level attribute: `ohai network/interfaces`
- multiple attributes: `ohai network kernel`
