### PR TITLE
If can't find an expected piece of metadata, log and continue

### DIFF
--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -101,7 +101,7 @@ module Ohai
       def metadata_get(id, api_version)
         response = http_client.get("/#{api_version}/meta-data/#{id}")
         unless response.code == '200'
-          raise "Encountered error retrieving EC2 metadata (returned #{response.code} response)"
+          Ohai::Log.debug("Encountered error retrieving EC2 metadata for /#{api_version}/meta-data/#{id} (returned #{response.code} response)")
         end
         response
       end


### PR DESCRIPTION
On certain instance types (e.g. hi.4xlarge), AWS returns 404 for certain pieces of metadata (e.g. on a hi.4xlarge, metrics/vhostmd returns 404). A half-completed ec2 section in ohai is still more helpful than an empty ec2 section, so log the error and continue, rather than raising an exception.

See also: https://tickets.opscode.com/browse/OHAI-541
