### PR TITLE
Update ohai to use /etc/centos-release if present.

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -59,6 +59,10 @@ Ohai.plugin(:Platform) do
       contents = File.read("/etc/parallels-release").chomp
       platform get_redhatish_platform(contents)
       platform_version contents.match(/(\d\.\d\.\d)/)[0]
+    elsif File.exists?("/etc/centos-release")
+      contents = File.read("/etc/centos-release").chomp
+      platform get_redhatish_platform(contents)
+      platform_version get_redhatish_version(contents)
     elsif File.exists?("/etc/redhat-release")
       contents = File.read("/etc/redhat-release").chomp
       platform get_redhatish_platform(contents)

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -26,6 +26,7 @@ describe Ohai::System, "Linux plugin platform" do
     allow(@plugin).to receive(:collect_os).and_return(:linux)
     @plugin[:lsb] = Mash.new
     allow(File).to receive(:exists?).with("/etc/debian_version").and_return(false)
+    allow(File).to receive(:exists?).with("/etc/centos-release").and_return(false)
     allow(File).to receive(:exists?).with("/etc/redhat-release").and_return(false)
     allow(File).to receive(:exists?).with("/etc/gentoo-release").and_return(false)
     allow(File).to receive(:exists?).with("/etc/exherbo-release").and_return(false)


### PR DESCRIPTION
this fixes https://github.com/chef/ohai/issues/517 by preferentially using centos-release over redhat-release.

thanks @cmluciano for pointing out where this was at.