### PR TITLE
Archlinux Version

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -87,6 +87,7 @@ Ohai.plugin(:Platform) do
       platform "arch"
       # no way to determine platform_version in a rolling release distribution
       # kernel release will be used - ex. 2.6.32-ARCH
+      platform_version File.read("/proc/version").scan(/Linux version (\d+\.+) /)
     elsif File.exists?('/etc/exherbo-release')
       platform "exherbo"
       # no way to determine platform_version in a rolling release distribution

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -16,12 +16,9 @@
 # limitations under the License.
 #
 
-#require 'ohai/plugin/kernel'
-
 Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_family"
   depends "lsb"
-  depends "kernel"
 
   def get_redhatish_platform(contents)
     contents[/^Red Hat/i] ? "redhat" : contents[/(\w+)/i, 1].downcase

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -16,9 +16,12 @@
 # limitations under the License.
 #
 
+#require 'ohai/plugin/kernel'
+
 Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_family"
   depends "lsb"
+  depends "kernel"
 
   def get_redhatish_platform(contents)
     contents[/^Red Hat/i] ? "redhat" : contents[/(\w+)/i, 1].downcase
@@ -87,11 +90,12 @@ Ohai.plugin(:Platform) do
       platform "arch"
       # no way to determine platform_version in a rolling release distribution
       # kernel release will be used - ex. 2.6.32-ARCH
-      platform_version File.read("/proc/version").scan(/Linux version (\d+\.+) /)
+      platform_version `uname -r`.strip
     elsif File.exists?('/etc/exherbo-release')
       platform "exherbo"
       # no way to determine platform_version in a rolling release distribution
       # kernel release will be used - ex. 3.13
+      platform_version `uname -r`.strip
     elsif lsb[:id] =~ /RedHat/i
       platform "redhat"
       platform_version lsb[:release]

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -203,6 +203,13 @@ describe Ohai::System, "Linux plugin platform" do
       expect(@plugin[:platform]).to eq("exherbo")
       expect(@plugin[:platform_family]).to eq("exherbo")
     end
+
+    it "should set platform_version to kernel release" do
+      expect(@plugin).to receive(:`).with('uname -r').and_return('3.18.2-2-ARCH')
+      @plugin.run
+      expect(@plugin[:platform_version]).to eq('3.18.2-2-ARCH')
+    end
+
   end
 
   describe "on redhat breeds" do

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -170,6 +170,12 @@ describe Ohai::System, "Linux plugin platform" do
       expect(@plugin[:platform_family]).to eq("arch")
     end
 
+    it "should set platform_version to kernel release" do
+      expect(@plugin).to receive(:`).with('uname -r').and_return('3.18.2-2-ARCH')
+      @plugin.run
+      expect(@plugin[:platform_version]).to eq('3.18.2-2-ARCH')
+    end
+
   end
 
   describe "on gentoo" do


### PR DESCRIPTION
Solves #2843, and is a better alternative to PR #2844, since it solves the cause of the issue (lack of platform_version) instead of patching the symptoms every time it is encountered.

Ohai doesn't get a platform_version for rolling-release linux distributions. This causes problems when platform_version is assumed to exist elsewhere in chef (such as spec/spec_helper.rb)

Uses the kernel version (uname -r) as the platform version for rolling-release distros

closes #405 