### PR TITLE
Simple Windows memory plugin

### DIFF
--- a/lib/ohai/plugins/windows/memory.rb
+++ b/lib/ohai/plugins/windows/memory.rb
@@ -1,0 +1,41 @@
+#
+# Author:: Sean Escriva (<sean.escriva@gmail.com>)
+# Copyright:: Copyright (c) 2014 Sean Escriva
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:Memory) do
+  provides "memory"
+
+  collect_data(:windows) do
+    require 'wmi-lite/wmi'
+
+    memory Mash.new
+    memory[:swap] = Mash.new
+
+    wmi = WmiLite::Wmi.new
+
+    os = wmi.first_of('Win32_OperatingSystem')
+
+    # MemTotal
+    memory[:total] = os["TotalVisibleMemorySize"]
+    # MemFree
+    memory[:free] = os["FreePhysicalMemory"]
+    # SwapTotal
+    memory[:swap][:total] = os["SizeStoredInPagingFiles"]
+    # SwapFree
+    memory[:swap][:free] = os["FreeSpaceInPagingFiles"]
+  end
+end


### PR DESCRIPTION
Perhaps just by platform defaults this info is already in `kernel[:os_info]` on Windows, but this deviates from what is typical on other supported platforms.

For consistency it's helpful to have it accessible as `memory`.

Similar issue was reported in jira as [OHAI-463](https://tickets.opscode.com/browse/OHAI-463)
