### PR TITLE
Move windows drivers out of kernel

### DIFF
--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -183,23 +183,5 @@ Ohai.plugin(:Kernel) do
 
     kernel[:machine] = machine_lookup("#{kernel[:cs_info][:system_type]}")
 
-    kext = Mash.new
-    pnp_drivers = Mash.new
-
-    drivers = wmi.instances_of('Win32_PnPSignedDriver')
-    drivers.each do |driver|
-      pnp_drivers[driver['deviceid']] = Mash.new
-      driver.wmi_ole_object.properties_.each do |p|
-        pnp_drivers[driver['deviceid']][p.name.wmi_underscore.to_sym] = driver[p.name.downcase]
-      end
-      if driver['devicename']
-        kext[driver['devicename']] = pnp_drivers[driver['deviceid']]
-        kext[driver['devicename']][:version] = pnp_drivers[driver['deviceid']][:driver_version]
-        kext[driver['devicename']][:date] = pnp_drivers[driver['deviceid']][:driver_date] ? pnp_drivers[driver['deviceid']][:driver_date].to_s[0..7] : nil
-      end
-    end
-
-    kernel[:pnp_drivers] = pnp_drivers
-    kernel[:modules] = kext
   end
 end

--- a/lib/ohai/plugins/windows/drivers.rb
+++ b/lib/ohai/plugins/windows/drivers.rb
@@ -1,0 +1,47 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:Drivers) do
+  provides "kernel/pnp_drivers", "kernel/modules"
+  depends "kernel"
+
+  collect_data(:windows) do
+    require 'wmi-lite/wmi'
+
+    wmi = WmiLite::Wmi.new
+
+    kext = Mash.new
+    pnp_drivers = Mash.new
+
+    drivers = wmi.instances_of('Win32_PnPSignedDriver')
+    drivers.each do |driver|
+      pnp_drivers[driver['deviceid']] = Mash.new
+      driver.wmi_ole_object.properties_.each do |p|
+        pnp_drivers[driver['deviceid']][p.name.wmi_underscore.to_sym] = driver[p.name.downcase]
+      end
+      if driver['devicename']
+        kext[driver['devicename']] = pnp_drivers[driver['deviceid']]
+        kext[driver['devicename']][:version] = pnp_drivers[driver['deviceid']][:driver_version]
+        kext[driver['devicename']][:date] = pnp_drivers[driver['deviceid']][:driver_date] ? pnp_drivers[driver['deviceid']][:driver_date].to_s[0..7] : nil
+      end
+    end
+
+    kernel[:pnp_drivers] = pnp_drivers
+    kernel[:modules] = kext
+
+  end
+end

--- a/spec/unit/plugins/kernel_spec.rb
+++ b/spec/unit/plugins/kernel_spec.rb
@@ -74,11 +74,10 @@ describe Ohai::System, "plugin kernel" do
       cs_wmi = WmiLite::Wmi::Instance.new(cs)
 
       expect_any_instance_of(WmiLite::Wmi).to receive(:first_of).with('Win32_ComputerSystem').and_return(cs_wmi)
-      expect_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with('Win32_PnPSignedDriver').and_return([])
 
       @plugin.run
     end
-    it "should set the corrent system information" do
+    it "should set the correct system information" do
       expect(@ohai_system.data[:kernel][:name]).to eq("Microsoft Windows 7 Ultimate")
       expect(@ohai_system.data[:kernel][:release]).to eq("6.1.7601")
       expect(@ohai_system.data[:kernel][:version]).to eq("6.1.7601 Service Pack 1 Build 7601")


### PR DESCRIPTION
With the introduction of minimal-ohai in chef, we don't want to
grab a bunch of garbage

cc @danielsdeleo @btm @smurawski @thommay @adamedx 

This needs to go out with minimal-ohai so that it's not a breaking change