### PR TITLE
OHAI-550 java -version wastes memory

### DIFF
--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:Java) do
 
   def get_java_info
     java = Mash.new
-    so = shell_out("java -mx16m -version")
+    so = shell_out("java -mx64m -version")
     if so.exitstatus == 0
       so.stderr.split(/\r?\n/).each do |line|
         case line

--- a/spec/unit/plugins/java_spec.rb
+++ b/spec/unit/plugins/java_spec.rb
@@ -28,11 +28,11 @@ describe Ohai::System, "plugin java (Java5 Client VM)" do
   shared_examples_for "when the JRE is installed" do
     before do
       @stderr = "java version \"1.5.0_16\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_16-b06-284)\nJava HotSpot(TM) Client VM (build 1.5.0_16-133, mixed mode, sharing)"
-      @plugin.stub(:shell_out).with("java -mx16m -version").and_return(mock_shell_out(0, "", @stderr))
+      @plugin.stub(:shell_out).with("java -mx64m -version").and_return(mock_shell_out(0, "", @stderr))
     end
 
-    it "should run java -mx16m -version" do
-      @plugin.should_receive(:shell_out).with("java -mx16m -version").and_return(mock_shell_out(0, "", @stderr))
+    it "should run java -mx64m -version" do
+      @plugin.should_receive(:shell_out).with("java -mx64m -version").and_return(mock_shell_out(0, "", @stderr))
       @plugin.run
     end
 
@@ -63,7 +63,7 @@ describe Ohai::System, "plugin java (Java5 Client VM)" do
 
     it "should not set the languages[:java] tree up if java command fails" do
       @stderr = "Some error output here"
-      @plugin.stub(:shell_out).with("java -mx16m -version").and_return(mock_shell_out(1, "", @stderr))
+      @plugin.stub(:shell_out).with("java -mx64m -version").and_return(mock_shell_out(1, "", @stderr))
       @plugin.run
       @plugin[:languages].should_not have_key(:java)
     end
@@ -73,11 +73,11 @@ describe Ohai::System, "plugin java (Java5 Client VM)" do
 
     before(:each) do
       @stderr = "java version \"1.6.0_22\"\nJava(TM) 2 Runtime Environment (build 1.6.0_22-b04)\nJava HotSpot(TM) Server VM (build 17.1-b03, mixed mode)"
-      @plugin.stub(:shell_out).with("java -mx16m -version").and_return(mock_shell_out(0, "", @stderr))
+      @plugin.stub(:shell_out).with("java -mx64m -version").and_return(mock_shell_out(0, "", @stderr))
     end
 
-    it "should run java -mx16m -version" do
-      @plugin.should_receive(:shell_out).with("java -mx16m -version").and_return(mock_shell_out(0, "", @stderr))
+    it "should run java -mx64m -version" do
+      @plugin.should_receive(:shell_out).with("java -mx64m -version").and_return(mock_shell_out(0, "", @stderr))
       @plugin.run
     end
 
@@ -108,7 +108,7 @@ describe Ohai::System, "plugin java (Java5 Client VM)" do
 
     it "should not set the languages[:java] tree up if java command fails" do
       @stderr = "Some error output here"
-      @plugin.stub(:shell_out).with("java -mx16m -version").and_return(mock_shell_out(0, "", @stderr))
+      @plugin.stub(:shell_out).with("java -mx64m -version").and_return(mock_shell_out(0, "", @stderr))
       @plugin.run
       @plugin[:languages].should_not have_key(:java)
     end
@@ -159,7 +159,7 @@ describe Ohai::System, "plugin java (Java5 Client VM)" do
       end
 
       it "does not attempt to get java info" do
-        @plugin.should_not_receive(:shell_out).with("java -mx16m -version")
+        @plugin.should_not_receive(:shell_out).with("java -mx64m -version")
         @plugin.run
         @plugin[:languages].should_not have_key(:java)
       end


### PR DESCRIPTION
On newer versions of java the java heap can start as the smaller of 1/4 of memory or 1gb rather than 64mb like in the past. Even when just running -version. Protect against mmaping 1gb of memory for no reason by specifying a 16mb max heap. This avoids causing pain for boxes where memory is mostly used.

This is for ticket: https://tickets.opscode.com/browse/OHAI-550
