### PR TITLE
catch and ignore failure to load chef

### DIFF
--- a/lib/ohai/plugins/chef.rb
+++ b/lib/ohai/plugins/chef.rb
@@ -23,6 +23,9 @@ Ohai.plugin(:Chef) do
     begin
       require 'chef/version'
     rescue Gem::LoadError
+      # this catches when you've done a major version bump of ohai, but
+      # your chef gem is incompatible, so we can't load it in the same VM
+      # (affects mostly internal testing)
       next
     end
 


### PR DESCRIPTION
if chef version is 11.8.2 and it pins ohai to <~ 6.0, then if we
install ohai 7, the chef plugin will attempt to load chef up and
then will puke hard since ohai 7 is already loaded.  this just skips
chef version detection if that dependency resolution problem occurs.
