### PR TITLE
Adds a --profile option to Ohai

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -94,17 +94,15 @@ class Ohai::Application
   def run_application
     ohai = Ohai::System.new
     ohai.all_plugins(@attributes)
+    ohai.data['ohai'] = ohai.profile
 
     if @attributes
+      @attributes << 'ohai' if Ohai::Config[:profiling]
       @attributes.each do |a|
         puts ohai.attributes_print(a)
       end
     else
       puts ohai.json_pretty_print
-    end
-    if Ohai::Config[:profiling]
-      puts ohai.json_pretty_print(
-        { Elapsed_millisecs_by_plugin: ohai.profile} )
     end
   end
 

--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -56,6 +56,11 @@ class Ohai::Application
     :proc         => lambda {|v| puts "Ohai: #{::Ohai::VERSION}"},
     :exit         => 0
 
+  option :profiling,
+    :short        => "-p",
+    :long         => "--profiling",
+    :boolean      => true
+
   def initialize
     super
 
@@ -95,6 +100,9 @@ class Ohai::Application
       end
     else
       puts ohai.json_pretty_print
+    end
+    if Ohai::Config[:profiling]
+      puts ohai.json_pretty_print({ Profile: ohai.profile} )
     end
   end
 

--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -59,6 +59,7 @@ class Ohai::Application
   option :profiling,
     :short        => "-p",
     :long         => "--profiling",
+    :description  => "Show elapsed time per plugin",
     :boolean      => true
 
   def initialize
@@ -102,7 +103,8 @@ class Ohai::Application
       puts ohai.json_pretty_print
     end
     if Ohai::Config[:profiling]
-      puts ohai.json_pretty_print({ Profile: ohai.profile} )
+      puts ohai.json_pretty_print(
+        { Elapsed_millisecs_by_plugin: ohai.profile} )
     end
   end
 


### PR DESCRIPTION
Simple add of millisecond profiling to ohai, as suggested by @johnbellone

``` bash
ohai -p cpu
...
{
  "real": 4,
  "total": 8,
  "mhz": 2800
}
{
  "Profile": {
    "CPU": 48
  }
}
```

or with out the attributes:

```
ohai -p
{
  "snip": true,
  "current_user": "pburkholder",
  "root_group": "wheel"
}
{
  "Profile": {
    "CPU": 91,
    "Filesystem": 16,
    "Kernel": 127,
    "Drivers": 0,
    "Memory": 12,
    "Network": 80,
    "NetworkRoutes": 10,
    "NetworkListeners": 38,
    "NetworkAddresses": 1,
    "Platform": 13,
    "Uptime": 17,
    "Virtualization": 1,
    "Joyent": 0,
    "VirtualizationInfo": 0,
    "Azure": 0,
    "C": 146,
    "Elixir": 5,
    "Erlang": 3,
    "Go": 3,
    "Groovy": 4,
    "Java": 254,
    "Languages": 0,
    "Lua": 21,
    "Mono": 4,
    "Nodejs": 20,
    "Perl": 24,
    "PHP": 121,
    "Powershell": 1,
    "Python": 55,
    "Ruby": 995,
    "Rust": 5,
    "Chef": 1,
    "Ohai": 0,
    "Cloud": 99,
    "CloudV2": 0,
    "Command": 0,
    "PS": 0,
    "SystemProfile": 821,
    "DigitalOcean": 0,
    "DMI": 6,
    "EC2": 0,
    "Eucalyptus": 0,
    "OS": 0,
    "GCE": 0,
    "Hostname": 18,
    "InitPackage": 1,
    "IpScopes": 0,
    "Keys": 0,
    "SSHHostKey": 1,
    "Linode": 0,
    "BlockDevice": 0,
    "LSB": 0,
    "Mdadm": 0,
    "OhaiTime": 0,
    "Openstack": 0,
    "Passwd": 26,
    "Rackspace": 0,
    "RootGroup": 1,
    "Zpools": 0
  }
}
```
