### PR TITLE
Add 'ibm_powerkvm' platform

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -100,7 +100,7 @@ Ohai.plugin(:Platform) do
       platform_family "debian"
     when /fedora/
       platform_family "fedora"
-    when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /amazon/, /xenserver/, /cloudlinux/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
+    when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /amazon/, /xenserver/, /cloudlinux/, /ibm_powerkvm/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
       platform_family "rhel"
     when /suse/
       platform_family "suse"

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -93,6 +93,14 @@ describe Ohai::System, "Linux plugin platform" do
       @plugin.run
       @plugin[:platform].should == "scientific"
     end
+
+    it "should set platform to ibm_powerkvm and platform_family to rhel when [:lsb][:id] contains IBM_PowerKVM" do
+      @plugin[:lsb][:id] = "IBM_PowerKVM"
+      @plugin[:lsb][:release] = "2.1"
+      @plugin.run
+      @plugin[:platform].should == "ibm_powerkvm"
+      @plugin[:platform_family].should == "rhel"
+    end
   end
 
   describe "on debian" do
@@ -215,6 +223,12 @@ describe Ohai::System, "Linux plugin platform" do
 
       it "should set the platform_family to redhat if the LSB name is scientific-ish" do
         @plugin[:lsb][:id] = "Scientific"
+        @plugin.run
+	@plugin[:platform_family].should == "rhel"
+      end
+
+      it "should set the platform_family to redhat if the LSB name is ibm-ish" do
+        @plugin[:lsb][:id] = "IBM_PowerKVM"
         @plugin.run
 	@plugin[:platform_family].should == "rhel"
       end


### PR DESCRIPTION
This change will allow Ohai to detect IBM PowerKVM specific operating
systems and map them to RHEL platform families.

Fixes: OHAI-558
Obvious Fix
