### PR TITLE
Update ip binary detection logic to work on Gentoo/CoreOS

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Network) do
   end
 
   def iproute2_binary_available?
-    ["/sbin/ip", "/usr/bin/ip"].any? { |path| File.exist?(path) }
+    ["/sbin/ip", "/usr/bin/ip", "/bin/ip"].any? { |path| File.exist?(path) }
   end
 
   collect_data(:linux) do


### PR DESCRIPTION
This is a fix for #397 where any Gentoo based OS does not get IP information.  The root cause is the detection logic for the ip command.  Even though shellout to IP on those platforms would work we first check to see if IP exists by looking for ip in specific paths.  We didn't include /bin/ip where Gentoo stores it.  This simply adds that path which should magically make it all work on Gentoo.  I'm not really sure how to write a test for this, but if anyone has ideas/examples I'm open to writing something.