### PR TITLE
extending with LVM device data

### DIFF
--- a/lib/ohai/plugins/linux/block_device.rb
+++ b/lib/ohai/plugins/linux/block_device.rb
@@ -40,6 +40,11 @@ Ohai.plugin(:BlockDevice) do
             File.open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
+        %w{name suspended uuid}.each do |check|
+          if File.exists?("/sys/block/#{dir}/dm/#{check}")
+            File.open?("/sys/block/#{dir}/dm/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+          end
+        end
       end
       block_device block
     end


### PR DESCRIPTION
Adding in additional values for block devices which are managed by LVM to include their associated logical volume name, suspended state, and uuid values


Before
```
"dm-0": {
  "size": "7806976",
  "removable": "0"
},
```

After
```
"dm-0": {
  "size": "7806976",
  "removable": "0",
  "name": "systemdisk-swap",
  "suspended": "0",
  "uuid": "LVM-EPxeR947k60ioTXkH3Zn8g1lp0sai3u4bcSipYslmhGE3rtV0T1khJIpuovkMDE6"
},
```
