### PR TITLE
Fixes OHAI-541 trouble reporting ec2 instance info because of failed vhostmd

### DIFF
--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -100,8 +100,12 @@ module Ohai
 
       def metadata_get(id, api_version)
         response = http_client.get("/#{api_version}/meta-data/#{id}")
-        unless response.code == '200'
-          raise "Encountered error retrieving EC2 metadata (returned #{response.code} response)"
+        begin
+          unless response.code == '200'
+            raise "Encountered error retrieving EC2 metadata (returned #{response.code} response)"
+          end
+        rescue
+          response.body = nil
         end
         response
       end


### PR DESCRIPTION
- Handles 404's on amazon and rackspace for hi1.4xlarge instances that have no vhostmd information
