### PR TITLE
Fix GitHub Issue #432

### DIFF
--- a/lib/ohai/plugins/cloud_v2.rb
+++ b/lib/ohai/plugins/cloud_v2.rb
@@ -124,7 +124,7 @@ Ohai.plugin(:CloudV2) do
   def get_gce_values
     public_ips = gce['instance']['networkInterfaces'].collect do |interface|
       if interface.has_key?('accessConfigs')
-        interface['accessConfigs'].collect{|ac| ac['externalIp']}
+        interface['accessConfigs'].collect{|ac| ac['externalIp'] unless ac['externalIp'] == ''}
       end
     end.flatten.compact
 

--- a/spec/unit/plugins/cloud_v2_spec.rb
+++ b/spec/unit/plugins/cloud_v2_spec.rb
@@ -115,31 +115,62 @@ describe Ohai::System, "plugin cloud" do
   end
 
   describe "with GCE mash" do
-    before do
-      @plugin[:gce] = Mash.new()
-      @plugin[:gce]['instance'] = Mash.new()
-      @plugin[:gce]['instance']['networkInterfaces'] = [
-        {
-          "accessConfigs" => [ {"externalIp" => "8.35.198.173", "type"=>"ONE_TO_ONE_NAT"} ],
-          "ip" => "10.240.0.102",
-          "network"=> "projects/foo/networks/default"
-        }
-      ]
+    describe "with a public IP" do
+      before do
+        @plugin[:gce] = Mash.new()
+        @plugin[:gce]['instance'] = Mash.new()
+        @plugin[:gce]['instance']['networkInterfaces'] = [
+          {
+            "accessConfigs" => [ {"externalIp" => "8.35.198.173", "type"=>"ONE_TO_ONE_NAT"} ],
+            "ip" => "10.240.0.102",
+            "network"=> "projects/foo/networks/default"
+          }
+        ]
+      end
+
+      it "populates cloud public ip" do
+        @plugin.run
+        @plugin[:cloud_v2][:public_ipv4_addrs][0].should == "8.35.198.173"
+      end
+
+      it "populates cloud private ip" do
+        @plugin.run
+        @plugin[:cloud_v2][:local_ipv4_addrs][0].should == "10.240.0.102"
+      end
+
+      it "populates cloud provider" do
+        @plugin.run
+        @plugin[:cloud_v2][:provider].should == "gce"
+      end
     end
 
-    it "populates cloud public ip" do
-      @plugin.run
-      @plugin[:cloud_v2][:public_ipv4_addrs][0].should == "8.35.198.173"
-    end
+    describe "with no public IP" do
+      before do
+        @plugin[:gce] = Mash.new()
+        @plugin[:gce]['instance'] = Mash.new()
+        @plugin[:gce]['instance']['networkInterfaces'] = [
+          {
+            "accessConfigs" => [ {"externalIp" => "", "type" => "ONE_TO_ONE_NAT"} ],
+            "ip" => "10.240.0.102",
+            "network" => "projects/foo/networks/default"
+          }
+        ]
+      end
 
-    it "populates cloud private ip" do
-      @plugin.run
-      @plugin[:cloud_v2][:local_ipv4_addrs][0].should == "10.240.0.102"
-    end
+      it "does not populate cloud public ip" do
+        @plugin.run
+        @plugin[:cloud_v2][:public_ipv4_addrs].should == nil
+      end
 
-    it "populates cloud provider" do
-      @plugin.run
-      @plugin[:cloud_v2][:provider].should == "gce"
+      it "populates cloud private ip" do
+        @plugin.run
+        @plugin[:cloud_v2][:local_ipv4_addrs][0].should == "10.240.0.102"
+      end
+
+      it "populates cloud provider" do
+        @plugin.run
+        @plugin[:cloud_v2][:provider].should == "gce"
+      end
     end
   end
 


### PR DESCRIPTION
Fixes GitHub issue #432: cloud_v2 fails to initialize on GCE hosts without external IP

Resolves a special-case issue where an empty public IP address is not handled correctly, causing cloud_v2 to fail to initialize when a GCE instance does not have a public IP. Spec included.

Obvious fix, though I think I signed the CLA last year anyway.

Closes #432 