### PR TITLE
Ignore passwd plugin on Windows

### DIFF
--- a/lib/ohai/plugins/passwd.rb
+++ b/lib/ohai/plugins/passwd.rb
@@ -35,4 +35,8 @@ Ohai.plugin(:Passwd) do
       current_user fix_encoding(Etc.getpwuid(Process.euid).name)
     end
   end
+
+  collect_data(:windows) do
+    # Etc returns nil on Windows
+  end
 end

--- a/spec/unit/plugins/passwd_spec.rb
+++ b/spec/unit/plugins/passwd_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper.rb')
 
-describe Ohai::System, "plugin etc" do
+describe Ohai::System, "plugin etc", :unix_only do
   before(:each) do
     @plugin = get_plugin("passwd")
   end


### PR DESCRIPTION
The Etc module returns nil on Windows for everything useful.
