### PR TITLE
bump mixlib-shellout + misc gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,10 @@ gemspec
 gem "rspec_junit_formatter", :git => 'https://github.com/sj26/rspec_junit_formatter.git',
                              :ref => "147836c41fab23ff7b92806f34122c8e5f2ddcad"
 
-# Rake 10.2 drops Ruby 1.8 support
-gem "rake", "~> 10.1.0"
+gem "mixlib-shellout", github: "opscode/mixlib-shellout", branch: "master"
 
 group :development do
+  gem "chef", github: "opscode/chef", branch: "master"
 
   gem "sigar", :platform => "ruby"
   gem 'plist'

--- a/lib/ohai/version.rb
+++ b/lib/ohai/version.rb
@@ -18,5 +18,5 @@
 
 module Ohai
   OHAI_ROOT = File.expand_path(File.dirname(__FILE__))
-  VERSION = '7.4.0.dev'
+  VERSION = '7.6.0.dev'
 end

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license = "Apache-2.0"
   s.author = "Adam Jacob"
   s.email = "adam@opscode.com"
-  s.homepage = "http://wiki.opscode.com/display/chef/Ohai"
+  s.homepage = "https://docs.getchef.com/ohai.html"
 
   s.add_dependency "mime-types", "~> 1.16"
   s.add_dependency "systemu", "~> 2.6.4"
@@ -19,15 +19,13 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli"
   s.add_dependency "mixlib-config", "~> 2.0"
   s.add_dependency "mixlib-log"
-  s.add_dependency "mixlib-shellout", "~> 1.2"
+  s.add_dependency "mixlib-shellout", ">= 2.0.0.rc.0", "< 3.0"
   s.add_dependency "net-dhcp"
   s.add_dependency "ipaddress"
   s.add_dependency "wmi-lite", "~> 1.0"
   s.add_dependency "ffi", "~> 1.9"
 
-  # Rake 10.2 drops Ruby 1.8 support, so stick to 10.1.x until chef also drops
-  # 1.8.
-  s.add_development_dependency "rake", "~> 10.1.0"
+  s.add_dependency "rake", "~> 10.1"
   s.add_development_dependency "rspec-core", "~> 3.0"
   s.add_development_dependency "rspec-expectations", "~> 3.0"
   s.add_development_dependency "rspec-mocks", "~> 3.0"


### PR DESCRIPTION
- bumps ohai version
- update homepage
- update rake now that we've dropped 1.8
