### PR TITLE
Work correctly when IPv6 is disabled on Linux

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -33,6 +33,10 @@ Ohai.plugin(:Network) do
     encap
   end
 
+  def ipv6_enabled?
+    File.exist? "/proc/net/if_inet6"
+  end
+
   def iproute2_binary_available?
     ["/sbin/ip", "/usr/bin/ip", "/bin/ip"].any? { |path| File.exist?(path) }
   end
@@ -60,12 +64,14 @@ Ohai.plugin(:Network) do
                     :default_route => "0.0.0.0/0",
                     :default_prefix => :default,
                     :neighbour_attribute => :arp
-                  },{
+                  }]
+
+      families << {
                     :name => "inet6",
                     :default_route => "::/0",
                     :default_prefix => :default_inet6,
                     :neighbour_attribute => :neighbour_inet6
-                  }]
+                  } if ipv6_enabled?
 
       so = shell_out("ip addr")
       cint = nil


### PR DESCRIPTION
Right now, ohai will return v4 addresses and routes for v6, rather than
just not returning anything. Fixes #380