### PR TITLE
Retreive OpenStack specific metadata

### DIFF
--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -27,7 +27,7 @@ Ohai.plugin(:Openstack) do
     path = "/openstack/#{api_version}/meta_data.json"
     uri = "http://#{addr}#{path}"
     begin
-      response = Net::HTTP.get_response(URI.parse(uri),nil,nil)
+      response = http_client.get_response(URI.parse(uri),nil,nil)
       case response.code
       when '200'
         JSON.parse(response.body)

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -147,7 +147,7 @@ EOM
       end
 
       def expect_get_response(url, response_body)
-        Net::HTTP.should_receive(:get_response).
+        http_client.should_receive(:get_response).
           with(url,nil,nil).
           and_return(double("HTTP Response", :code => "200", :body => response_body))
       end


### PR DESCRIPTION
Hi,

I have added for retrieve OpenStack specific metadata from metadata API .

[OpenStack specific metadata API](http://docs.openstack.org/grizzly/openstack-compute/admin/content/metadata-service.html)

The result of unit test is below.

```
OpenStack Plugin
  when there is no relevant hint
    does not set any openstack data
  when there is an `openstack` hint
    and the metadata service is not available
      does not set any openstack data
    and the metadata service is available
      reads the reservation_id from the metadata service
      reads the public_keys_0_openssh_key from the metadata service
      reads the security_groups from the metadata service
      reads the public_ipv4 from the metadata service
      reads the ami_manifest_path from the metadata service
      reads the instance_type from the metadata service
      reads the instance_id from the metadata service
      reads the local_ipv4 from the metadata service
      reads the ari_id from the metadata service
      reads the local_hostname from the metadata service
      reads the placement_availability_zone from the metadata service
      reads the ami_launch_index from the metadata service
      reads the public_hostname from the metadata service
      reads the hostname from the metadata service
      reads the ami_id from the metadata service
      reads the instance_action from the metadata service
      reads the aki_id from the metadata service
      reads the block_device_mapping_ami from the metadata service
      reads the block_device_mapping_root from the metadata service
      reads the provider from the metadata service

## Add this context
      Retreive openStack specific metadata
        reads the availability_zone from the openstack metadata service
        reads the hostname from the openstack metadata service
        reads the launch_index from the openstack metadata service
        reads the meta from the openstack metadata service
        reads the name from the openstack metadata service
        reads the public_keys from the openstack metadata service
        reads the uuid from the openstack metadata service

Finished in 0.16776 seconds (files took 0.12595 seconds to load)
29 examples, 0 failures
```
