### PR TITLE
Temporarily force rubygems 2.1.x for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,16 @@
+# Temporary workaround for issue with rubygems 2.2.0 with bundler 1.5 on ruby
+# 1.8.7.
+#
+# A fix has been merged to rubygems but not yet released. See:
+# https://github.com/rubygems/rubygems/commit/f8e0f1d5f67cfc4e1966cc1e2db367aebf8a09e4
+#
+# See also CHEF-4916
+#
+# This workaround should be removed when that fix is released.
+before_install:
+  - gem update --system 2.1.11
+  - gem --version
+
 rvm:
   - 1.8.7
   - 1.9.2


### PR DESCRIPTION
This works around an incompatibility between bundler, rubygems 2.2.0,
and ruby 1.8.7.
