### PR TITLE
OHAI-339 Unable to detect IPAddress on CoreOS/Gentoo

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -33,6 +33,10 @@ Ohai.plugin(:Network) do
     encap
   end
 
+  def iproute2_binary_available?
+    ["/sbin/ip", "/usr/bin/ip"].any? { |path| File.exist?(path) }
+  end
+
   collect_data(:linux) do
     require 'ipaddr'
 
@@ -49,8 +53,7 @@ Ohai.plugin(:Network) do
     # The '@eth0:' portion doesn't exist on primary interfaces and thus is optional in the regex
     IPROUTE_INT_REGEX = /^(\d+): ([0-9a-zA-Z@:\.\-_]*?)(@[0-9a-zA-Z]+|):\s/ unless defined? IPROUTE_INT_REGEX
 
-    if File.exist?("/sbin/ip")
-
+    if iproute2_binary_available?
       # families to get default routes from
       families = [{
                     :name => "inet",

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -268,11 +268,21 @@ fe80::21c:eff:fe12:3456 dev eth0.153 lladdr 00:1c:0e:30:28:00 router REACHABLE
     allow(plugin).to receive(:shell_out).with("arp -an").and_return(mock_shell_out(0, linux_arp_an, ""))
   end
 
+  describe "#iproute2_binary_available?" do
+    ["/sbin/ip", "/usr/bin/ip"].each do |path|
+      it "accepts #{path}" do
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with(path).and_return(true)
+        expect(plugin.iproute2_binary_available?).to be_truthy
+      end
+    end
+  end
+
   ["ifconfig","iproute2"].each do |network_method|
 
     describe "gathering IP layer address info via #{network_method}" do
       before(:each) do
-        allow(File).to receive(:exist?).with("/sbin/ip").and_return( network_method == "iproute2" )
+        plugin.stub(:iproute2_binary_available?).and_return( network_method == "iproute2" )
         plugin.run
       end
 
@@ -378,7 +388,7 @@ fe80::21c:eff:fe12:3456 dev eth0.153 lladdr 00:1c:0e:30:28:00 router REACHABLE
 
     describe "gathering interface counters via #{network_method}" do
       before(:each) do
-        allow(File).to receive(:exist?).with("/sbin/ip").and_return( network_method == "iproute2" )
+        plugin.stub(:iproute2_binary_available?).and_return( network_method == "iproute2" )
         plugin.run
       end
 
@@ -416,7 +426,7 @@ fe80::21c:eff:fe12:3456 dev eth0.153 lladdr 00:1c:0e:30:28:00 router REACHABLE
 
     describe "setting the node's default IP address attribute with #{network_method}" do
       before(:each) do
-        allow(File).to receive(:exist?).with("/sbin/ip").and_return( network_method == "iproute2" )
+        plugin.stub(:iproute2_binary_available?).and_return( network_method == "iproute2" )
         plugin.run
       end
 


### PR DESCRIPTION
On Gentoo based distributions the `ip` executable is not linked to `/sbin/ip` but to `/usr/bin/ip`. This fixes #397 Check for both locations. 

A general fix could be:
```
ENV['PATH'].split(File::PATH_SEPARATOR).any? do |directory|
    File.executable?(File.join(directory, "ip"))
  end
```

But maybe overkill. So, let's keep it simple. :)