### PR TITLE
mixlib-shellout gem released

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ gemspec
 gem "rspec_junit_formatter", :git => 'https://github.com/sj26/rspec_junit_formatter.git',
                              :ref => "147836c41fab23ff7b92806f34122c8e5f2ddcad"
 
-gem "mixlib-shellout", github: "opscode/mixlib-shellout", branch: "master"
-
 group :development do
   gem "chef", github: "opscode/chef", branch: "master"
 


### PR DESCRIPTION
i believe we still need to pull in chef-12 off github in the dev
gems
