### PR TITLE
[OHAI-584] Update systemu to 2.6.4 for Ruby 2.1.x optimization

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://wiki.opscode.com/display/chef/Ohai"
 
   s.add_dependency "mime-types", "~> 1.16"
-  s.add_dependency "systemu", "~> 2.5.2"
+  s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "yajl-ruby"
   s.add_dependency "mixlib-cli"
   s.add_dependency "mixlib-config", "~> 2.0"


### PR DESCRIPTION
Update systemu dependency to 2.6.4.

There are a couple of reasons for doing this:

```
Fixes for bizarre hostnames whilst running on Windows
Fixes for Ruby 2.1.x compatibility
```

Since ahoward doesn't provide actual tagged releases (ugh), you can read the patch here. It's not very big.

https://github.com/ahoward/systemu/compare/cb253a8bf213beea69f27418202e936a22d7308f...076ef54e839e7ea0a70126dfe1f6c0ef5ed30859

Specs all pass with this. https://travis-ci.org/juliandunn/ohai/builds/25521166
