### PR TITLE
OC-11083 MS C compiler plugin regression -- trailing return character removal

### DIFF
--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -62,7 +62,7 @@ Ohai.plugin(:C) do
     begin
       so = shell_out("cl /?")
       if so.exitstatus == 0
-        description = so.stderr.split($/).first
+        description = so.stderr.lines.first.chomp
         if description =~ /Compiler Version ([\d\.]+)/
           c[:cl] = Mash.new
           c[:cl][:version] = $1


### PR DESCRIPTION
A fix from @sersut -- @dan, @lamont, @claire, this addresses an apparent difference of the new usage of mixlib-shellout for process execution on Windows where Windows-style line endings are not treated the same as they were with the Ohai 6 process launch mechanism.
