### PR TITLE
Fix Linux::Filesystem reading of /proc/mounts

### DIFF
--- a/lib/ohai/plugins/linux/filesystem.rb
+++ b/lib/ohai/plugins/linux/filesystem.rb
@@ -122,7 +122,7 @@ Ohai.plugin(:Filesystem) do
 
     # Grab any missing mount information from /proc/mounts
     if File.exists?('/proc/mounts')
-      File.open('/proc/mounts').read_nonblock(4096).each_line do |line|
+      File.open('/proc/mounts').read.each_line do |line|
         if line =~ /^(\S+) (\S+) (\S+) (\S+) \S+ \S+$/
           filesystem = $1
           next if fs.has_key?(filesystem)

--- a/spec/unit/plugins/linux/filesystem_spec.rb
+++ b/spec/unit/plugins/linux/filesystem_spec.rb
@@ -350,7 +350,7 @@ BLKID_LABEL
     before(:each) do
       File.stub(:exists?).with("/proc/mounts").and_return(true)
       @double_file = double("/proc/mounts")
-      @double_file.stub(:read_nonblock).and_return(@double_file)
+      @double_file.stub(:read).and_return(@double_file)
       @double_file.stub(:each_line).
         and_yield("rootfs / rootfs rw 0 0").
         and_yield("none /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0").


### PR DESCRIPTION
At the moment you only read 4K of data, which drops lots of important things. I
don't know why anyone thought 4K would be sufficient.
