### PR TITLE
pin rspec version to 2.14

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -20,9 +20,9 @@ spec = Gem::Specification.new do |s|
   s.add_dependency "mixlib-shellout"
   s.add_dependency "ipaddress"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec-core"
-  s.add_development_dependency "rspec-expectations"
-  s.add_development_dependency "rspec-mocks"
+  s.add_development_dependency "rspec-core", "~> 2.14.0"
+  s.add_development_dependency "rspec-expectations", "~> 2.14.0"
+  s.add_development_dependency "rspec-mocks", "~> 2.14.0"
   s.add_development_dependency "rspec_junit_formatter"
   s.bindir = "bin"
   s.executables = %w(ohai)


### PR DESCRIPTION
Travis was slurping in RSpec 3, which was causing failures due to unsupported formatting flag -s. Until/if we choose to update RSpec to version 3, pin at 2.14. Gives lots of deprecation warnings, so can try pinning at an older version if that's an issue.
