### PR TITLE
Only execute tests with elevated privileges

### DIFF
--- a/ci/jenkins_run_tests.sh
+++ b/ci/jenkins_run_tests.sh
@@ -5,8 +5,12 @@ export PATH=$PATH:/usr/local/bin
 ruby -v;
 # remove the Gemfile.lock and try again if bundler fails.
 # This should take care of Gemfile changes that result in "bad" bundles without forcing us to rebundle every time
-bundle install --without docgen --path vendor/bundle || ( rm Gemfile.lock && bundle install --path vendor/bundle )
-bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation spec;
+bundle install --binstubs --without docgen --path vendor/bundle || ( rm Gemfile.lock && bundle install --path vendor/bundle )
+# preserve the environment and $PATH of the `jenkins` user
+sudo -E bash -c "export PATH=$PATH && bin/rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation spec"
+# Ensure Jenkins can clean this file up
+sudo chown $USER test.xml
+
 RSPEC_RETURNCODE=$?
 
 # exit with the result of running rspec


### PR DESCRIPTION
Some of the Ohai tests require elevated privileges. Previously this entire script was executed with elevated privileges but this created a situation where Jenkins could not clean up it's own workspace (namely files generated by Bundler were owned by root).

This change only executes the actual tests with elevated privileges and ensures the generated test.xml file is owned by the Jenkins user.

/cc @opscode/client-eng 
