### PR TITLE
Eucalyptus metadata server, presume 'latest' API version on 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 * root_group provider not implemented for Windows (OHAI-491)
 * `Ohai::Exceptions::AttributeNotFound` errors in Chef's ohai resource
 * Be reluctant to call something an LXC host (OHAI-573)
-
+* Assume 'latest' metadata versions on 404
 
 ## Release: 7.0.4
 

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -76,7 +76,10 @@ module Ohai
 
       def best_api_version
         response = http_client.get("/")
-        unless response.code == '200'
+        if response.code == '404'
+          Ohai::Log.debug("Received HTTP 404 from metadata server while determining API version, assuming 'latest'")
+          return "latest"
+        elsif response.code != '200'
           raise "Unable to determine EC2 metadata version (returned #{response.code} response)"
         end
         # Note: Sorting the list of versions may have unintended consequences in

--- a/spec/unit/mixin/ec2_metadata_spec.rb
+++ b/spec/unit/mixin/ec2_metadata_spec.rb
@@ -53,11 +53,12 @@ describe Ohai::Mixin::Ec2Metadata do
       end
     end
 
+    # Presume 'latest' when we get a 404 for Eucalyptus back-compat
     context "when the response code is 404" do
-      let(:response) { double("Net::HTTP Response", :body => "1.0\n2011-05-01\n2012-01-12\nUnsupported", :code => "404") }
+      let(:response) { double("Net::HTTP Response", :code => "404") }
 
-      it "raises an error" do
-        lambda { mixin.best_api_version}.should raise_error
+      it "returns 'latest' as the version" do
+        mixin.best_api_version.should == 'latest'
       end
     end
 


### PR DESCRIPTION
Replaces #178 

Apparently Eucalytpus may not give you a list of API versions when you query "/" on the metadata server, so we presume latest in that case.

Note that this is shared code though.
