### PR TITLE
Bump version to 8.1.0

### DIFF
--- a/lib/ohai/version.rb
+++ b/lib/ohai/version.rb
@@ -18,5 +18,5 @@
 
 module Ohai
   OHAI_ROOT = File.expand_path(File.dirname(__FILE__))
-  VERSION = '8.0.1'
+  VERSION = '8.1.0'
 end


### PR DESCRIPTION
Reason for 8.1.0 vs 8.0.2 was because of https://github.com/chef/ohai/commit/f0b89f760099e5d773b6dd815245123ae412b30e