### PR TITLE
getlogin() often lies, especially when run under "su"

### DIFF
--- a/lib/ohai/plugins/passwd.rb
+++ b/lib/ohai/plugins/passwd.rb
@@ -32,7 +32,7 @@ Ohai.plugin(:Passwd) do
     end
 
     unless current_user
-      current_user fix_encoding(Etc.getlogin)
+      current_user fix_encoding(Etc.getpwuid(Process.euid).name)
     end
   end
 end

--- a/spec/unit/plugins/passwd_spec.rb
+++ b/spec/unit/plugins/passwd_spec.rb
@@ -24,7 +24,8 @@ describe Ohai::System, "plugin etc" do
   end
 
   it "should set the current user" do
-    Etc.should_receive(:getlogin).and_return('chef')
+    Process.should_receive(:euid).and_return('31337')
+    Etc.should_receive(:getpwuid).and_return(PasswdEntry.new('chef', 31337, 31337, '/home/chef', '/bin/ksh', 'Julia Child'))
     @plugin.run
     @plugin[:current_user].should == 'chef'
   end


### PR DESCRIPTION
Run under "su", Ohai incorrectly returns the calling user as `node['current_user']` because `getlogin()` lies to us.
According to the Ruby documentation, it's safer to use getpwuid().
