### PR TITLE
Fix my_mountpoint view in filesystem2; add tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,7 +47,10 @@ Unlike the 'filesystem' plugin, it provides 3 views into the data:
   be a symlink to /proc/mounts it can still have data loss due to different
   mount options, or multiple virtualfs mounts with the same fake device name.
 * `by_mount` similar to the above but indexed by mountpoint. Won't include
-  unmounted filesystems, of course.
+  unmounted filesystems, of course. Instead of a 'device' entry it has a
+  'devices' entry that is an array. Similar to the 'by_device' view, this extra
+  feature can solve many problems of of the old filesystem plugin, but may still
+  have data loss on things like mount options.
 
 It is recommended to always use `by_pair` when iterating or wanting a full view
 of storage devices. The other two are provided for convenient lookup. Other

--- a/lib/ohai/plugins/darwin/filesystem2.rb
+++ b/lib/ohai/plugins/darwin/filesystem2.rb
@@ -43,8 +43,12 @@ Ohai.plugin(:Filesystem2) do
       next unless entry[:mount]
       view[entry[:mount]] = Mash.new unless view[entry[:mount]]
       entry.each do |key, val|
-        next if key == 'mount'
+        next if ['mount', 'device'].include?(key)
         view[entry[:mount]][key] = val
+      end
+      if entry[:device]
+        view[entry[:mount]][:devices] = [] unless view[entry[:mount]][:devices]
+        view[entry[:mount]][:devices] << entry[:device]
       end
     end
     view

--- a/lib/ohai/plugins/linux/filesystem2.rb
+++ b/lib/ohai/plugins/linux/filesystem2.rb
@@ -78,8 +78,12 @@ Ohai.plugin(:Filesystem2) do
       next unless entry[:mount]
       view[entry[:mount]] = Mash.new unless view[entry[:mount]]
       entry.each do |key, val|
-        next if key == 'mount'
+        next if ['mount', 'device'].include?(key)
         view[entry[:mount]][key] = val
+      end
+      if entry[:device]
+        view[entry[:mount]][:devices] = [] unless view[entry[:mount]][:devices]
+        view[entry[:mount]][:devices] << entry[:device]
       end
     end
     view

--- a/spec/unit/plugins/darwin/filesystem2_spec.rb
+++ b/spec/unit/plugins/darwin/filesystem2_spec.rb
@@ -93,4 +93,47 @@ MOUNT
       expect(@plugin[:filesystem2]["by_pair"]["/dev/disk0s2,/"][:mount_options]).to eq([ "local", "journaled" ])
     end
   end
+
+  describe "when gathering filesystem data with devices mounted more than once" do
+    before(:each) do
+      @dfstdout = <<-DF
+Filesystem           512-blocks      Used Available Capacity  iused    ifree %iused  Mounted on
+/dev/disk0s2          488555536 313696448 174347088    65% 39276054 21793386   64%   /
+devfs                       385       385         0   100%      666        0  100%   /dev
+map /etc/auto.direct          0         0         0   100%        0        0  100%   /mnt/vol
+map -hosts                    0         0         0   100%        0        0  100%   /net
+map -static                   0         0         0   100%        0        0  100%   /mobile_symbol
+deweyfs@osxfuse0              0         0         0   100%        0        0  100%   /mnt/dewey
+/dev/disk0s2          488555536 313696448 174347088    65% 39276054 21793386 64%   /another/mountpoint
+DF
+      allow(@plugin).to receive(:shell_out).with("df -i").and_return(mock_shell_out(0, @dfstdout, ""))
+    end
+
+    it "should provide a devices view with all mountpoints" do
+      @plugin.run
+      expect(@plugin[:filesystem2]["by_device"]["/dev/disk0s2"][:mounts]).to eq(['/', '/another/mountpoint'])
+    end
+  end
+
+  describe "when gathering filesystem data with double-mounts" do
+    before(:each) do
+      @dfstdout = <<-DF
+Filesystem           512-blocks      Used Available Capacity  iused    ifree %iused  Mounted on
+/dev/disk0s2          488555536 313696448 174347088    65% 39276054 21793386   64%   /
+devfs                       385       385         0   100%      666        0  100%   /dev
+map /etc/auto.direct          0         0         0   100%        0        0  100%   /mnt/vol
+map -hosts                    0         0         0   100%        0        0  100%   /net
+map -static                   0         0         0   100%        0        0  100%   /mobile_symbol
+deweyfs@osxfuse0              0         0         0   100%        0        0  100%   /mnt/dewey
+/dev/disk0s3          488555536 313696448 174347088    65% 39276054 21793386 64% /mnt
+/dev/disk0s4          488555536 313696448 174347088    65% 39276054 21793386 64% /mnt
+DF
+      allow(@plugin).to receive(:shell_out).with("df -i").and_return(mock_shell_out(0, @dfstdout, ""))
+    end
+
+    it "should provide a mounts view with all devices" do
+      @plugin.run
+      expect(@plugin[:filesystem2]["by_mountpoint"]["/mnt"][:devices]).to eq(['/dev/disk0s3', '/dev/disk0s4'])
+    end
+  end
 end


### PR DESCRIPTION
The same trick for by_device to list multiple pointpoints should be in
by_mounpoint for multiple devices.

Add tests for both alternative views.