### PR TITLE
[OHAI-572] Fix warning message about constants already defined

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -46,7 +46,7 @@ Ohai.plugin(:Network) do
     # Match the lead line for an interface from iproute2
     # 3: eth0.11@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP
     # The '@eth0:' portion doesn't exist on primary interfaces and thus is optional in the regex
-    IPROUTE_INT_REGEX = /^(\d+): ([0-9a-zA-Z@:\.\-_]*?)(@[0-9a-zA-Z]+|):\s/
+    IPROUTE_INT_REGEX = /^(\d+): ([0-9a-zA-Z@:\.\-_]*?)(@[0-9a-zA-Z]+|):\s/ unless defined? IPROUTE_INT_REGEX
 
     if File.exist?("/sbin/ip")
 


### PR DESCRIPTION
As decribed in my ticket, I started getting a couple of warnings after upgrading to the latest version of chef/ohai:

-snip-

Recipe: ohai::default
ohai[custom_plugins] action reload
/usr/local/share/ruby/gems/2.0/gems/ohai-7.0.2/lib/ohai/plugins/linux/network.rb:49: warning: already initialized constant IPROUTE_INT_REGEX
/usr/local/share/ruby/gems/2.0/gems/ohai-7.0.2/lib/ohai/plugins/linux/network.rb:49: warning: previous definition of IPROUTE_INT_REGEX was here

-snip-

I've added a simple check to see if the constant was previously defined.
