### PR TITLE
Fix windows 2008 hostname truncation 

### DIFF
--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -151,7 +151,7 @@ Ohai.plugin(:Hostname) do
     wmi = WmiLite::Wmi.new
     host = wmi.first_of('Win32_ComputerSystem')
 
-    hostname "#{host['name']}"
+    hostname "#{host['dnshostname']}"
     machinename "#{host['name']}"
 
     info = Socket.gethostbyname(Socket.gethostname)


### PR DESCRIPTION
On Windows 2008 R2 (and possibly other versions of Windows), `node['hostname']` returns only the first 15 characters of the hostname--this breaks for machines with hostnames longer than 15 chars. This commit changes the WMI attribute that populates `node['hostname']` to be one that provides the full hostname. The truncated version is preserved in `machinename`.