### PR TITLE
fix ability to run a single plugin file

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -27,11 +27,6 @@ class Ohai::Application
     :long        => "--directory DIRECTORY",
     :description => "A directory to add to the Ohai search path"
 
-  option :file,
-    :short       => "-f FILE",
-    :long        => "--file FILE",
-    :description => "A file to run Ohai against"
-
   option :log_level,
     :short        => "-l LEVEL",
     :long         => "--log_level LEVEL",
@@ -92,11 +87,8 @@ class Ohai::Application
 
   def run_application
     ohai = Ohai::System.new
-    if Ohai::Config[:file]
-      ohai.from_file(Ohai::Config[:file])
-    else
-      ohai.all_plugins(@attributes)
-    end
+    ohai.all_plugins(@attributes)
+
     if @attributes
       @attributes.each do |a|
         puts ohai.attributes_print(a)


### PR DESCRIPTION
@btm pointed out that the ohai application would break when using the `-f` command. I've now updated the ohai application to run a single file.

I've marked a TODO item on [line 102](https://github.com/opscode/ohai/blob/c7043950e65bc927e52eedbe83b983cc8a9a25d3/lib/ohai/application.rb#L102-L103). The help description on [line 33](https://github.com/opscode/ohai/blob/c7043950e65bc927e52eedbe83b983cc8a9a25d3/lib/ohai/application.rb#L33) is the most non-invasive fix I could come up with for now. Not sure if we want to do anything about it. @danielsdeleo 
