### PR TITLE
OHAI-542 defined cloud_v2 plugin interface object

### DIFF
--- a/lib/ohai/plugins/cloud_v2.rb
+++ b/lib/ohai/plugins/cloud_v2.rb
@@ -1,0 +1,289 @@
+#
+# Author:: Cary Penniman (<cary@rightscale.com>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Ohai.plugin(:CloudV2) do
+  provides "cloud_v2"
+
+  depends "ec2"
+  depends "gce"
+  depends "rackspace"
+  depends "eucalyptus"
+  depends "linode"
+  depends "openstack"
+  depends "azure"
+
+  # Class to help enforce the interface exposed to node[:cloud] (OHAI-542)
+  #
+  # cloud[:provider] - (String) the cloud provider the VM is running on.
+  #
+  # cloud[:public_hostname] - (String) a fully qualified hostname
+  # cloud[:local_hostname] - (String) a hostname resolvable on the internal (private) network
+  #
+  # cloud[:public_ipv4_addrs] - (Array) a list of all publicly accessible IPv4 addresses
+  # cloud[:local_ipv4_addrs] - (Array) a list of all private IPv4 addresses
+  # cloud[:public_ipv4] - (String) the first public IPv4 address detected
+  # cloud[:local_ipv4] - (String) the first private IPv4 address detected
+  #
+  # cloud[:public_ipv6_addrs] - (Array) a list of all publicly accessible IPv6 addresses
+  # cloud[:local_ipv6_addrs] - (Array) a list of all private IPv6 addresses
+  # cloud[:public_ipv6] - (String) the first public IPv6 address detected
+  # cloud[:local_ipv6] - (String) the first private IPv6 address detected
+  #
+  class CloudAttrs
+    attr_writer :provider, :public_hostname, :local_hostname
+
+    def initialize
+      @cloud = Mash.new
+    end
+
+    def add_ipv4_addr(ip, accessibility)
+      return if ip.nil? # just skip if ip is nil
+      ipaddr = validate_ip_addr(ip, :ipv4)
+
+      case accessibility
+      when :public
+        @cloud[:public_ipv4_addrs] ||= Array.new
+        @cloud[:public_ipv4_addrs] << ipaddr.to_s
+      when :private
+        @cloud[:local_ipv4_addrs] ||= Array.new
+        @cloud[:local_ipv4_addrs] << ipaddr.to_s
+      else
+        raise "ERROR: in valid accessibility param of '#{accessibility}'. must be :public or :private."
+      end
+    end
+
+    def add_ipv6_addr(ip, accessibility)
+      return if ip.nil? # just skip if ip is nil
+      ipaddr = validate_ip_addr(ip, :ipv6)
+
+      raise "ERROR: invalid ipv6 address of '#{ip}' detected. " unless ipaddr.ipv6?
+      case accessibility
+      when :public
+        @cloud[:public_ipv6_addrs] ||= Array.new
+        @cloud[:public_ipv6_addrs] << ipaddr.to_s
+      when :private
+        @cloud[:local_ipv6_addrs] ||= Array.new
+        @cloud[:local_ipv6_addrs] << ipaddr.to_s
+      else
+        raise "ERROR: in valid accessibility param of '#{accessibility}'. must be :public or :private."
+      end
+    end
+
+    def cloud_mash
+      @cloud[:provider] = @provider if @provider
+
+      @cloud[:public_hostname] = @public_hostname if @public_hostname
+      @cloud[:local_hostname] = @local_hostname if @local_hostname
+
+      @cloud[:public_ipv4] = @cloud[:public_ipv4_addrs][0] if @cloud[:public_ipv4_addrs]
+      @cloud[:local_ipv4] = @cloud[:local_ipv4_addrs][0] if @cloud[:local_ipv4_addrs]
+
+      @cloud[:public_ipv6] = @cloud[:public_ipv6_addrs][0] if @cloud[:public_ipv6_addrs]
+      @cloud[:local_ipv6] = @cloud[:local_ipv6_addrs][0] if @cloud[:local_ipv6_addrs]
+
+      # if empty, return nil
+      (@cloud.empty?) ? nil : @cloud
+    end
+
+    private
+
+    def validate_ip_addr(ip, address_family = :ipv4)
+      ipaddr = ""
+      begin
+        ipaddr = IPAddr.new(ip)
+        raise ArgumentError, "not valid #{address_family} address" unless (address_family == :ipv4) ? ipaddr.ipv4? : ipaddr.ipv6?
+      rescue ArgumentError => e
+        raise "ERROR: the ohai 'cloud' plugin failed with an IP address of '#{ip}' : #{e.message}"
+      end
+      ipaddr
+    end
+  end
+
+
+  #---------------------------------------
+  # Google Compute Engine (gce)
+  #--------------------------------------
+
+  def on_gce?
+    gce != nil
+  end
+
+  def get_gce_values
+    public_ips = gce['instance']['networkInterfaces'].collect do |interface|
+      if interface.has_key?('accessConfigs')
+        interface['accessConfigs'].collect{|ac| ac['externalIp']}
+      end
+    end.flatten.compact
+
+    private_ips = gce['instance']['networkInterfaces'].collect do |interface|
+      interface['ip']
+    end.compact
+
+    public_ips.each { |ipaddr|  @cloud_attr_obj.add_ipv4_addr(ipaddr, :public) }
+    private_ips.each { |ipaddr|  @cloud_attr_obj.add_ipv4_addr(ipaddr, :private) }
+    @cloud_attr_obj.local_hostname = gce['instance']['hostname']
+    @cloud_attr_obj.provider = "gce"
+  end
+
+  # ----------------------------------------
+  # ec2
+  # ----------------------------------------
+
+  # Is current cloud ec2?
+  #
+  # === Return
+  # true:: If ec2 Hash is defined
+  # false:: Otherwise
+  def on_ec2?
+    ec2 != nil
+  end
+
+  # Fill cloud hash with ec2 values
+  def get_ec2_values
+    @cloud_attr_obj.add_ipv4_addr(ec2['public_ipv4'], :public)
+    @cloud_attr_obj.add_ipv4_addr(ec2['local_ipv4'], :private)
+    @cloud_attr_obj.public_hostname = ec2['public_hostname']
+    @cloud_attr_obj.local_hostname = ec2['local_hostname']
+    @cloud_attr_obj.provider = "ec2"
+  end
+
+  # ----------------------------------------
+  # rackspace
+  # ----------------------------------------
+
+  # Is current cloud rackspace?
+  #
+  # === Return
+  # true:: If rackspace Hash is defined
+  # false:: Otherwise
+  def on_rackspace?
+    rackspace != nil
+  end
+
+  # Fill cloud hash with rackspace values
+  def get_rackspace_values
+    @cloud_attr_obj.add_ipv4_addr(rackspace['public_ipv4'], :public)
+    @cloud_attr_obj.add_ipv4_addr(rackspace['local_ipv4'], :private)
+    @cloud_attr_obj.add_ipv6_addr(rackspace['public_ipv6'], :public)
+    @cloud_attr_obj.add_ipv6_addr(rackspace['local_ipv6'], :private)
+    @cloud_attr_obj.public_hostname = rackspace['public_hostname']
+    @cloud_attr_obj.local_hostname = rackspace['local_hostname']
+    @cloud_attr_obj.provider = "rackspace"
+  end
+
+  # ----------------------------------------
+  # linode
+  # ----------------------------------------
+
+  # Is current cloud linode?
+  #
+  # === Return
+  # true:: If linode Hash is defined
+  # false:: Otherwise
+  def on_linode?
+    linode != nil
+  end
+
+  # Fill cloud hash with linode values
+  def get_linode_values
+    @cloud_attr_obj.add_ipv4_addr(linode['public_ip'], :public)
+    @cloud_attr_obj.add_ipv4_addr(linode['private_ip'], :private)
+    @cloud_attr_obj.public_hostname = linode['public_hostname']
+    @cloud_attr_obj.local_hostname = linode['local_hostname']
+    @cloud_attr_obj.provider = "linode"
+  end
+
+  # ----------------------------------------
+  # eucalyptus
+  # ----------------------------------------
+
+  # Is current cloud eucalyptus?
+  #
+  # === Return
+  # true:: If eucalyptus Hash is defined
+  # false:: Otherwise
+  def on_eucalyptus?
+    eucalyptus != nil
+  end
+
+  def get_eucalyptus_values
+    @cloud_attr_obj.add_ipv4_addr(eucalyptus['public_ipv4'], :public)
+    @cloud_attr_obj.add_ipv4_addr(eucalyptus['local_ipv4'], :private)
+    @cloud_attr_obj.public_hostname = eucalyptus['public_hostname']
+    @cloud_attr_obj.local_hostname = eucalyptus['local_hostname']
+    @cloud_attr_obj.provider = "eucalyptus"
+  end
+
+  # ----------------------------------------
+  # openstack
+  # ----------------------------------------
+
+  # Is current cloud openstack-based?
+  #
+  # === Return
+  # true:: If openstack Hash is defined
+  # false:: Otherwise
+  def on_openstack?
+    openstack != nil
+  end
+
+  # Fill cloud hash with openstack values
+  def get_openstack_values
+    @cloud_attr_obj.add_ipv4_addr(openstack['public_ipv4'], :public)
+    @cloud_attr_obj.add_ipv4_addr(openstack['local_ipv4'], :private)
+    @cloud_attr_obj.public_hostname = openstack['public_hostname']
+    @cloud_attr_obj.local_hostname = openstack['local_hostname']
+    @cloud_attr_obj.provider = "openstack"
+  end
+
+  # ----------------------------------------
+  # azure
+  # ----------------------------------------
+
+  # Is current cloud azure?
+  #
+  # === Return
+  # true:: If azure Hash is defined
+  # false:: Otherwise
+  def on_azure?
+    azure != nil
+  end
+
+  # Fill cloud hash with azure values
+  def get_azure_values
+    @cloud_attr_obj.add_ipv4_addr(azure['public_ip'], :public)
+    @cloud_attr_obj.add_ipv4_addr(azure['private_ip'], :private)
+    @cloud_attr_obj.public_hostname = azure['public_fqdn']
+    @cloud_attr_obj.provider = "azure"
+  end
+
+  collect_data do
+    require "ipaddr"
+
+    @cloud_attr_obj = CloudAttrs.new()
+
+    get_gce_values if on_gce?
+    get_ec2_values if on_ec2?
+    get_rackspace_values if on_rackspace?
+    get_linode_values if on_linode?
+    get_eucalyptus_values if on_eucalyptus?
+    get_openstack_values if on_openstack?
+    get_azure_values if on_azure?
+
+    # set node[:cloud] hash here
+    cloud_v2 @cloud_attr_obj.cloud_mash
+  end
+end

--- a/spec/unit/plugins/cloud_v2_spec.rb
+++ b/spec/unit/plugins/cloud_v2_spec.rb
@@ -1,0 +1,292 @@
+#
+# Author:: Cary Penniman (<cary@rightscale.com>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper.rb')
+require 'ipaddr'
+
+describe "CloudAttrs object" do
+  before(:each) do
+    @plugin = get_plugin("cloud_v2")
+  end
+
+  let(:cloud_node) do
+    {"public_ipv4_addrs"=>["1.2.3.1"],
+     "local_ipv4_addrs"=>["1.2.4.1"],
+     "public_ipv6_addrs"=>["3ffe:505:2::1"],
+     "local_ipv6_addrs"=>["3ffe:506:2::1"],
+     "public_ipv4"=>"1.2.3.1",
+     "local_ipv4"=>"1.2.4.1",
+     "public_ipv6"=>"3ffe:505:2::1",
+     "local_ipv6"=>"3ffe:506:2::1",
+     "public_hostname"=>"myhost.somewhere.com",
+     "local_hostname"=>"my-localhost",
+     "provider"=>"my_awesome_cloud"
+     }
+  end
+
+  it "populates cloud mash" do
+    @cloud_attr_obj = ::CloudAttrs.new()
+    @cloud_attr_obj.add_ipv4_addr("1.2.3.1", :public)
+    @cloud_attr_obj.add_ipv4_addr("1.2.4.1", :private)
+    @cloud_attr_obj.add_ipv6_addr("3ffe:505:2::1", :public)
+    @cloud_attr_obj.add_ipv6_addr("3ffe:506:2::1", :private)
+    @cloud_attr_obj.public_hostname = "myhost.somewhere.com"
+    @cloud_attr_obj.local_hostname = "my-localhost"
+    @cloud_attr_obj.provider = "my_awesome_cloud"
+    @cloud_attr_obj.cloud_mash.should == cloud_node
+  end
+
+  it "throws exception with a bad ipv4 address" do
+    @cloud_attr_obj = ::CloudAttrs.new()
+    lambda {  @cloud_attr_obj.add_ipv6_addr("somebogusstring", :public) }.should raise_error
+  end
+
+  it "throws exception with a bad ipv6 address" do
+    @cloud_attr_obj = ::CloudAttrs.new()
+    lambda {  @cloud_attr_obj.add_ipv6_addr("FEED:B0B:DEAD:BEEF", :public)  }.should raise_error
+  end
+
+  it "throws exception with ipv6 address passed to ipv4" do
+    @cloud_attr_obj = ::CloudAttrs.new()
+    lambda {  @cloud_attr_obj.add_ipv4_addr("3ffe:506:2::1", :public) }.should raise_error
+  end
+
+  it "throws exception with ipv4 address passed to ipv6" do
+    @cloud_attr_obj = ::CloudAttrs.new()
+    lambda {  @cloud_attr_obj.add_ipv6_addr("1.2.3.4", :public) }.should raise_error
+  end
+
+
+end
+
+describe Ohai::System, "plugin cloud" do
+  before(:each) do
+    @plugin = get_plugin("cloud_v2")
+  end
+
+  describe "with no cloud mashes" do
+    it "doesn't populate the cloud data" do
+      @plugin[:ec2] = nil
+      @plugin[:rackspace] = nil
+      @plugin[:eucalyptus] = nil
+      @plugin[:linode] = nil
+      @plugin[:azure] = nil
+      @plugin[:gce] = nil
+      @plugin.run
+      @plugin[:cloud_v2].should be_nil
+    end
+  end
+
+  describe "with EC2 mash" do
+    before do
+      @plugin[:ec2] = Mash.new()
+    end
+
+    it "populates cloud public ip" do
+      @plugin[:ec2]['public_ipv4'] = "174.129.150.8"
+      @plugin.run
+      @plugin[:cloud_v2][:public_ipv4_addrs][0].should == @plugin[:ec2]['public_ipv4']
+    end
+
+    it "populates cloud private ip" do
+      @plugin[:ec2]['local_ipv4'] = "10.252.42.149"
+      @plugin.run
+      @plugin[:cloud_v2][:local_ipv4_addrs][0].should == @plugin[:ec2]['local_ipv4']
+    end
+
+    it "populates cloud provider" do
+      @plugin.run
+      @plugin[:cloud_v2][:provider].should == "ec2"
+    end
+  end
+
+  describe "with GCE mash" do
+    before do
+      @plugin[:gce] = Mash.new()
+      @plugin[:gce]['instance'] = Mash.new()
+      @plugin[:gce]['instance']['networkInterfaces'] = [
+        {
+          "accessConfigs" => [ {"externalIp" => "8.35.198.173", "type"=>"ONE_TO_ONE_NAT"} ],
+          "ip" => "10.240.0.102",
+          "network"=> "projects/foo/networks/default"
+        }
+      ]
+    end
+
+    it "populates cloud public ip" do
+      @plugin.run
+      @plugin[:cloud_v2][:public_ipv4_addrs][0].should == "8.35.198.173"
+    end
+
+    it "populates cloud private ip" do
+      @plugin.run
+      @plugin[:cloud_v2][:local_ipv4_addrs][0].should == "10.240.0.102"
+    end
+
+    it "populates cloud provider" do
+      @plugin.run
+      @plugin[:cloud_v2][:provider].should == "gce"
+    end
+  end
+
+  describe "with rackspace" do
+    before do
+      @plugin[:rackspace] = Mash.new()
+    end
+
+    it "populates cloud public ip" do
+      @plugin[:rackspace][:public_ipv4] = "174.129.150.8"
+      @plugin.run
+      @plugin[:cloud_v2][:public_ipv4].should == @plugin[:rackspace][:public_ipv4]
+    end
+
+    it "populates cloud public ipv6" do
+      @plugin[:rackspace][:public_ipv6] = "2a00:1a48:7805:111:e875:efaf:ff08:75"
+      @plugin.run
+      @plugin[:cloud_v2][:public_ipv6].should == @plugin[:rackspace][:public_ipv6]
+    end
+
+    it "populates cloud private ip" do
+      @plugin[:rackspace][:local_ipv4] = "10.252.42.149"
+      @plugin.run
+      @plugin[:cloud_v2][:local_ipv4].should == @plugin[:rackspace][:local_ipv4]
+    end
+
+    it "populates cloud private ipv6" do
+      @plugin[:rackspace][:local_ipv6] = "2a00:1a48:7805:111:e875:efaf:ff08:75"
+      @plugin.run
+      @plugin[:cloud_v2][:local_ipv6].should == @plugin[:rackspace][:local_ipv6]
+    end
+
+    it "populates first cloud public ip" do
+      @plugin[:rackspace][:public_ipv4] = "174.129.150.8"
+      @plugin.run
+      @plugin[:cloud_v2][:public_ipv4_addrs].first.should == @plugin[:rackspace][:public_ipv4]
+    end
+
+    it "populates first cloud public ip" do
+      @plugin[:rackspace][:local_ipv4] = "174.129.150.8"
+      @plugin.run
+      @plugin[:cloud_v2][:local_ipv4_addrs].first.should == @plugin[:rackspace][:local_ipv4]
+    end
+
+    it "populates cloud provider" do
+      @plugin.run
+      @plugin[:cloud_v2][:provider].should == "rackspace"
+    end
+  end
+
+  describe "with linode mash" do
+    before do
+      @plugin[:linode] = Mash.new()
+    end
+
+    it "populates cloud public ip" do
+      @plugin[:linode]['public_ip'] = "174.129.150.8"
+      @plugin.run
+      @plugin[:cloud_v2][:public_ipv4_addrs][0].should == @plugin[:linode][:public_ip]
+    end
+
+    it "populates cloud private ip" do
+      @plugin[:linode]['private_ip'] = "10.252.42.149"
+      @plugin.run
+      @plugin[:cloud_v2][:local_ipv4_addrs][0].should == @plugin[:linode][:private_ip]
+    end
+
+    it "populates first cloud public ip" do
+      @plugin[:linode]['public_ip'] = "174.129.150.8"
+      @plugin.run
+      @plugin[:cloud_v2][:public_ipv4_addrs].first.should == @plugin[:linode][:public_ip]
+    end
+
+    it "populates cloud provider" do
+      @plugin.run
+      @plugin[:cloud_v2][:provider].should == "linode"
+    end
+  end
+
+  describe "with eucalyptus mash" do
+    before do
+      @plugin[:eucalyptus] = Mash.new()
+    end
+
+    it "populates cloud public ip" do
+      @plugin[:eucalyptus]['public_ipv4'] = "174.129.150.8"
+      @plugin.run
+      @plugin[:cloud_v2][:public_ipv4_addrs][0].should == @plugin[:eucalyptus]['public_ipv4']
+    end
+
+    it "populates cloud private ip" do
+      @plugin[:eucalyptus]['local_ipv4'] = "10.252.42.149"
+      @plugin.run
+      @plugin[:cloud_v2][:local_ipv4_addrs][0].should == @plugin[:eucalyptus]['local_ipv4']
+    end
+
+    it "populates cloud provider" do
+      @plugin.run
+      @plugin[:cloud_v2][:provider].should == "eucalyptus"
+    end
+  end
+
+  describe "with Azure mash" do
+    before do
+      @plugin[:azure] = Mash.new()
+    end
+
+    it "populates cloud public ip" do
+      @plugin[:azure]['public_ip'] = "174.129.150.8"
+      @plugin.run
+      @plugin[:cloud_v2][:public_ipv4_addrs][0].should == @plugin[:azure]['public_ip']
+    end
+
+    it "doesn't populates cloud vm_name" do
+      @plugin[:azure]['vm_name'] = "linux-vm"
+      @plugin.run
+      @plugin[:cloud_v2][:vm_name].should_not == @plugin[:azure]['vm_name']
+    end
+
+    it "populates cloud public_hostname" do
+      @plugin[:azure]['public_fqdn'] = "linux-vm-svc.cloudapp.net"
+      @plugin.run
+      @plugin[:cloud_v2][:public_hostname].should == @plugin[:azure]['public_fqdn']
+    end
+
+    it "doesn't populate cloud public_ssh_port" do
+      @plugin[:azure]['public_ssh_port'] = "22"
+      @plugin.run
+      @plugin[:cloud_v2][:public_ssh_port].should be_nil
+    end
+
+    it "should not populate cloud public_ssh_port when winrm is used" do
+      @plugin[:azure]['public_winrm_port'] = "5985"
+      @plugin.run
+      @plugin[:cloud_v2][:public_ssh_port].should be_nil
+    end
+
+    it "populates cloud public_winrm_port" do
+      @plugin[:azure]['public_winrm_port'] = "5985"
+      @plugin.run
+      @plugin[:cloud_v2][:public_winrm_port].should be_nil
+    end
+
+    it "populates cloud provider" do
+      @plugin.run
+      @plugin[:cloud_v2][:provider].should == "azure"
+    end
+  end
+
+end


### PR DESCRIPTION
replaced PR #251
# Cloud_v2 Plugin

The `node['cloud_v2']` plugin is available to provide consistent access to server configurations typically managed by IaaS (aka "cloud"") environments. Since the `node['cloud']` structure can vary from cloud-to-cloud it has been deprecated. Use the `node['cloud_v2']` in your recipes when you intend for it to work in multiple IaaS environments.
## Migrating to the cloud_v2 plugin:
- **GCE Specific Recipes**: the `node['cloud']['public_ipv4']` and `node['cloud']['local_ipv4']` attributes are no longer arrays in the cloud_v2 plugin, but are strings representing the first NICs reported. Use `node['cloud_v2']['public_ipv4_addrs']` and `node['cloud_v2']['local_ipv4_addrs']`, respectively, if you still need an Array of all NICs available to VM.
- **Azure Specific Recipes**: the `node['cloud']` attributes are all Azure specific, use `node['azure']` instead.
- **All Clouds**: `node['cloud']['public_ips']` and `node['cloud']['private_ips']` are now deprecated to allow consistent naming for both IPv4 and IPv6 NICs. Use `node[:cloud_v2][:public_ipv4_addrs]` and `node[:cloud_v2][:local_ipv4_addrs]` instead.
