### PR TITLE
[ohai 7] Linux::filesystems should prefer lsblk to blkid when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased:
 
+* [**Phil Dibowitz**:](https://github.com/jaymzh)
+  Use lsblk instead of blkid if available.
 
 ## Last Release: 7.2.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,5 +27,6 @@ populate the old system (role & system) with LXC if there are no other virtualiz
 ### Miscellaneous
 
 * Ohai now collects mdadm RAID information.
+* Ohai know uses lsblk, if available, instead of blkid
 
 # Ohai Breaking Changes:


### PR DESCRIPTION
blkid has several bugs, and will miss a variety of things.

For starters, it'll never report on a device that has partitions even if the
parent is the thing with a filesystem on it. It has weird bugs like:

http://marc.info/?l=linux-ext4&m=119636478426226&w=2

lsblk, on the other hand, probes everything in /sys/block and reports
consistently.

This is the Ohai7 port of #353 and addresses #351
