### PR TITLE
fix uptime plugin to remove sigar

### DIFF
--- a/lib/ohai/plugins/uptime.rb
+++ b/lib/ohai/plugins/uptime.rb
@@ -42,7 +42,7 @@ Ohai.plugin(:Uptime) do
     return [nil, nil]
   end
 
-  collect_data(:default) do
+  collect_data(:aix, :hpux, :default) do
     require 'sigar'
 
     sigar = Sigar.new


### PR DESCRIPTION
- sneaks in a fix for OHAI-443 uptime on solaris as well
