### PR TITLE
Ensure CPU total is an integer on FreeBSD

### DIFF
--- a/lib/ohai/plugins/freebsd/cpu.rb
+++ b/lib/ohai/plugins/freebsd/cpu.rb
@@ -55,6 +55,6 @@ Ohai.plugin(:CPU) do
 
     cpu cpuinfo
     so = shell_out("sysctl -n hw.ncpu")
-    cpu[:total] = so.stdout.split($/)[0]
+    cpu[:total] = so.stdout.split($/)[0].to_i
   end
 end

--- a/spec/unit/plugins/freebsd/cpu_spec.rb
+++ b/spec/unit/plugins/freebsd/cpu_spec.rb
@@ -62,7 +62,7 @@ describe Ohai::System, "FreeBSD cpu plugin" do
 
   it "detects all CPU total" do
     @plugin.run
-    @plugin[:cpu][:total].should == "2"
+    @plugin[:cpu][:total].should == 2
   end
 
 end


### PR DESCRIPTION
This matches the behavior on other platforms.

/cc @opscode/client-engineers @opscode/release-engineers 
