### PR TITLE
Fix java version parsing regex

### DIFF
--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -30,7 +30,7 @@ Ohai.plugin(:Java) do
           java[:version] = $1
         when /^(.+Runtime Environment.*) \((build)\s*(.+)\)$/
           java[:runtime] = { "name" => $1, "build" => $3 }
-        when /^(.+ (Client|Server) VM) \(build (.+)\)$/
+        when /^(.+ (Client|Server) VM) \(build\s*(.+)\)$/
           java[:hotspot] = { "name" => $1, "build" => $3 }
         end
       end


### PR DESCRIPTION
Fix java version parsing regex.

Old regex failed for parsing below string on aix.
Java(TM) 2 Runtime Environment, Standard Edition (build pap32dev-20120810 (SR14 ))
