### PR TITLE
OHAI-546: Return what we have at the end of the provides map

### DIFF
--- a/lib/ohai/provides_map.rb
+++ b/lib/ohai/provides_map.rb
@@ -110,7 +110,8 @@ module Ohai
       subtree = provides_map
       parts = normalize_and_validate(attribute)
       parts.each do |part|
-        return nil unless subtree[part]
+        # OHAI-546: We may have reached the end of a 'provides' chain, return what we have.
+        return subtree unless subtree[part]
         subtree = subtree[part]
       end
       subtree


### PR DESCRIPTION
Some attributes are dynamically defined, e.g. network/interfaces/eth0, so
we cannot declare them using provides prior to running the plugin. Return the
closest plugin we can find in the provides map.

This may limit multiple plugins providing dynamic attributes from the same level.
