### PR TITLE
force ohai output to UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Ohai Changelog
 
+## Unreleased
+
+* [PR #548](https://github.com/chef/ohai/548):
+  Coerce non-UTF8 strings to UTF8 in output to suppress UTF8 encoding exceptions
+
 ## Release 8.4.0
 
 * Correctly skip unwanted DMI information

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -178,7 +178,7 @@ module Ohai
     # Pretty Print this object as JSON
     #
     def json_pretty_print(item=nil)
-      FFI_Yajl::Encoder.new(:pretty => true).encode(item || @data)
+      FFI_Yajl::Encoder.new(pretty: true, validate_utf8: false).encode(item || @data)
     end
 
     def attributes_print(a)

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "mime-types", "~> 2.0"
   s.add_dependency "systemu", "~> 2.6.4"
-  s.add_dependency "ffi-yajl", ">= 1.1", "< 3.0"
+  s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "mixlib-cli"
   s.add_dependency "mixlib-config", "~> 2.0"
   s.add_dependency "mixlib-log"


### PR DESCRIPTION
replaces invalid characters in the rendered JSON and avoids throwing
an exception at that stage.