### PR TITLE
avoid monkeypatching the encaps_lookup() method

### DIFF
--- a/lib/ohai/plugins/darwin/network.rb
+++ b/lib/ohai/plugins/darwin/network.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Network) do
               media[line_array[i]]["options"] << opt unless media[line_array[i]]["options"].include?(opt)
             end
           else
-            media[line_array[i]]["options"] = $1.split(",") 
+            media[line_array[i]]["options"] = $1.split(",")
           end
         else
           if line_array[i].eql?("autoselect")
@@ -50,7 +50,7 @@ Ohai.plugin(:Network) do
     media
   end
 
-  def encaps_lookup(ifname)
+  def darwin_encaps_lookup(ifname)
     return "Loopback" if ifname.eql?("lo")
     return "1394" if ifname.eql?("fw")
     return "IPIP" if ifname.eql?("gif")
@@ -79,7 +79,7 @@ Ohai.plugin(:Network) do
         return ifc if addr.eql? mac
       end
     end
-    
+
     nil
   end
 
@@ -90,7 +90,7 @@ Ohai.plugin(:Network) do
     network[:interfaces] = Mash.new unless network[:interfaces]
     counters Mash.new unless counters
     counters[:network] = Mash.new unless counters[:network]
-    
+
     so = shell_out("route -n get default")
     so.stdout.lines do |line|
       if line =~ /(\w+): ([\w\.]+)/
@@ -102,7 +102,7 @@ Ohai.plugin(:Network) do
         end
       end
     end
-    
+
     iface = Mash.new
     so = shell_out("ifconfig -a")
     cint = nil
@@ -120,7 +120,7 @@ Ohai.plugin(:Network) do
         if cint =~ /^(\w+)(\d+.*)/
           iface[cint][:type] = $1
           iface[cint][:number] = $2
-          iface[cint][:encapsulation] = encaps_lookup($1)
+          iface[cint][:encapsulation] = darwin_encaps_lookup($1)
         end
       end
       if line =~ /^\s+ether ([0-9a-f\:]+)/

--- a/lib/ohai/plugins/sigar/network.rb
+++ b/lib/ohai/plugins/sigar/network.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:Network) do
   provides "network", "network/interfaces"
   provides "counters/network", "counters/network/interfaces"
 
-  def encaps_lookup(encap)
+  def sigar_encaps_lookup(encap)
     return "Loopback" if encap.eql?("Local Loopback")
     return "PPP" if encap.eql?("Point-to-Point Protocol")
     return "SLIP" if encap.eql?("Serial Line IP")
@@ -45,7 +45,7 @@ Ohai.plugin(:Network) do
       end
 
       ifconfig = sigar.net_interface_config(cint)
-      iface[cint][:encapsulation] = encaps_lookup(ifconfig.type)
+      iface[cint][:encapsulation] = sigar_encaps_lookup(ifconfig.type)
 
       iface[cint][:addresses] = Mash.new
       # Backwards compat: loopback has no hwaddr

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -57,7 +57,7 @@ Ohai.plugin(:Network) do
   provides "network", "network/interfaces"
   provides "counters/network", "counters/network/interfaces"
 
-  def encaps_lookup(ifname)
+  def solaris_encaps_lookup(ifname)
     return "Ethernet" if ifname.eql?("e1000g")
     return "Ethernet" if ifname.eql?("eri")
     return "Ethernet" if ifname.eql?("net")
@@ -100,7 +100,7 @@ Ohai.plugin(:Network) do
         if cint =~ /^(\w+)(\d+.*)/
           iface[cint][:type] = $1
           iface[cint][:number] = $2
-          iface[cint][:encapsulation] = encaps_lookup($1)
+          iface[cint][:encapsulation] = solaris_encaps_lookup($1)
         end
       end
       if line =~ /\s+inet (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) netmask (([0-9a-f]){1,8})\s*$/

--- a/lib/ohai/plugins/windows/network.rb
+++ b/lib/ohai/plugins/windows/network.rb
@@ -20,7 +20,7 @@ Ohai.plugin(:Network) do
   provides "network", "network/interfaces"
   provides "counters/network", "counters/network/interfaces"
 
-  def encaps_lookup(encap)
+  def windows_encaps_lookup(encap)
     return "Ethernet" if encap.eql?("Ethernet 802.3")
     encap
   end
@@ -95,7 +95,7 @@ Ohai.plugin(:Network) do
         iface[cint][:mtu] = iface[cint][:configuration][:mtu]
         iface[cint][:type] = iface[cint][:instance][:adapter_type]
         iface[cint][:arp] = {}
-        iface[cint][:encapsulation] = encaps_lookup(iface[cint][:instance][:adapter_type])
+        iface[cint][:encapsulation] = windows_encaps_lookup(iface[cint][:instance][:adapter_type])
         if iface[cint][:configuration][:default_ip_gateway] != nil and iface[cint][:configuration][:default_ip_gateway].size > 0
           network[:default_gateway] = iface[cint][:configuration][:default_ip_gateway].first
           network[:default_interface] = cint


### PR DESCRIPTION
the windows definition of #encaps_lookup() was winning, either through
accident or through alphabetical sort order.

long term we may want better isolation between different files that
are defining a plugin.
