### PR TITLE
Add a trailing dot to avoid using search option in resolv.conf

### DIFF
--- a/lib/ohai/mixin/gce_metadata.rb
+++ b/lib/ohai/mixin/gce_metadata.rb
@@ -21,7 +21,7 @@ module Ohai
   module Mixin
     module GCEMetadata
 
-      GCE_METADATA_ADDR = "metadata.google.internal" unless defined?(GCE_METADATA_ADDR)
+      GCE_METADATA_ADDR = "metadata.google.internal." unless defined?(GCE_METADATA_ADDR)
       GCE_METADATA_URL = "/computeMetadata/v1beta1/?recursive=true" unless defined?(GCE_METADATA_URL)
 
       def can_metadata_connect?(addr, port, timeout=2)

--- a/lib/ohai/mixin/gce_metadata.rb
+++ b/lib/ohai/mixin/gce_metadata.rb
@@ -21,6 +21,7 @@ module Ohai
   module Mixin
     module GCEMetadata
 
+      # Trailing dot to host is added to avoid DNS search path
       GCE_METADATA_ADDR = "metadata.google.internal." unless defined?(GCE_METADATA_ADDR)
       GCE_METADATA_URL = "/computeMetadata/v1beta1/?recursive=true" unless defined?(GCE_METADATA_URL)
 


### PR DESCRIPTION
This PR fixes issue 399 to don't expand a FQDN without a trailing dot to avoid being detected as GCE in other cloud providers 


Fixes #399