### PR TITLE
Move :disabled_plugin check for plugins to running time of the plugins

### DIFF
--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -91,7 +91,12 @@ module Ohai
 
       def run
         @has_run = true
-        run_plugin
+
+        if Ohai::Config[:disabled_plugins].include?(name)
+          Ohai::Log.debug("Skipping disabled plugin #{name}")
+        else
+          run_plugin
+        end
       end
 
       def has_run?

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -37,11 +37,6 @@ module Ohai
         raise Ohai::Exceptions::InvalidPlugin, "Invalid plugin #{plugin} (must be an Ohai::DSL::Plugin or subclass)"
       end
 
-      if Ohai::Config[:disabled_plugins].include?(plugin.name)
-        Ohai::Log.debug("Skipping disabled plugin #{plugin.name}")
-        return false
-      end
-
       begin
         case plugin.version
         when :version7

--- a/spec/unit/dsl/plugin_spec.rb
+++ b/spec/unit/dsl/plugin_spec.rb
@@ -31,10 +31,46 @@ shared_examples "Ohai::DSL::Plugin" do
   end
 
   context "#run" do
-    it "should set has_run? to true" do
+    before do
       plugin.stub(:run_plugin).and_return(true)
-      plugin.run
-      plugin.has_run?.should be_true
+      plugin.stub(:name).and_return(:TestPlugin)
+    end
+
+    describe "when plugin is enabled" do
+      before do
+        Ohai::Config.stub(:[]).with(:disabled_plugins).and_return([ ])
+      end
+
+      it "should run the plugin" do
+        plugin.should_receive(:run_plugin)
+        plugin.run
+      end
+
+      it "should set has_run? to true" do
+        plugin.run
+        plugin.has_run?.should be_true
+      end
+    end
+
+    describe "if the plugin is disabled" do
+      before do
+        Ohai::Config.stub(:[]).with(:disabled_plugins).and_return([ :TestPlugin ])
+      end
+
+      it "should not run the plugin" do
+        plugin.should_not_receive(:run_plugin)
+        plugin.run
+      end
+
+      it "should log a message to debug" do
+        Ohai::Log.should_receive(:debug).with(/Skipping disabled plugin TestPlugin/)
+        plugin.run
+      end
+
+      it "should set has_run? to true" do
+        plugin.run
+        plugin.has_run?.should be_true
+      end
     end
   end
 

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -51,27 +51,6 @@ describe Ohai::Runner, "run_plugin" do
           plugin.should_not_receive(:safe_run)
           @runner.run_plugin(plugin)
         end
-
-        describe "if the plugin is disabled" do
-          before(:each) do
-            @disabled = Ohai::Config[:disabled_plugins]
-            Ohai::Config[:disabled_plugins] = [:Test]
-          end
-
-          after(:each) do
-            Ohai::Config[:disabled_plugins] = @disabled
-          end
-
-          it "should not run the plugin" do
-            @runner.should_not_receive(:run_v7_plugin)
-            @runner.run_plugin(plugin)
-          end
-
-          it "should log a message to debug" do
-            Ohai::Log.should_receive(:debug).with(/Skipping disabled plugin Test/)
-            @runner.run_plugin(plugin)
-          end
-        end
       end
     end
 
@@ -110,14 +89,6 @@ describe Ohai::Runner, "run_plugin" do
         end
 
       end
-
-      describe "if the plugin is disabled" do
-        it "should not run the plugin" do
-          Ohai::Config.should_receive(:[]).with(:disabled_plugins).and_return(["Test"])
-          @runner.should_not_receive(:run_v7_plugin)
-            @runner.run_plugin(plugin)
-        end
-      end
     end
 
     describe "invalid version" do
@@ -125,17 +96,6 @@ describe Ohai::Runner, "run_plugin" do
 
       it "should raise error" do
         lambda { @runner.run_plugin(plugin) }.should raise_error(Ohai::Exceptions::InvalidPlugin)
-      end
-    end
-
-    describe "when plugin is disabled" do
-      before do
-        Ohai::Config.should_receive(:[]).with(:disabled_plugins).and_return(["Test"])
-      end
-
-      it "should not run the plugin" do
-        @runner.should_not_receive(:run_v7_plugin)
-        @runner.run_plugin(plugin)
       end
     end
   end


### PR DESCRIPTION
Currently we check the :disabled_plugins in Ohai::Runner#run_plugin. Dependency resolution for V7 plugins happen after this check. Because of this you can't disable a plugin using its name if that plugin is dependent on by other plugins.

Move the logic to check if a plugin is disabled to the time when we are actually running the plugin so that one can disable a plugin for sure.

/cc: @opscode/client-eng 
