### PR TITLE
Workaround for hyperic/sigar#48, throw on 0 pid

### DIFF
--- a/lib/ohai/plugins/network_listeners.rb
+++ b/lib/ohai/plugins/network_listeners.rb
@@ -39,6 +39,11 @@ Ohai.plugin(:NetworkListeners) do
       listeners[port][:address] = addr
       begin
         pid = sigar.proc_port(conn.type, port)
+        # workaround for a failure of proc_state to throw
+        # after the first 0 has been supplied to it
+        #
+        # no longer required when hyperic/sigar#48 is fixed
+        throw ArgumentError.new("No such process") if pid == 0
         listeners[port][:pid] = pid
         listeners[port][:name] = sigar.proc_state(pid).name
       rescue


### PR DESCRIPTION
When proc_state is called for the second and all future times on a
single sigar instance, it fails to throw an exception, resulting in
invalid memory access during ohai reporting of process names. This
workaround causes an invalid pid (0) to be caught and prevent the
invalid access.  Closes #423 and will be unnecessary and should be
reverted when hyperic/sigar#48 is resolved.