### PR TITLE
Fix node['hostname'] on systems with only a bare hostname.

### DIFF
--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -67,7 +67,7 @@ Ohai.plugin(:Hostname) do
   def collect_hostname
     # Hostname is everything before the first dot
     if machinename
-      machinename =~ /(.+?)\./
+      machinename =~ /(\w+)\.?/
       hostname $1
     elsif fqdn
       fqdn =~ /(.+?)\./

--- a/spec/unit/plugins/hostname_spec.rb
+++ b/spec/unit/plugins/hostname_spec.rb
@@ -72,6 +72,18 @@ describe Ohai::System, "hostname plugin" do
     end
   end
 
+  context "when a system has a bare hostname without a FQDN" do
+    before(:each) do
+      @plugin.stub(:collect_os).and_return(:default)
+      @plugin.stub(:shell_out).with("hostname").and_return(mock_shell_out(0, "katie", ""))
+    end
+
+    it "should correctly set the [short] hostname" do
+      @plugin.run
+      @plugin[:hostname].should == "katie"
+    end
+  end
+
   context "hostname --fqdn when it returns empty string" do
     before(:each) do
       @plugin.stub(:collect_os).and_return(:linux)


### PR DESCRIPTION
Some systems do not have a FQDN, but instead have just a bare hostname. Users expect `node['hostname']` to be properly set, but the regex for capturing this was incorrect for this corner case.

Phenomenon seen in IBM's VLP cluster, where all AIX LPARs are set up like this.
