### PR TITLE
add extra metadata passed in from hints in knife-linode

### DIFF
--- a/lib/ohai/plugins/linode.rb
+++ b/lib/ohai/plugins/linode.rb
@@ -56,6 +56,7 @@ Ohai.plugin(:Linode) do
       linode Mash.new
       get_ip_address(:public_ip, :eth0)
       get_ip_address(:private_ip, "eth0:1")
+      hint?('linode').each{|k,v| linode[k] = v } if hint?('linode').kind_of?(Hash)
     end
   end
 end


### PR DESCRIPTION
linode doesn't have a metadata server like ec2, so the metadata has to be passed into the hints from the knife-linode plugin during bootstrap.  The knife-linode plugin currently does this, but ohai is doing nothing with it.