### PR TITLE
save plugin source(s) for version 7 plugins during loading

### DIFF
--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -83,7 +83,6 @@ module Ohai
       include Ohai::Mixin::SecondsToHuman
 
       attr_reader :data
-      attr_reader :source
 
       def initialize(data)
         @data = data

--- a/lib/ohai/dsl/plugin/versionvi.rb
+++ b/lib/ohai/dsl/plugin/versionvi.rb
@@ -22,18 +22,19 @@ module Ohai
     class Plugin
       class VersionVI < Plugin
         attr_reader :version
+        attr_reader :source
 
         def initialize(controller, plugin_path)
           super(controller.data)
           @controller = controller
           @version = :version6
-          @plugin_path = plugin_path
+          @source = plugin_path
         end
 
         def name
           # Ohai V6 doesn't have any name specification for plugins. 
           # So we are using the full path to the plugin as the name of the plugin.
-          @plugin_path
+          @source
         end
 
         def self.version

--- a/lib/ohai/dsl/plugin/versionvii.rb
+++ b/lib/ohai/dsl/plugin/versionvii.rb
@@ -22,9 +22,11 @@ module Ohai
     class Plugin
       class VersionVII < Plugin
         attr_reader :version
+        attr_reader :source
 
         def initialize(data)
           super(data)
+          @source = self.class.sources
           @version = :version7
         end
 
@@ -34,6 +36,10 @@ module Ohai
 
         def self.version
           :version7
+        end
+
+        def self.sources
+          @source_list ||= []
         end
 
         def self.provides_attrs

--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -168,6 +168,7 @@ For more information visit here: docs.opscode.com/ohai_custom.html")
       unless plugin_class.kind_of?(Class) and plugin_class < Ohai::DSL::Plugin
         raise Ohai::Exceptions::IllegalPluginDefinition, "Plugin file cannot contain any statements after the plugin definition"
       end
+      plugin_class.sources << plugin_path
       @v7_plugin_classes << plugin_class unless @v7_plugin_classes.include?(plugin_class)
       plugin_class
     rescue SystemExit, Interrupt


### PR DESCRIPTION
Adds ability to save the plugin source file(s) to the plugin class during loading. Saves v7 plugin sources in an array.

Todo? Add source information to log messages.

@danielsdeleo @sersut 
