### PR TITLE
ssh_host_key: detect ed25519 host key

### DIFF
--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -28,6 +28,8 @@ Ohai.plugin(:SSHHostKey) do
       [ "rsa", nil ]
     when /^ecdsa/
       [ "ecdsa", content[0] ]
+    when 'ssh-ed25519'
+      [ 'ed25519', nil ]
     else
       [ nil, nil ]
     end
@@ -72,6 +74,10 @@ Ohai.plugin(:SSHHostKey) do
       content = IO.read("/etc/ssh/ssh_host_ecdsa_key.pub")
       keys[:ssh][:host_ecdsa_public] = content.split[1]
       keys[:ssh][:host_ecdsa_type] = content.split[0]
+    end
+
+    if keys[:ssh][:host_ed25519_public].nil? && File.exists?("/etc/ssh/ssh_host_ed25519_key.pub")
+      keys[:ssh][:host_ed25519_public] = IO.read("/etc/ssh/ssh_host_ed25519_key.pub").split[1]
     end
   end
 end

--- a/spec/unit/plugins/ssh_host_keys_spec.rb
+++ b/spec/unit/plugins/ssh_host_keys_spec.rb
@@ -30,6 +30,7 @@ describe Ohai::System, "ssh_host_key plugin" do
     allow(File).to receive(:exists?).with("/etc/ssh/ssh_host_dsa_key.pub").and_return(true)
     allow(File).to receive(:exists?).with("/etc/ssh/ssh_host_rsa_key.pub").and_return(true)
     allow(File).to receive(:exists?).with("/etc/ssh/ssh_host_ecdsa_key.pub").and_return(true)
+    allow(File).to receive(:exists?).with("/etc/ssh/ssh_host_ed25519_key.pub").and_return(true)
 
     # Ensure we can still use IO.read
     io_read = IO.method(:read)
@@ -39,9 +40,11 @@ describe Ohai::System, "ssh_host_key plugin" do
     @dsa_key = "ssh-dss AAAAB3NzaC1kc3MAAACBAMHlT02xN8kietxPfhcb98xHueTzKCOTz6dZlP/dmKILHrQOAExuSEeNiA2uvmhHNVQvs/cBsRiDxgSKux3ie2q8+MB6vHCiSpSkoPjrL75iT57YDilCB4/sytt6IJpj+H42wRDWTX0/QRybMHUvmnmEL0cwZXykSvrIum0BKB6hAAAAFQDsi6WUCClhtZIiTY9uh8eAre+SbQAAAIEAgNnuw0uEuqtcVif+AYd/bCZvL9FPqg7DrmTkamNEcVinhUGwsPGJTLJf+o5ens1X4RzQoi1R6Y6zCTL2FN/hZgINJNO0z9BN402wWrZmQd+Vb1U5DyDtveuvipqyQS+fm9neRwdLuv36Fc9f9nkZ7YHpkGPJp+yJpG4OoeREhwgAAACBAIf9kKLf2XiXnlByzlJ2Naa55d/hp2E059VKCRsBS++xFKYKvSqjnDQBFiMtAUhb8EdTyBGyalqOgqogDQVtwHfTZWZwqHAhry9aM06y92Eu/xSey4tWjKeknOsnRe640KC4zmKDBRTrjjkuAdrKPN9k3jl+OCc669JHlIfo6kqf oppa"
     @rsa_key = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAuhcVXV+nNapkyUC5p4TH1ymRxUjtMBKqYWmwyI29gVFnUNeHkKFHWon0KFeGJP2Rm8BfTiZa9ER9e8pRr4Nd+z1C1o0kVoxEEfB9tpSdTlpk1GG83D94l57fij8THRVIwuCEosViUlg1gDgC4SpxbqfdBkUN2qyf6JDOh7t2QpYh7berpDEWeBpb7BKdLEDT57uw7ijKzSNyaXqq8KkB9I+UFrRwpuos4W7ilX+PQ+mWLi2ZZJfTYZMxxVS+qJwiDtNxGCRwTOQZG03kI7eLBZG+igupr0uD4o6qeftPOr0kxgjoPU4nEKvYiGq8Rqd2vYrhiaJHLk9QB6xStQvS3Q== oppa"
     @ecdsa_key = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBx8VgvxmHxs/sIn/ATh0iUcuz1I2Xc0e1ejXCGHBMZ98IE3FBt1ezlqCpNMcHVV2skQQ8vyLbKxzweyZuNSDU8= oppa"
+    @ed25519_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFYGnIM5K5JaRxbMCqz8cPMmLp57ZoJQvA5Tlj18EO6H djb"
     allow(IO).to receive(:read).with("/etc/ssh/ssh_host_dsa_key.pub").and_return(@dsa_key)
     allow(IO).to receive(:read).with("/etc/ssh/ssh_host_rsa_key.pub").and_return(@rsa_key)
     allow(IO).to receive(:read).with("/etc/ssh/ssh_host_ecdsa_key.pub").and_return(@ecdsa_key)
+    allow(IO).to receive(:read).with("/etc/ssh/ssh_host_ed25519_key.pub").and_return(@ed25519_key)
   end
 
   shared_examples "loads keys" do
@@ -62,6 +65,12 @@ describe Ohai::System, "ssh_host_key plugin" do
       expect(@plugin[:keys][:ssh][:host_ecdsa_public]).to eql(@ecdsa_key.split[1])
       expect(@plugin[:keys][:ssh][:host_ecdsa_type]).to eql(@ecdsa_key.split[0])
     end
+
+    it "reads the key and sets the ed25519 attribute correctly" do
+      @plugin.run
+      expect(@plugin[:keys][:ssh][:host_ed25519_public]).to eql(@ed25519_key.split[1])
+      expect(@plugin[:keys][:ssh][:host_ed25519_type]).to be_nil
+    end
   end
 
   context "when an sshd_config exists" do
@@ -71,6 +80,7 @@ describe Ohai::System, "ssh_host_key plugin" do
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
 EOS
     end
     it_behaves_like "loads keys"
@@ -83,6 +93,7 @@ EOS
 #HostKey /etc/ssh/ssh_host_rsa_key
 #HostKey /etc/ssh/ssh_host_dsa_key
 #HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
 EOS
     end
     it_behaves_like "loads keys"


### PR DESCRIPTION
Starting with openssh 6.5 also ed25519 keys are supported. As openssh
6.6 und 6.7 are packaged in trusty / jessie, they become common. This
patch extends the ssh host key ohai plugin to extract also
ed25519 host key.