### PR TITLE
Use a timeout when running 'df' and 'mount'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Work around libc bug in `hostname --fqdn`
 * java -version wastes memory (OHAI-550)
+* Add timeouts to 'df' and 'mount' commands
 
 ## Last Release: 7.0.0.rc.0 (01/20/2014)
 

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -6,3 +6,4 @@ Example Contribution:
 -->
 # OHAI Contributions:
 * **jaymzh**: Work around libc bug in `hostname --fqdn`
+* **jaymzh**: Add timeouts to 'df' and 'mount' commands

--- a/spec/unit/plugins/linux/filesystem_spec.rb
+++ b/spec/unit/plugins/linux/filesystem_spec.rb
@@ -25,8 +25,23 @@ describe Ohai::System, "Linux filesystem plugin" do
     @ohai.stub!(:require_plugin).and_return(true)
     @ohai.extend(SimpleFromFile)
 
-    @ohai.stub!(:popen4).with("df -P").and_return(false)
-    @ohai.stub!(:popen4).with("mount").and_return(false)
+    stdout = mock("STDOUT_SKEL")
+    stderr = mock("STDERR_SKEL")
+    stdout.stub!(:each_line).and_yield('')
+    stderr.stub!(:each_line).and_yield('')
+
+    @df_cmd = {
+      :command => "df -P",
+      :timeout => 120,
+      :no_status_check => true
+    }
+    @mount_cmd = {
+      :command => "mount",
+      :timeout => 120,
+    }
+
+    @ohai.stub!(:run_command).with(@df_cmd).and_return([0,stdout,stderr])
+    @ohai.stub!(:run_command).with(@mount_cmd).and_return([0,stdout,stderr])
     @ohai.stub!(:popen4).with("blkid -s TYPE").and_return(false)
     @ohai.stub!(:popen4).with("blkid -s UUID").and_return(false)
     @ohai.stub!(:popen4).with("blkid -s LABEL").and_return(false)
@@ -42,7 +57,7 @@ describe Ohai::System, "Linux filesystem plugin" do
       @stdout = mock("STDOUT")
       @status = 0
 
-      @stdout.stub!(:each).
+      @stdout.stub!(:each_line).
         and_yield("Filesystem         1024-blocks      Used Available Capacity Mounted on").
         and_yield("/dev/mapper/sys.vg-root.lv   4805760    378716   4182924       9% /").
         and_yield("tmpfs                  2030944         0   2030944       0% /lib/init/rw").
@@ -57,36 +72,36 @@ describe Ohai::System, "Linux filesystem plugin" do
     end
 
     it "should run df -P" do
-      @ohai.should_receive(:popen4).with("df -P").and_return(true)
+      @ohai.should_receive(:run_command).with(@df_cmd).and_return(true)
       @ohai._require_plugin("linux::filesystem")
     end
 
     it "should set kb_size to value from df -P" do
-      @ohai.stub!(:popen4).with("df -P").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+      @ohai.stub!(:run_command).with(@df_cmd).and_return([@status, @stdout, @stderr])
       @ohai._require_plugin("linux::filesystem")
       @ohai[:filesystem]["/dev/mapper/sys.vg-special.lv"][:kb_size].should be == "97605057"
     end
 
     it "should set kb_used to value from df -P" do
-      @ohai.stub!(:popen4).with("df -P").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+      @ohai.stub!(:run_command).with(@df_cmd).and_return([@status, @stdout, @stderr])
       @ohai._require_plugin("linux::filesystem")
       @ohai[:filesystem]["/dev/mapper/sys.vg-special.lv"][:kb_used].should be == "53563253"
     end
 
     it "should set kb_available to value from df -P" do
-      @ohai.stub!(:popen4).with("df -P").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+      @ohai.stub!(:run_command).with(@df_cmd).and_return([@status, @stdout, @stderr])
       @ohai._require_plugin("linux::filesystem")
       @ohai[:filesystem]["/dev/mapper/sys.vg-special.lv"][:kb_available].should be == "44041805"
     end
 
     it "should set percent_used to value from df -P" do
-      @ohai.stub!(:popen4).with("df -P").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+      @ohai.stub!(:run_command).with(@df_cmd).and_return([@status, @stdout, @stderr])
       @ohai._require_plugin("linux::filesystem")
       @ohai[:filesystem]["/dev/mapper/sys.vg-special.lv"][:percent_used].should be == "56%"
     end
 
     it "should set mount to value from df -P" do
-      @ohai.stub!(:popen4).with("df -P").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+      @ohai.stub!(:run_command).with(@df_cmd).and_return([@status, @stdout, @stderr])
       @ohai._require_plugin("linux::filesystem")
       @ohai[:filesystem]["/dev/mapper/sys.vg-special.lv"][:mount].should be == "/special"
     end
@@ -100,7 +115,7 @@ describe Ohai::System, "Linux filesystem plugin" do
       @stdout = mock("STDOUT")
       @status = 0
 
-      @stdout.stub!(:each).
+      @stdout.stub!(:each_line).
         and_yield("/dev/mapper/sys.vg-root.lv on / type ext4 (rw,noatime,errors=remount-ro)").
         and_yield("tmpfs on /lib/init/rw type tmpfs (rw,nosuid,mode=0755)").
         and_yield("proc on /proc type proc (rw,noexec,nosuid,nodev)").
@@ -119,24 +134,24 @@ describe Ohai::System, "Linux filesystem plugin" do
     end
 
     it "should run mount" do
-      @ohai.should_receive(:popen4).with("mount").and_return(true)
+      @ohai.stub!(:run_command).with(@mount_cmd).and_return([@status, @stdout, @stderr])
       @ohai._require_plugin("linux::filesystem")
     end
 
     it "should set mount to value from mount" do
-      @ohai.stub!(:popen4).with("mount").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+      @ohai.stub!(:run_command).with(@mount_cmd).and_return([@status, @stdout, @stderr])
       @ohai._require_plugin("linux::filesystem")
       @ohai[:filesystem]["/dev/mapper/sys.vg-special.lv"][:mount].should be == "/special"
     end
 
     it "should set fs_type to value from mount" do
-      @ohai.stub!(:popen4).with("mount").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+      @ohai.stub!(:run_command).with(@mount_cmd).and_return([@status, @stdout, @stderr])
       @ohai._require_plugin("linux::filesystem")
       @ohai[:filesystem]["/dev/mapper/sys.vg-special.lv"][:fs_type].should be == "xfs"
     end
 
     it "should set mount_options to an array of values from mount" do
-      @ohai.stub!(:popen4).with("mount").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+      @ohai.stub!(:run_command).with(@mount_cmd).and_return([@status, @stdout, @stderr])
       @ohai._require_plugin("linux::filesystem")
       @ohai[:filesystem]["/dev/mapper/sys.vg-special.lv"][:mount_options].should be == [ "ro", "noatime" ]
     end


### PR DESCRIPTION
They can otherwise hang chef forever run when running on
machines with hung NFS mounts.
