### PR TITLE
Digital Ocean ohai/cloud support round 2

### DIFF
--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -1,0 +1,81 @@
+#
+# Author:: Stafford Brunk (<stafford.brunk@gmail.com>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'ohai/util/ip_helper'
+
+Ohai.plugin(:DigitalOcean) do
+  include Ohai::Util::IpHelper
+
+  DIGITALOCEAN_FILE = '/etc/digitalocean'
+
+  provides "digital_ocean"
+
+  depends "network/interfaces"
+
+  def extract_droplet_ip_addresses
+    addresses = Mash.new({'v4' => [], 'v6' => []})
+    network[:interfaces].each_value do |iface|
+      iface[:addresses].each do |address, details|
+        next if loopback?(address) || details[:family] == 'lladdr'
+
+        ip = IPAddress(address)
+        type = digital_ocean_address_type(ip)
+        address_hash = build_address_hash(ip, details)
+        addresses[type] << address_hash
+      end 
+    end
+    addresses
+  end
+
+  def build_address_hash(ip, details)
+    address_hash = Mash.new({
+      'ip_address' => ip.address,
+      'type' => private_address?(ip.address) ? 'private' : 'public'
+    })
+
+    if ip.ipv4?
+      address_hash['netmask'] = details[:netmask]
+    elsif ip.ipv6?
+      address_hash['cidr'] = ip.prefix
+    end
+    address_hash
+  end
+
+  def digital_ocean_address_type(ip)
+    ip.ipv4? ? 'v4' : 'v6'
+  end
+
+  def looks_like_digital_ocean?
+    hint?('digital_ocean') || File.exist?(DIGITALOCEAN_FILE)
+  end
+
+  collect_data do
+    if looks_like_digital_ocean?
+      digital_ocean Mash.new
+      hint = hint?('digital_ocean') || {}
+      hint.each {|k, v| digital_ocean[k] = v unless k == 'ip_addresses'}
+
+      # Extract actual ip addresses
+      # The networks sub-hash is structured similarly to how
+      # Digital Ocean's v2 API structures things:
+      # https://developers.digitalocean.com/#droplets
+      digital_ocean[:networks] = extract_droplet_ip_addresses
+    else
+      Ohai::Log.debug("No hints present for digital_ocean.")
+      false
+    end
+  end
+end

--- a/lib/ohai/util/ip_helper.rb
+++ b/lib/ohai/util/ip_helper.rb
@@ -1,0 +1,52 @@
+#
+# Author:: Stafford Brunk (<stafford.brunk@gmail.com>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Ohai
+  module Util
+    module IpHelper
+      # Corresponding to RFC 4193
+      IPV6_PRIVATE_ADDRESS_BLOCK = IPAddress('fc00::/7')
+
+      def private_address?(addr)
+        ip = IPAddress(addr)
+
+        if ip.respond_to? :private?
+          ip.private?
+        else
+          IPV6_PRIVATE_ADDRESS_BLOCK.include?(ip)
+        end
+      end
+      alias :unique_local_address? :private_address?
+
+      def public_address?(addr)
+        !private_address?(addr)
+      end
+
+      # The ipaddress gem doesn't implement loopback?
+      # for IPv4 addresses
+      # https://github.com/bluemonk/ipaddress/issues/25
+      def loopback?(addr)
+        ip = IPAddress(addr)
+
+        if ip.respond_to? :loopback?
+          ip.loopback?
+        else
+          IPAddress('127.0.0.0/8').include? ip
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -30,6 +30,7 @@ describe Ohai::System, "plugin cloud" do
       @plugin[:linode] = nil
       @plugin[:azure] = nil
       @plugin[:cloudstack] = nil
+      @plugin[:digital_ocean] = nil
       @plugin.run
       @plugin[:cloud].should be_nil
     end
@@ -235,5 +236,58 @@ describe Ohai::System, "plugin cloud" do
     end
   end
 
+  describe "with digital_ocean mash" do
+    before do
+      @plugin[:digital_ocean] = Mash.new
+      @plugin[:digital_ocean][:name] = "public.example.com"
+      @plugin[:digital_ocean][:networks] = Mash.new
+      @plugin[:digital_ocean][:networks][:v4] = [{"ip_address" => "1.2.3.4", "type" => "public"},
+                                                 {"ip_address" => "5.6.7.8", "type" => "private"}]
+      @plugin[:digital_ocean][:networks][:v6] = [{"ip_address" => "fe80::4240:95ff:fe47:6eee", "type" => "public"},
+                                                 {"ip_address" => "fdf8:f53b:82e4::53", "type" => "private"}]
+    end
+
+    before(:each) do
+      @plugin.run
+    end
+
+    it "populates cloud public hostname" do
+      @plugin[:cloud][:public_hostname].should == "public.example.com"
+    end
+
+    it "populates cloud local hostname" do
+      @plugin[:cloud][:local_hostname].should be_nil
+    end
+
+    it "populates cloud public ips" do
+      @plugin[:cloud][:public_ips].should == @plugin[:digital_ocean][:networks][:v4].select{|ip| ip['type'] == 'public'} +
+                                             @plugin[:digital_ocean][:networks][:v6].select{|ip| ip['type'] == 'public'}
+    end
+
+    it "populates cloud private ips" do
+      @plugin[:cloud][:private_ips].should == @plugin[:digital_ocean][:networks][:v4].select{|ip| ip['type'] == 'private'} +
+                                              @plugin[:digital_ocean][:networks][:v6].select{|ip| ip['type'] == 'private'}
+    end
+
+    it "populates cloud public_ipv4" do
+      @plugin[:cloud][:public_ipv4].should == @plugin[:digital_ocean][:networks][:v4].find{|ip| ip['type'] == 'public'}
+    end
+
+    it "populates cloud local_ipv4" do
+      @plugin[:cloud][:local_ipv4].should == @plugin[:digital_ocean][:networks][:v4].find{|ip| ip['type'] == 'private'}
+    end
+
+    it "populates cloud public_ipv6" do
+      @plugin[:cloud][:public_ipv6].should == @plugin[:digital_ocean][:networks][:v6].find{|ip| ip['type'] == 'public'}
+    end
+
+    it "populates cloud local_ipv6" do
+      @plugin[:cloud][:local_ipv6].should == @plugin[:digital_ocean][:networks][:v6].find{|ip| ip['type'] == 'private'}
+    end
+
+    it "populates cloud provider" do
+      @plugin[:cloud][:provider].should == "digital_ocean"
+    end
+  end
 
 end

--- a/spec/unit/plugins/cloud_v2_spec.rb
+++ b/spec/unit/plugins/cloud_v2_spec.rb
@@ -86,6 +86,7 @@ describe Ohai::System, "plugin cloud" do
       @plugin[:linode] = nil
       @plugin[:azure] = nil
       @plugin[:gce] = nil
+      @plugin[:digital_ocean] = nil
       @plugin.run
       @plugin[:cloud_v2].should be_nil
     end
@@ -286,6 +287,72 @@ describe Ohai::System, "plugin cloud" do
     it "populates cloud provider" do
       @plugin.run
       @plugin[:cloud_v2][:provider].should == "azure"
+    end
+  end
+
+  describe "with digital_ocean mash" do
+    before do
+      @plugin[:digital_ocean] = Mash.new
+      @plugin[:digital_ocean][:name] = "public.example.com"
+      @plugin[:digital_ocean][:networks] = Mash.new
+      @plugin[:digital_ocean][:networks][:v4] = [{"ip_address" => "1.2.3.4", "type" => "public"},
+                                                 {"ip_address" => "5.6.7.8", "type" => "private"}]
+      @plugin[:digital_ocean][:networks][:v6] = [{"ip_address" => "fe80::4240:95ff:fe47:6eee", "type" => "public"},
+                                                 {"ip_address" => "fdf8:f53b:82e4::53", "type" => "private"}]
+    end
+
+    before(:each) do
+      @plugin.run
+    end
+
+    it "populates cloud public hostname" do
+      @plugin[:cloud_v2][:public_hostname].should == "public.example.com"
+    end
+
+    it "populates cloud local hostname" do
+      @plugin[:cloud_v2][:local_hostname].should be_nil
+    end
+
+    it "populates cloud public_ipv4_addrs" do
+      @plugin[:cloud_v2][:public_ipv4_addrs].should == @plugin[:digital_ocean][:networks][:v4].select{|ip| ip['type'] == 'public'}
+                                                                                              .map{|ip| ip['ip_address']}
+                                                       
+    end
+
+    it "populates cloud local_ipv4_addrs" do
+      @plugin[:cloud_v2][:local_ipv4_addrs].should == @plugin[:digital_ocean][:networks][:v4].select{|ip| ip['type'] == 'private'}
+                                                                                             .map{|ip| ip['ip_address']}
+                                                      
+    end
+
+    it "populates cloud public_ipv4" do
+      @plugin[:cloud_v2][:public_ipv4].should == @plugin[:digital_ocean][:networks][:v4].find{|ip| ip['type'] == 'public'}['ip_address']
+    end
+
+    it "populates cloud local_ipv4" do
+      @plugin[:cloud_v2][:local_ipv4].should == @plugin[:digital_ocean][:networks][:v4].find{|ip| ip['type'] == 'private'}['ip_address']
+    end
+
+    it "populates cloud public_ipv6_addrs" do
+      @plugin[:cloud_v2][:public_ipv6_addrs].should == @plugin[:digital_ocean][:networks][:v6].select{|ip| ip['type'] == 'public'}
+                                                                                              .map{|ip| ip['ip_address']}
+    end
+
+    it "populates cloud local_ipv6_addrs" do
+      @plugin[:cloud_v2][:local_ipv6_addrs].should == @plugin[:digital_ocean][:networks][:v6].select{|ip| ip['type'] == 'private'}
+                                                                                             .map{|ip| ip['ip_address']}
+    end
+
+    it "populates cloud public_ipv6" do
+      @plugin[:cloud_v2][:public_ipv6].should == @plugin[:digital_ocean][:networks][:v6].find{|ip| ip['type'] == 'public'}['ip_address']
+    end
+
+    it "populates cloud local_ipv6" do
+      @plugin[:cloud_v2][:local_ipv6].should == @plugin[:digital_ocean][:networks][:v6].find{|ip| ip['type'] == 'private'}['ip_address']
+    end
+
+    it "populates cloud provider" do
+      @plugin[:cloud_v2][:provider].should == "digital_ocean"
     end
   end
 

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -1,0 +1,211 @@
+#
+# Author:: Stafford Brunk (<stafford.brunk@gmail.com>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'ipaddress'
+require 'spec_helper'
+
+describe Ohai::System, "plugin digital_ocean" do
+  let(:hint_path_nix) { '/etc/chef/ohai/hints/digital_ocean.json' }
+  let(:hint_path_win) { 'C:\chef\ohai\hints/digital_ocean.json' }
+  let(:digitalocean_path) { '/etc/digitalocean' }
+  let(:hint) {
+    '{
+      "droplet_id": 12345678,
+      "name": "example.com",
+      "image_id": 3240036,
+      "size_id": 66,
+      "region_id": 4,
+      "ip_addresses": {
+        "public": "1.2.3.4",
+        "private": "5.6.7.8"
+      }
+    }'
+  }
+
+  before do
+    @plugin = get_plugin("digital_ocean")
+    @plugin[:network] = {
+      "interfaces"=> {
+        "eth0"=> {
+          "addresses"=> {
+            "1.2.3.4"=> {
+              "netmask"=> "255.255.255.0"
+            },
+            "2400:6180:0000:00d0:0000:0000:0009:7001"=> {}
+          }
+        }
+      }
+    }
+
+    File.stub(:exist?).with(hint_path_nix).and_return(true)
+    File.stub(:read).with(hint_path_nix).and_return(hint)
+    File.stub(:exist?).with(hint_path_win).and_return(true)
+    File.stub(:read).with(hint_path_win).and_return(hint)
+  end
+
+
+  shared_examples_for "!digital_ocean"  do
+    before(:each) do
+      @plugin.run
+    end
+
+    it "does not create the digital_ocean mash" do
+      @plugin[:digital_ocean].should be_nil
+    end
+  end
+
+  shared_examples_for "digital_ocean_networking" do
+    it "creates the networks attribute" do
+      @plugin[:digital_ocean][:networks].should_not be_nil
+    end
+
+    it "pulls ip addresses from the network interfaces" do
+      @plugin[:digital_ocean][:networks][:v4].should == [{"ip_address" => "1.2.3.4",
+                                                         "type" => "public",
+                                                         "netmask" => "255.255.255.0"}]
+      @plugin[:digital_ocean][:networks][:v6].should == [{"ip_address"=>"2400:6180:0000:00d0:0000:0000:0009:7001",
+                                                          "type"=>"public",
+                                                          "cidr"=>128}]
+    end
+  end
+
+  shared_examples_for "digital_ocean" do
+    before(:each) do
+      @plugin.run
+    end
+
+    it "creates a digital_ocean mash" do
+      @plugin[:digital_ocean].should_not be_nil
+    end
+
+    it "has all hint attributes" do
+      @plugin[:digital_ocean][:droplet_id].should_not be_nil
+      @plugin[:digital_ocean][:name].should_not be_nil
+      @plugin[:digital_ocean][:image_id].should_not be_nil
+      @plugin[:digital_ocean][:size_id].should_not be_nil
+      @plugin[:digital_ocean][:region_id].should_not be_nil
+    end
+
+    it "skips the ip_addresses hint attribute" do
+      @plugin[:digital_ocean][:ip_addresses].should be_nil
+    end
+
+    it "has correct values for all hint attributes" do
+      @plugin[:digital_ocean][:droplet_id].should == 12345678
+      @plugin[:digital_ocean][:name].should == "example.com"
+      @plugin[:digital_ocean][:image_id].should == 3240036
+      @plugin[:digital_ocean][:size_id].should == 66
+      @plugin[:digital_ocean][:region_id].should == 4
+    end
+
+    include_examples 'digital_ocean_networking'
+  end
+
+  describe "with digital_ocean hint file" do
+    before do
+      File.stub(:exist?).with(hint_path_nix).and_return(true)
+      File.stub(:exist?).with(hint_path_win).and_return(true)
+    end
+
+    context "without private networking enabled" do
+      it_should_behave_like "digital_ocean"
+    end
+
+    context "with private networking enabled" do
+      before do
+        @plugin[:network][:interfaces][:eth1] = {
+          "addresses"=> {
+            "10.128.142.89" => {
+              "netmask" => "255.255.255.0"
+            },
+            "fdf8:f53b:82e4:0000:0000:0000:0000:0053" => {}
+          }
+        }
+
+        @plugin.run
+      end
+
+      it "should extract the private networking ips" do
+        @plugin[:digital_ocean][:networks][:v4].should == [{"ip_address" => "1.2.3.4",
+                                                            "type" => "public",
+                                                            "netmask" => "255.255.255.0"},
+                                                            {"ip_address" => "10.128.142.89",
+                                                            "type" => "private",
+                                                            "netmask" => "255.255.255.0"}]
+        @plugin[:digital_ocean][:networks][:v6].should == [{"ip_address"=>"2400:6180:0000:00d0:0000:0000:0009:7001",
+                                                            "type"=>"public",
+                                                            "cidr"=>128},
+                                                           {"ip_address"=>"fdf8:f53b:82e4:0000:0000:0000:0000:0053",
+                                                            "type"=>"private",
+                                                            "cidr"=>128}]
+      end
+    end
+  end
+
+  describe "without digital_ocean hint file" do
+    before do
+      File.stub(:exist?).with(hint_path_nix).and_return(false)
+      File.stub(:exist?).with(hint_path_win).and_return(false)
+    end
+
+
+    describe "with the /etc/digitalocean file" do
+      before do
+        File.stub(:exist?).with(digitalocean_path).and_return(true)
+        @plugin.run
+      end
+      it_should_behave_like "digital_ocean_networking"
+    end
+
+    describe "without the /etc/digitalocean file" do
+      before do
+        File.stub(:exist?).with(digitalocean_path).and_return(false)
+      end
+      it_should_behave_like "!digital_ocean"
+    end
+  end
+
+  context "with ec2 hint file" do
+    let(:ec2_hint_path_nix) { '/etc/chef/ohai/hints/ec2.json' }
+    let(:ec2_hint_path_win) { 'C:\chef\ohai\hints/ec2.json' }
+
+    before do
+      File.stub(:exist?).with(hint_path_nix).and_return(false)
+      File.stub(:exist?).with(hint_path_win).and_return(false)
+
+      File.stub(:exist?).with(ec2_hint_path_nix).and_return(true)
+      File.stub(:read).with(ec2_hint_path_nix).and_return('')
+      File.stub(:exist?).with(ec2_hint_path_win).and_return(true)
+      File.stub(:read).with(ec2_hint_path_win).and_return('')
+    end
+
+    describe "with the /etc/digitalocean file" do
+      before do
+        File.stub(:exist?).with(digitalocean_path).and_return(true)
+        @plugin.run
+      end
+      it_should_behave_like "digital_ocean_networking"
+    end
+
+    describe "without the /etc/digitalocean file" do
+      before do
+        File.stub(:exist?).with(digitalocean_path).and_return(false)
+      end
+      it_should_behave_like "!digital_ocean"
+    end
+  end
+end

--- a/spec/unit/util/ip_helper_spec.rb
+++ b/spec/unit/util/ip_helper_spec.rb
@@ -1,0 +1,128 @@
+#
+# Author:: Stafford Brunk (<stafford.brunk@gmail.com>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'ipaddress'
+require 'spec_helper'
+require 'ohai/util/ip_helper'
+
+class IpHelperMock
+  include Ohai::Util::IpHelper
+end
+
+describe "Ohai::Util::IpHelper" do
+  let(:ip_helper) { IpHelperMock.new }
+
+  shared_examples 'ip address types' do
+    context 'with an IPv4 address' do
+      context 'that is private' do
+        let(:address) { '10.128.142.89' }
+
+        it 'identifies the address as private' do
+          expect(ip_helper.private_address?(address)).to be_truthy
+        end
+      end
+
+      context 'that is public' do
+        let(:address) { '74.125.224.72' }
+
+        it 'identifies the address as public' do
+          expect(ip_helper.private_address?(address)).to be_falsey
+        end
+      end
+    end
+
+    context 'with an IPv6 address' do
+      context 'that is an RFC 4193 unique local address' do
+        let(:address) { 'fdf8:f53b:82e4::53' }
+
+        it 'identifies the address as a unique local address' do
+          expect(ip_helper.private_address?(address)).to be_truthy
+        end
+      end
+
+      context 'that is a non RFC 4193 unique local address' do
+        let(:address) { 'FE80::0202:B3FF:FE1E:8329' }
+
+        it 'does not identify the address as a unique local address' do
+          expect(ip_helper.private_address?(address)).to be_falsey
+        end
+      end
+    end
+  end
+
+  describe 'private_address?' do
+    include_examples 'ip address types'
+  end 
+
+  describe 'unique_local_address?' do
+    include_examples 'ip address types'
+  end
+
+  describe 'public_address?' do
+    let(:address) { '10.128.142.89' }
+
+    before do
+      allow(ip_helper).to receive(:private_address?)
+    end
+
+    it 'should call #private_address?' do
+      expect(ip_helper).to receive(:private_address?)
+      ip_helper.public_address?(address)
+    end
+
+    it 'should return the inverse of #private_address?' do
+      expect(ip_helper.public_address?(address)).to equal !ip_helper.private_address?(address)
+    end
+  end
+
+  describe 'loopback?' do
+    context 'with an IPv4 address' do
+      context 'that is a loopback address' do
+        let(:address) { '127.0.0.1' }
+
+        it 'should identify the address as a loopback address' do
+          expect(ip_helper.loopback?(address)).to be_truthy
+        end
+      end
+
+      context 'that is not a loopback address' do
+        let(:address) { '1.2.3.4' }
+
+        it 'should not identify the address as a loopback address' do
+          expect(ip_helper.loopback?(address)).to be_falsey
+        end
+      end
+    end
+
+    context 'with an IPv6 address' do
+      context 'that is a loopback address' do
+        let(:address) { '0:0:0:0:0:0:0:1' }
+
+        it 'should identify the address as a loopback address' do
+          expect(ip_helper.loopback?(address)).to be_truthy
+        end
+      end
+
+      context 'that is not a loopback address' do
+        let(:address) { '2400:6180:0000:00D0:0000:0000:0009:7001' }
+
+        it 'should not identify the address as a loopback address' do
+          expect(ip_helper.loopback?(address)).to be_falsey
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a follow-up to PR #347.

This PR:

* Adds an `IpHelper`. This provides a few useful methods for figuring out if an ip address is a private address and if it is a loopback address
* Implements a Digital Ocean ohai plugin. Digital Ocean is detected via a hint file or via the `/etc/digitalocean` file.
* Adds support for said plugin to the cloud plugin
* Adds support for said plugin to the cloud_v2 plugin

I decided to store the detected network addresses in a similar manner to how the v2 Digital Ocean API will be [reporting them](https://developers.digitalocean.com/v2/#droplets). Since we can detect network data directly, storing it in this way will help ease the transition over to the v2 API whenever `knife-digital_ocean` does so. The remainder of the hint file is kept under the v1 payload structure.

cc @mcquin @btm @brodock @wfarr