### PR TITLE
ec2_metadata: specify path in exception

### DIFF
--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -99,9 +99,10 @@ module Ohai
       end
 
       def metadata_get(id, api_version)
-        response = http_client.get("/#{api_version}/meta-data/#{id}")
+        path = "/#{api_version}/meta-data/#{id}"
+        response = http_client.get(path)
         unless response.code == '200'
-          raise "Encountered error retrieving EC2 metadata (returned #{response.code} response)"
+          raise "Encountered error retrieving EC2 metadata (#{path} returned #{response.code} response)"
         end
         response
       end


### PR DESCRIPTION
The current message is rather unhelpful to establish what exactly fails,
eg:

```
DEBUG: Plugin Ec2 threw #<RuntimeError: Encountered error retrieving EC2 metadata (returned 404 response)>
DEBUG: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-7.0.2/lib/ohai/mixin/ec2_metadata.rb:104:in `metadata_get'
DEBUG: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-7.0.2/lib/ohai/mixin/ec2_metadata.rb:120:in `block in fetch_metadata'
DEBUG: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-7.0.2/lib/ohai/mixin/ec2_metadata.rb:113:in `each'
DEBUG: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-7.0.2/lib/ohai/mixin/ec2_metadata.rb:113:in `fetch_metadata'
DEBUG: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-7.0.2/lib/ohai/mixin/ec2_metadata.rb:130:in `block in fetch_metadata'
DEBUG: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-7.0.2/lib/ohai/mixin/ec2_metadata.rb:113:in `each'
DEBUG: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-7.0.2/lib/ohai/mixin/ec2_metadata.rb:113:in `fetch_metadata'
DEBUG: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-7.0.2/lib/ohai/plugins/ec2.rb:52:in `block (2 levels) in <main>'
```
