### PR TITLE
collect only unique providers

### DIFF
--- a/lib/ohai/dsl/plugin/versionvii.rb
+++ b/lib/ohai/dsl/plugin/versionvii.rb
@@ -56,13 +56,13 @@ module Ohai
 
         def self.provides(*attrs)
           attrs.each do |attr|
-            provides_attrs << attr
+            provides_attrs << attr unless provides_attrs.include?(attr)
           end
         end
 
         def self.depends(*attrs)
           attrs.each do |attr|
-            depends_attrs << attr
+            depends_attrs << attr unless depends_attrs.include?(attr)
           end
         end
 

--- a/lib/ohai/provides_map.rb
+++ b/lib/ohai/provides_map.rb
@@ -45,7 +45,6 @@ module Ohai
         end
         attrs[:_plugins] ||= []
         attrs[:_plugins] << plugin
-        attrs[:_plugins].uniq!
       end
     end
 

--- a/spec/unit/dsl/plugin_spec.rb
+++ b/spec/unit/dsl/plugin_spec.rb
@@ -143,6 +143,12 @@ describe Ohai::DSL::Plugin::VersionVII do
       plugin = Ohai.plugin(@name) { provides("two", "three") }
       plugin.provides_attrs.should eql(["one", "two", "three"])
     end
+
+    it "should collect unique attributes" do
+      plugin = Ohai.plugin(@name) { provides("one") }
+      plugin = Ohai.plugin(@name) { provides("one", "two") }
+      plugin.provides_attrs.should eql(["one", "two"])
+    end
   end
 
   describe "#depends" do
@@ -169,6 +175,12 @@ describe Ohai::DSL::Plugin::VersionVII do
       plugin = Ohai.plugin(@name) { depends("one") }
       plugin = Ohai.plugin(@name) { depends("two", "three") }
       plugin.depends_attrs.should eql(["one", "two", "three"])
+    end
+
+    it "should collect unique attributes" do
+      plugin = Ohai.plugin(@name) { depends("one") }
+      plugin = Ohai.plugin(@name) { depends("one", "two") }
+      plugin.depends_attrs.should eql(["one", "two"])
     end
   end
 


### PR DESCRIPTION
Noticed the `provides_map` would contain multiple copies of the same plugin under `attr[:_plugins]`. This changes the `provides_map` so that it saves only one copy of a plugin in `attr[:_plugins]`.

@danielsdeleo @sersut 
