### PR TITLE
Expand version number constraint for mime-types dependency

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_dependency "mime-types", "~> 1.16"
+  s.add_dependency "mime-types", ">= 1.16"
   s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "ffi-yajl", "~> 1.1"
   s.add_dependency "mixlib-cli"


### PR DESCRIPTION
The mime-types version constraint has been changed from '~> 1.16' to '>= 1.16' so it will no longer cause Bundler conflicts with gems that specify a current version of the mime-types gem (e.g. CarrierWave).  (The ~> 1.16 constraint doesn't match anything more recent than June 2012.)  All tests are passing.