### PR TITLE
[#OHAI-561] Ignore users if we've already seen them

### DIFF
--- a/lib/ohai/plugins/passwd.rb
+++ b/lib/ohai/plugins/passwd.rb
@@ -19,7 +19,8 @@ Ohai.plugin(:Passwd) do
       Etc.passwd do |entry|
         user_passwd_entry = Mash.new(:dir => entry.dir, :gid => entry.gid, :uid => entry.uid, :shell => entry.shell, :gecos => entry.gecos)
         user_passwd_entry.each_value {|v| fix_encoding(v)}
-        etc[:passwd][fix_encoding(entry.name)] = user_passwd_entry
+        entry_name = fix_encoding(entry.name)
+        etc[:passwd][entry_name] = user_passwd_entry unless etc[:passwd].has_key?(entry_name)
       end
 
       Etc.group do |entry|

--- a/spec/unit/plugins/passwd_spec.rb
+++ b/spec/unit/plugins/passwd_spec.rb
@@ -16,6 +16,13 @@ describe Ohai::System, "plugin etc" do
     @plugin[:etc][:passwd]['www'].should == Mash.new(:shell => '/bin/false', :gecos => 'Serving the web since 1970', :gid => 800, :uid => 800, :dir => '/var/www')
   end
 
+  it "should ignore duplicate users" do
+    Etc.should_receive(:passwd).and_yield(PasswdEntry.new("root", 1, 1, '/root', '/bin/zsh', 'BOFH')).
+      and_yield(PasswdEntry.new('root', 1, 1, '/', '/bin/false', 'I do not belong'))
+    @plugin.run
+    @plugin[:etc][:passwd]['root'].should == Mash.new(:shell => '/bin/zsh', :gecos => 'BOFH', :gid => 1, :uid => 1, :dir => '/root')
+  end
+
   it "should set the current user" do
     Etc.should_receive(:getlogin).and_return('chef')
     @plugin.run


### PR DESCRIPTION
For environments with duplicate users in different password databases,
such as files and ldap, ohai was using the _last_ entry returned by
`getpwent` but the system uses the first.
