### PR TITLE
Fix for removal of :Config in ruby 2.2

### DIFF
--- a/lib/ohai/plugins/ruby.rb
+++ b/lib/ohai/plugins/ruby.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:Ruby) do
   depends "languages"
 
   def run_ruby(command)
-    cmd = "ruby -e \"require 'rbconfig'; #{command}\""
+    cmd = "ruby -e \"require 'rbconfig'; Object.const_set :Config, RbConfig; #{command}\""
     so = shell_out(cmd)
     so.stdout.strip
   end

--- a/lib/ohai/plugins/ruby.rb
+++ b/lib/ohai/plugins/ruby.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:Ruby) do
   depends "languages"
 
   def run_ruby(command)
-    cmd = "ruby -e \"require 'rbconfig'; Object.const_set :Config, RbConfig; #{command}\""
+    cmd = "ruby -e \"require 'rbconfig'; #{command}\""
     so = shell_out(cmd)
     so.stdout.strip
   end
@@ -34,16 +34,16 @@ Ohai.plugin(:Ruby) do
       :platform => "RUBY_PLATFORM",
       :version => "RUBY_VERSION",
       :release_date => "RUBY_RELEASE_DATE",
-      :target => "::Config::CONFIG['target']",
-      :target_cpu => "::Config::CONFIG['target_cpu']",
-      :target_vendor => "::Config::CONFIG['target_vendor']",
-      :target_os => "::Config::CONFIG['target_os']",
-      :host => "::Config::CONFIG['host']",
-      :host_cpu => "::Config::CONFIG['host_cpu']",
-      :host_os => "::Config::CONFIG['host_os']",
-      :host_vendor => "::Config::CONFIG['host_vendor']",
-      :bin_dir => "::Config::CONFIG['bindir']",
-      :ruby_bin => "::File.join(::Config::CONFIG['bindir'], ::Config::CONFIG['ruby_install_name'])"
+      :target => "RbConfig::CONFIG['target']",
+      :target_cpu => "RbConfig::CONFIG['target_cpu']",
+      :target_vendor => "RbConfig::CONFIG['target_vendor']",
+      :target_os => "RbConfig::CONFIG['target_os']",
+      :host => "RbConfig::CONFIG['host']",
+      :host_cpu => "RbConfig::CONFIG['host_cpu']",
+      :host_os => "RbConfig::CONFIG['host_os']",
+      :host_vendor => "RbConfig::CONFIG['host_vendor']",
+      :bin_dir => "RbConfig::CONFIG['bindir']",
+      :ruby_bin => "::File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])"
     }
 
     # Create a query string from above hash


### PR DESCRIPTION
Ohai ruby attribute detection is broken on ruby 2.2 due to removal of Config module which has been deprecated in favour of RbConfig for some time.  The ruby plugin uses :Config::CONFIG['foo'] which errors with Constant Config not defined.

This fix alters the ruby invocation to replace the :Config constant with RbConfig. 

The spec passes.