### PR TITLE
[ci] bundle install into system gems

### DIFF
--- a/ci/jenkins_run_tests.bat
+++ b/ci/jenkins_run_tests.bat
@@ -4,7 +4,7 @@ call bundle check
 
 if %ERRORLEVEL% NEQ 0 (
    call rm Gemfile.lock
-   call bundle install --without docgen --path vendor/bundle
+   call bundle install --without docgen
 )
 
 bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation spec


### PR DESCRIPTION
Git on Windows respects the MAX_PATH from the Win32 API. Since MAX_PATH is 260 characters and the path to the Jenkin’s workspace is fairly long, `bundle install --path=vendor/bundle` commands will fail if the `Gemfile` contains a `git` sources.

Although `msysgit` is working on experimental long path support, there are still various bugs in the implementation: https://github.com/msysgit/git/pull/122

/cc @opscode/client-engineers @opscode/release-engineers 
