### PR TITLE
make linux/network.rb define collect_data(:linux)

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -32,7 +32,7 @@ Ohai.plugin(:Network) do
     encap
   end
 
-  collect_data do
+  collect_data(:linux) do
     require 'ipaddr'
 
     iface = Mash.new

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -26,6 +26,7 @@ rescue LoadError => e
 end
 
 def do_stubs
+  @plugin.stub(:collect_os).and_return(:linux)
   @plugin.stub(:shell_out).with("ip addr").and_return(mock_shell_out(0, @linux_ip_addr, ""))
   @plugin.stub(:shell_out).with("ip -d -s link").and_return(mock_shell_out(0, @linux_ip_link_s_d, ""))
   @plugin.stub(:shell_out).with("ip -f inet neigh show").and_return(mock_shell_out(0, @linux_ip_neighbor_show, ""))


### PR DESCRIPTION
`linux/network.rb` defined a default collect_data block, and there was no stub in `linux/network_spec.rb` defining the platform (e.g., `.stub(:collect_data).and_return(:linux)`). The tests were stubbed out enough that this wasn't caught.

I'm thinking of adding something to one of the spec helpers, like `when_on_platform(:x)`, which ensures that `collect_data(:x)` is chosen for that plugin and the code under `:x` is executed (or at the very least performs the `:collect_os` stub). Also, maybe we should treat errors raised by `Ohai::Loader` as failures during testing... Thoughts?

@danielsdeleo @sersut 
