### PR TITLE
filesystem2 bugfix

### DIFF
--- a/lib/ohai/plugins/linux/filesystem2.rb
+++ b/lib/ohai/plugins/linux/filesystem2.rb
@@ -64,8 +64,8 @@ Ohai.plugin(:Filesystem2) do
         next if ['device', 'mount'].include?(key)
         view[entry[:device]][key] = val
       end
+      view[entry[:device]][:mounts] = [] unless view[entry[:device]][:mounts]
       if entry[:mount]
-        view[entry[:device]][:mounts] = [] unless view[entry[:device]][:mounts]
         view[entry[:device]][:mounts] << entry[:mount]
       end
     end
@@ -81,8 +81,8 @@ Ohai.plugin(:Filesystem2) do
         next if ['mount', 'device'].include?(key)
         view[entry[:mount]][key] = val
       end
+      view[entry[:mount]][:devices] = [] unless view[entry[:mount]][:devices]
       if entry[:device]
-        view[entry[:mount]][:devices] = [] unless view[entry[:mount]][:devices]
         view[entry[:mount]][:devices] << entry[:device]
       end
     end

--- a/lib/ohai/plugins/linux/filesystem2.rb
+++ b/lib/ohai/plugins/linux/filesystem2.rb
@@ -64,7 +64,7 @@ Ohai.plugin(:Filesystem2) do
         next if ['device', 'mount'].include?(key)
         view[entry[:device]][key] = val
       end
-      view[entry[:device]][:mounts] = [] unless view[entry[:device]][:mounts]
+      view[entry[:device]][:mounts] ||= []
       if entry[:mount]
         view[entry[:device]][:mounts] << entry[:mount]
       end
@@ -81,7 +81,7 @@ Ohai.plugin(:Filesystem2) do
         next if ['mount', 'device'].include?(key)
         view[entry[:mount]][key] = val
       end
-      view[entry[:mount]][:devices] = [] unless view[entry[:mount]][:devices]
+      view[entry[:mount]][:devices] ||= []
       if entry[:device]
         view[entry[:mount]][:devices] << entry[:device]
       end


### PR DESCRIPTION
This makes 'mounts' in by_device and 'devices' in by_mount always get
initialized as an empty array instead of not existing. if the data doesn't
exist. This prevents callers from having to do

```
if foo and foo['mounts'] and foo['mounts'].emtpy?
```

to determine if something is mounted.