### PR TITLE
Fix #531: Docker changed their cgroups format

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -190,8 +190,9 @@ Ohai.plugin(:Virtualization) do
     # Full notes, https://tickets.opscode.com/browse/OHAI-551
     # Kernel docs, https://www.kernel.org/doc/Documentation/cgroups
     if File.exists?("/proc/self/cgroup")
-      if File.read("/proc/self/cgroup") =~ %r{^\d+:[^:]+:/(lxc|docker)/.+$} ||
-         File.read("/proc/self/cgroup") =~ %r{^\d+:[^:]+:/[^/]+/(lxc|docker)-.+$}
+      cgroup_content = File.read("/proc/self/cgroup")
+      if cgroup_content =~ %r{^\d+:[^:]+:/(lxc|docker)/.+$} ||
+         cgroup_content =~ %r{^\d+:[^:]+:/[^/]+/(lxc|docker)-.+$}
         virtualization[:system] = $1
         virtualization[:role] = "guest"
         virtualization[:systems][$1.to_sym] = "guest"

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -190,7 +190,8 @@ Ohai.plugin(:Virtualization) do
     # Full notes, https://tickets.opscode.com/browse/OHAI-551
     # Kernel docs, https://www.kernel.org/doc/Documentation/cgroups
     if File.exists?("/proc/self/cgroup")
-      if File.read("/proc/self/cgroup") =~ %r{^\d+:[^:]+:/(lxc|docker)/.+$}
+      if File.read("/proc/self/cgroup") =~ %r{^\d+:[^:]+:/(lxc|docker)/.+$} ||
+         File.read("/proc/self/cgroup") =~ %r{^\d+:[^:]+:/[^/]+/(lxc|docker)-.+$}
         virtualization[:system] = $1
         virtualization[:role] = "guest"
         virtualization[:systems][$1.to_sym] = "guest"

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -513,7 +513,9 @@ CGROUP
       expect(plugin[:virtualization][:systems][:docker]).to eq("guest")
     end
 
-    it "should set docker guest if /proc/self/cgroup exists and there are /system.slice/docker-<hexadecimal> mounts" do
+    # Relevant at least starting docker 1.6.2, kernel 4.0.5 & systemd 224-1.
+    # Doi not exactly know which software/version really matters here.
+    it "should set docker guest if /proc/self/cgroup exists and there are /system.slice/docker-<hexadecimal> mounts (systemd managed cgroup)" do
       self_cgroup=<<-CGROUP
 8:devices:/system.slice/docker-47341c91be8d491cb3b8a475ad5b4aef6e79bf728cbb351c384e4a6c410f172f.scope
 7:cpuset:/system.slice/docker-47341c91be8d491cb3b8a475ad5b4aef6e79bf728cbb351c384e4a6c410f172f.scope

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -513,6 +513,25 @@ CGROUP
       expect(plugin[:virtualization][:systems][:docker]).to eq("guest")
     end
 
+    it "should set docker guest if /proc/self/cgroup exists and there are /system.slice/docker-<hexadecimal> mounts" do
+      self_cgroup=<<-CGROUP
+8:devices:/system.slice/docker-47341c91be8d491cb3b8a475ad5b4aef6e79bf728cbb351c384e4a6c410f172f.scope
+7:cpuset:/system.slice/docker-47341c91be8d491cb3b8a475ad5b4aef6e79bf728cbb351c384e4a6c410f172f.scope
+6:blkio:/system.slice/docker-47341c91be8d491cb3b8a475ad5b4aef6e79bf728cbb351c384e4a6c410f172f.scope
+5:freezer:/system.slice/docker-47341c91be8d491cb3b8a475ad5b4aef6e79bf728cbb351c384e4a6c410f172f.scope
+4:net_cls:/
+3:memory:/system.slice/docker-47341c91be8d491cb3b8a475ad5b4aef6e79bf728cbb351c384e4a6c410f172f.scope
+2:cpu,cpuacct:/system.slice/docker-47341c91be8d491cb3b8a475ad5b4aef6e79bf728cbb351c384e4a6c410f172f.scope
+1:name=systemd:/system.slice/docker-47341c91be8d491cb3b8a475ad5b4aef6e79bf728cbb351c384e4a6c410f172f.scope
+CGROUP
+      allow(File).to receive(:exists?).with("/proc/self/cgroup").and_return(true)
+      allow(File).to receive(:read).with("/proc/self/cgroup").and_return(self_cgroup)
+      @plugin.run
+      expect(@plugin[:virtualization][:system]).to eq("docker")
+      expect(@plugin[:virtualization][:role]).to eq("guest")
+      expect(@plugin[:virtualization][:systems][:docker]).to eq("guest")
+    end
+
     it "sets not set anything if /proc/self/cgroup exist and the cgroup is named arbitrarily, it isn't necessarily lxc." do
       self_cgroup=<<-CGROUP
 8:blkio:/Charlie

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -529,9 +529,9 @@ CGROUP
       allow(File).to receive(:exists?).with("/proc/self/cgroup").and_return(true)
       allow(File).to receive(:read).with("/proc/self/cgroup").and_return(self_cgroup)
       plugin.run
-      expect(@plugin[:virtualization][:system]).to eq("docker")
-      expect(@plugin[:virtualization][:role]).to eq("guest")
-      expect(@plugin[:virtualization][:systems][:docker]).to eq("guest")
+      expect(plugin[:virtualization][:system]).to eq("docker")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+      expect(plugin[:virtualization][:systems][:docker]).to eq("guest")
     end
 
     it "sets not set anything if /proc/self/cgroup exist and the cgroup is named arbitrarily, it isn't necessarily lxc." do

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -526,7 +526,7 @@ CGROUP
 CGROUP
       allow(File).to receive(:exists?).with("/proc/self/cgroup").and_return(true)
       allow(File).to receive(:read).with("/proc/self/cgroup").and_return(self_cgroup)
-      @plugin.run
+      plugin.run
       expect(@plugin[:virtualization][:system]).to eq("docker")
       expect(@plugin[:virtualization][:role]).to eq("guest")
       expect(@plugin[:virtualization][:systems][:docker]).to eq("guest")


### PR DESCRIPTION
Take into account new cgroup format for docker.
Tested with docker 1.6.2 on Debian sid with kernel 4.0.5