### PR TITLE
OHAI-587: Rackspace plugin rescues Errno::ENOENT if xenstore-* utils are not found

### DIFF
--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -105,14 +105,15 @@ Ohai.plugin(:Rackspace) do
         if _so.exitstatus == 0
           networks.push(Yajl::Parser.new.parse(_so.stdout))
         else
-          raise Ohai::Exceptions::Exec
+          Ohai::Log.debug('Unable to capture custom private networking information for Rackspace cloud')
+          return false
         end
       end
       # these networks are already known to ohai, and are not 'private networks'
       networks.delete_if { |hash| hash['label'] == 'private' }
       networks.delete_if { |hash| hash['label'] == 'public' }
     end
-  rescue Ohai::Exceptions::Exec, Errno::ENOENT
+  rescue Errno::ENOENT
     Ohai::Log.debug('Unable to capture custom private networking information for Rackspace cloud')
     nil
   end


### PR DESCRIPTION
The Rackspace plugin attempts to use `xenstore-ls` and `xenstore-read` to extract cloud server information regarding the region and networking. This does not exist on FirstGen servers, so an `Errno::ENOENT` (file not found) exception is thrown. It seems the ideal exception might be `Ohai::Exceptions::Exec`, but usage of the `Mixlib::ShellOut` library returns the uncaught `Errno::ENOENT`.

https://tickets.opscode.com/browse/OHAI-587
