### PR TITLE
Add 'ibm_powerkvm' platform

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -100,7 +100,7 @@ Ohai.plugin(:Platform) do
       platform_family "debian"
     when /fedora/
       platform_family "fedora"
-    when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /amazon/, /xenserver/, /cloudlinux/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
+    when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /amazon/, /xenserver/, /cloudlinux/, /ibm_powerkvm/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
       platform_family "rhel"
     when /suse/
       platform_family "suse"


### PR DESCRIPTION
This change will allow Ohai to detect IBM PowerKVM specific operating
systems and map them to RHEL platform families.

Fixes: OHAI-558
Obvious Fix

https://tickets.opscode.com/browse/OHAI-558
