### PR TITLE
Collect kernel modules for AIX

### DIFF
--- a/lib/ohai/plugins/aix/kernel.rb
+++ b/lib/ohai/plugins/aix/kernel.rb
@@ -26,6 +26,20 @@ Ohai.plugin(:Kernel) do
     kernel[:release] = shell_out("uname -r").stdout.split($/)[0]
     kernel[:version] = shell_out("uname -v").stdout.split($/)[0]
     kernel[:machine] = shell_out("uname -p").stdout.split($/)[0]
-    kernel[:modules] = Mash.new
+
+    modules = Mash.new
+    so = shell_out("genkex -d")
+    #     Text address     Size     Data address     Size File
+    #
+    # f1000000c0338000    77000 f1000000c0390000    1ec8c /usr/lib/drivers/cluster
+    #          6390000    20000          63a0000      ba8 /usr/lib/drivers/if_en
+    # f1000000c0318000    20000 f1000000c0320000    17138 /usr/lib/drivers/random
+    so.stdout.lines do |line|
+      if line =~ /\s*([0-9a-f]+)\s+([0-9a-f]+)\s+([0-9a-f]+)\s+([0-9a-f]+)\s+([a-zA-Z0-9\/\._]+)/
+        modules[$5] = { :text => { :address => $1, :size => $2 }, :data => { :address => $3, :size => $4 } }
+      end
+    end
+
+    kernel[:modules] = modules
   end
 end

--- a/spec/unit/plugins/aix/kernel_spec.rb
+++ b/spec/unit/plugins/aix/kernel_spec.rb
@@ -25,8 +25,7 @@ describe Ohai::System, "AIX kernel plugin" do
     @plugin.stub(:shell_out).with("uname -r").and_return(mock_shell_out(0, "1", nil))
     @plugin.stub(:shell_out).with("uname -v").and_return(mock_shell_out(0, "6", nil))
     @plugin.stub(:shell_out).with("uname -p").and_return(mock_shell_out(0, "powerpc", nil))
-    @modules = Mash.new
-    @plugin.stub(:modules).and_return(@modules)
+    @plugin.stub(:shell_out).with("genkex -d").and_return(mock_shell_out(0, "    Text address     Size     Data address     Size File\nf1000000c0338000    77000 f1000000c0390000    1ec8c /usr/lib/drivers/cluster\n         6390000    20000          63a0000      ba8 /usr/lib/drivers/if_en", nil))
     @plugin.run
   end
 
@@ -47,6 +46,10 @@ describe Ohai::System, "AIX kernel plugin" do
   end
 
   it "detects the modules" do
-    @plugin[:kernel][:modules].should == @modules
+    @plugin[:kernel][:modules]["/usr/lib/drivers/cluster"]["text"].should == { "address" => "f1000000c0338000", "size" => "77000" }
+    @plugin[:kernel][:modules]["/usr/lib/drivers/cluster"]["data"].should == { "address" => "f1000000c0390000", "size" => "1ec8c" }
+    @plugin[:kernel][:modules]["/usr/lib/drivers/if_en"]["text"].should == { "address" => "6390000", "size" => "20000"}
+    @plugin[:kernel][:modules]["/usr/lib/drivers/if_en"]["data"].should == { "address" => "63a0000", "size" => "ba8"}
+
   end
 end


### PR DESCRIPTION
The current implementation of the kernel plugin fails to collect loaded modules (sets it to an empty `Mash`)
