### PR TITLE
Deprecate Ohai::Config in favor of Ohai::Config.ohai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   Detect Parallels host and guest virtualisation
 * [**Phil Dibowitz**](https://github.com/jymzh):
   Fix Darwin filesystem plugin on newer MacOSX
+* [**Claire McQuin**](https://github.com/mcquin):
+  Deprecate Ohai::Config in favor of Ohai::Config.ohai.
 
 ## Release 8.5.0
 

--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -7,3 +7,16 @@ Description of the required change.
 -->
 
 # Ohai Doc Changes:
+
+## Ohai::Config[:configurable] is deprecated, use Ohai::Config.ohai
+`Ohai::Config` is deprecated in favor of `Ohai::Config.ohai`. Configuring ohai
+using `Ohai::Config` is deprecated and will be removed in future releases of
+ohai.
+
+The [Ohai Settings](https://docs.chef.io/config_rb_client.html#ohai-settings)
+subsection of the `client.rb` documentation should be updated to use
+`ohai.option` instead of `Ohai::Config[:option]`.
+
+If there is any mention of the ability to access configuration options via
+`Ohai::Config`, it should be updated to `Ohai::Config.ohai`. Additionally, it
+should be mentioned that `Ohai.config` is an alias for `Ohai::Config.ohai`.

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ group :development do
   gem "sigar", :platform => "ruby"
   gem 'plist'
 
-  # gem 'pry-debugger'
+  # gem 'pry-byebug'
   # gem 'pry-stack_explorer'
 end

--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -82,8 +82,8 @@ class Ohai::Application
   end
 
   def configure_logging
-    Ohai::Log.init(Ohai::Config[:log_location])
-    Ohai::Log.level = Ohai::Config[:log_level]
+    Ohai::Log.init(Ohai.config[:log_location])
+    Ohai::Log.level = Ohai.config[:log_level]
   end
 
   def run_application
@@ -103,12 +103,12 @@ class Ohai::Application
     # Log a fatal error message to both STDERR and the Logger, exit the application
     def fatal!(msg, err = -1)
       STDERR.puts("FATAL: #{msg}")
-      Chef::Log.fatal(msg)
+      Ohai::Log.fatal(msg)
       Process.exit err
     end
 
     def exit!(msg, err = -1)
-      Chef::Log.debug(msg)
+      Ohai::Log.debug(msg)
       Process.exit err
     end
   end

--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -74,9 +74,10 @@ class Ohai::Application
     @attributes = parse_options
     @attributes = nil if @attributes.empty?
 
-    Ohai::Config.merge!(config)
-    if Ohai::Config[:directory]
-      Ohai::Config[:plugin_path] << Ohai::Config[:directory]
+    Ohai::Config.merge_deprecated_config
+    Ohai.config.merge!(config)
+    if Ohai.config[:directory]
+      Ohai.config[:plugin_path] << Ohai.config[:directory]
     end
   end
 

--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -17,6 +17,7 @@
 #
 
 require 'mixlib/config'
+require 'ohai/log'
 
 module Ohai
   class Config
@@ -32,7 +33,6 @@ module Ohai
       end
       path
     end
-
 
     default :log_level, :info
     default :log_location, STDERR

--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@opscode.com>)
-# Copyright:: Copyright (c) 2008 Opscode, Inc.
+# Author:: Claire McQuin (<claire@chef.io>)
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,28 +17,109 @@
 # limitations under the License.
 #
 
-require 'mixlib/config'
 require 'ohai/log'
+require 'chef-config/logger'
+
+ChefConfig::Logger = Ohai::Log
+
+require 'chef-config/config'
 
 module Ohai
-  class Config
-    extend Mixlib::Config
+  Config = ChefConfig::Config
 
-    # from chef/config.rb, should maybe be moved to mixlib-config?
-    def self.platform_specific_path(path)
-      if RUBY_PLATFORM =~ /mswin|mingw|windows/
-        # turns /etc/chef/client.rb into C:/chef/client.rb
-        path = File.join(ENV['SYSTEMDRIVE'], path.split('/')[2..-1])
-        # ensure all forward slashes are backslashes
-        path.gsub!(File::SEPARATOR, (File::ALT_SEPARATOR || '\\'))
-      end
-      path
+  # Reopens ChefConfig::Config to add Ohai configuration settings.
+  # see: https://github.com/chef/chef/blob/master/lib/chef/config.rb
+  class Config
+    # These methods need to be defined before they are used as config defaults,
+    # otherwise they will get method_missing'd to nil.
+    private
+    def self.default_hints_path
+      [ platform_specific_path('/etc/chef/ohai/hints') ]
     end
 
+    def self.default_plugin_path
+      [ File.expand_path(File.join(File.dirname(__FILE__), 'plugins')) ]
+    end
+
+    public
+    # Copy deprecated configuration options into the ohai config context.
+    def self.merge_deprecated_config
+      [ :hints_path, :plugin_path ].each do |option|
+        if has_key?(option) && send(option) != send("default_#{option}".to_sym)
+          Ohai::Log.warn(option_deprecated(option))
+        end
+      end
+
+      ohai.merge!(configuration)
+    end
+
+    # Keep "old" config defaults around so anyone calling Ohai::Config[:key]
+    # won't be broken. Also allows users to append to configuration options
+    # (e.g., Ohai::Config[:plugin_path] << some_path) in their config files.
+    default :disabled_plugins, []
+    default :hints_path, default_hints_path
     default :log_level, :info
     default :log_location, STDERR
-    default :plugin_path, [ File.expand_path(File.join(File.dirname(__FILE__), 'plugins'))]
-    default :disabled_plugins, []
-    default(:hints_path) { [ platform_specific_path('/etc/chef/ohai/hints') ] }
+    default :plugin_path, default_plugin_path
+
+    # Log deprecation warning when a top-level configuration option is set.
+    # TODO: Should we implement a config_attr_reader so that deprecation
+    # warnings will be generatd on read?
+    [
+      :directory,
+      :disabled_plugins,
+      :log_level,
+      :log_location,
+      :version
+    ].each do |option|
+      # https://docs.chef.io/config_rb_client.html#ohai-settings
+      # hints_path and plugin_path are intentionally excluded here; warnings for
+      # setting these attributes are generated in merge_deprecated_config since
+      # append (<<) operations bypass the config writer.
+      config_attr_writer option do |value|
+        # log_level and log_location are common configuration options for chef
+        # and other chef applications. When configuration files are read there
+        # is no distinction between log_level and Ohai::Config[:log_level] and
+        # we may emit a false deprecation warning. The deprecation warnings for
+        # these settings reflect that possibility.
+        # Furthermore, when the top-level config settings are removed we will
+        # need to ensure that Ohai.config[:log_level] can be set by writing
+        # log_level in a configuration file for consistent behavior with chef.
+        deprecation_warning = [ :log_level, :log_location ].include?(value) ?
+          option_might_be_deprecated(option) : option_deprecated(option)
+        Ohai::Log.warn(deprecation_warning)
+        value
+      end
+    end
+
+    config_context :ohai do
+      default :disabled_plugins, []
+      default :hints_path, Ohai::Config.default_hints_path
+      default :log_level, :info
+      default :log_location, STDERR
+      default :plugin_path, Ohai::Config.default_plugin_path
+    end
+
+    private
+    def self.option_deprecated(option)
+      <<-EOM.chomp!.gsub("\n", " ")
+Ohai::Config[:#{option}] is set. Ohai::Config[:#{option}] is deprecated and will
+be removed in future releases of ohai. Use ohai.#{option} in your configuration
+file to configure :#{option} for ohai.
+EOM
+    end
+
+    def self.option_might_be_deprecated(option)
+      option_deprecated(option) + <<-EOM.chomp!.gsub("\n", " ")
+ If your configuration file is used with other applications which configure
+:#{option}, and you have not configured Ohai::Config[:#{option}], you may
+disregard this warning.
+EOM
+    end
+  end
+
+  # Shortcut for Ohai::Config.ohai
+  def self.config
+    Config::ohai
   end
 end

--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -34,7 +34,7 @@ module Ohai
     # otherwise they will get method_missing'd to nil.
     private
     def self.default_hints_path
-      [ platform_specific_path('/etc/chef/ohai/hints') ]
+      [ ChefConfig::Config.platform_specific_path('/etc/chef/ohai/hints') ]
     end
 
     def self.default_plugin_path

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -92,7 +92,7 @@ module Ohai
       def run
         @has_run = true
 
-        if Ohai::Config[:disabled_plugins].include?(name)
+        if Ohai.config[:disabled_plugins].include?(name)
           Ohai::Log.debug("Skipping disabled plugin #{name}")
         else
           run_plugin

--- a/lib/ohai/hints.rb
+++ b/lib/ohai/hints.rb
@@ -29,7 +29,7 @@ module Ohai
       @hints ||= Hash.new
       return @hints[name] if @hints[name]
 
-      Ohai::Config[:hints_path].each do |path|
+      Ohai.config[:hints_path].each do |path|
         filename = File.join(path, "#{name}.json")
         if File.exist?(filename)
           begin

--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -24,7 +24,7 @@ require 'pathname'
 module Ohai
 
   # Ohai plugin loader. Finds all the plugins in your
-  # `Ohai::Config[:plugin_path]` (supports a single or multiple path setting
+  # `Ohai.config[:plugin_path]` (supports a single or multiple path setting
   # here), evaluates them and returns plugin objects.
   class Loader
 
@@ -57,7 +57,7 @@ module Ohai
     # Searches all plugin paths and returns an Array of PluginFile objects
     # representing each plugin file.
     def plugin_files_by_dir
-      Array(Ohai::Config[:plugin_path]).inject([]) do |plugin_files, plugin_path|
+      Array(Ohai.config[:plugin_path]).inject([]) do |plugin_files, plugin_path|
         plugin_files + PluginFile.find_all_in(plugin_path)
       end
     end

--- a/lib/ohai/log.rb
+++ b/lib/ohai/log.rb
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,15 +16,14 @@
 # limitations under the License.
 #
 
-require 'ohai/config'
 require 'mixlib/log'
 
 module Ohai
   class Log
     extend Mixlib::Log
-    
-    init(Ohai::Config[:log_location])
-    level = Ohai::Config[:log_level]
-    
+
+    init(STDERR)
+    level = :info
+
   end
 end

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -49,8 +49,8 @@ module Ohai
       @v6_dependency_solver = Hash.new
 
       # configure logging
-      Ohai::Log.init(Ohai::Config[:log_location])
-      Ohai::Log.level = Ohai::Config[:log_level]
+      Ohai::Log.init(Ohai.config[:log_location])
+      Ohai::Log.level = Ohai.config[:log_level]
 
       @loader = Ohai::Loader.new(self)
       @runner = Ohai::Runner.new(self, true)

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -48,6 +48,10 @@ module Ohai
 
       @v6_dependency_solver = Hash.new
 
+      # configure logging
+      Ohai::Log.init(Ohai::Config[:log_location])
+      Ohai::Log.level = Ohai::Config[:log_level]
+
       @loader = Ohai::Loader.new(self)
       @runner = Ohai::Runner.new(self, true)
 

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ipaddress"
   s.add_dependency "wmi-lite", "~> 1.0"
   s.add_dependency "ffi", "~> 1.9"
+  s.add_dependency "chef-config", "~> 12.4"
 
   s.add_dependency "rake", "~> 10.1"
   s.add_development_dependency "rspec-core", "~> 3.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require 'spec/support/platform_helpers'
 require 'spec/support/integration_helper'
 require 'wmi-lite'
 require 'ohai'
-Ohai::Config[:log_level] = :error
+Ohai.config[:log_level] = :error
 
 PLUGIN_PATH = File.expand_path("../../lib/ohai/plugins", __FILE__)
 SPEC_PLUGIN_PATH = File.expand_path("../data/plugins", __FILE__)
@@ -118,6 +118,10 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.before :each do
+    # TODO: Change to Ohai.config once Ohai::Config is deprecated fully. Needs
+    # to stay Ohai::Config for now so that top-level attributes will get cleared
+    # out between tests (config_spec should be the only place where top-level
+    # config attributes are set).
     Ohai::Config.reset
   end
 end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -1,0 +1,88 @@
+#
+# Author:: Claire McQuin <claire@chef.io>
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative '../spec_helper'
+
+require 'ohai/application'
+
+RSpec.describe 'Ohai::Application' do
+
+  let(:argv) { [] }
+  let(:app) { Ohai::Application.new }
+
+  before(:each) do
+    @original_argv = ARGV
+    ARGV.replace(argv)
+  end
+
+  after(:each) do
+    ARGV.replace(@original_argv)
+  end
+
+  describe '#configure_ohai' do
+    it 'merges deprecated config settings into the ohai config context' do
+      expect(Ohai::Config).to receive(:merge_deprecated_config)
+      app.configure_ohai
+    end
+
+    context 'when CLI options are provided' do
+      let(:argv) { [ '-d', directory ] }
+      let(:directory) { '/some/fantastic/plugins' }
+
+      it 'does not generate deprecated config warnings for cli options' do
+        expect(Ohai::Log).to_not receive(:warn).
+          with(/Ohai::Config\[:directory\] is deprecated/)
+        app.configure_ohai
+      end
+
+      it 'merges CLI options into the ohai config context' do
+        app.configure_ohai
+        expect(Ohai.config[:directory]).to eq(directory)
+      end
+    end
+
+    context 'when directory is configured' do
+      let(:directory) { '/some/fantastic/plugins' }
+
+      shared_examples_for 'directory' do
+        it 'adds directory to plugin_path' do
+          app.configure_ohai
+          expect(Ohai.config[:plugin_path]).to include(directory)
+        end
+      end
+
+      context 'in a configuration file' do
+        before do
+          allow(Ohai::Log).to receive(:warn).
+            with(/Ohai::Config\[:directory\] is deprecated/)
+          Ohai::Config[:directory] = directory
+        end
+
+        include_examples 'directory'
+      end
+
+      context 'as a command line option' do
+        let(:argv) { ['-d', directory] }
+
+        include_examples 'directory'
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,0 +1,140 @@
+#
+# Author:: Claire McQuin (<claire@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative '../spec_helper'
+
+require 'ohai/config'
+
+RSpec.describe Ohai::Config do
+
+  describe "top-level configuration options" do
+    shared_examples_for "option" do
+      it "logs a deprecation warning and sets the value" do
+        expect(Ohai::Log).to receive(:warn).
+          with(/Ohai::Config\[:#{option}\] is deprecated/)
+        Ohai::Config[option] = value
+        expect(Ohai::Config[option]).to eq(value)
+      end
+    end
+
+    shared_examples_for "appendable option" do
+      it "sets the value" do
+        expect(Ohai::Log).to_not receive(:warn)
+        Ohai::Config[option] << value
+        expect(Ohai::Config[option]).to include(value)
+      end
+    end
+
+    describe ":directory" do
+      include_examples "option" do
+        let(:option) { :directory }
+        let(:value)  { "/some/fantastic/plugins" }
+      end
+    end
+
+    describe ":disabled_plugins" do
+      include_examples "option" do
+        let(:option) { :disabled_plugins }
+        let(:value)  { [ :Foo, :Baz ] }
+      end
+    end
+
+    describe ":hints_path" do
+      include_examples "appendable option" do
+        let(:option) { :hints_path }
+        let(:value)  { "/some/helpful/hints" }
+      end
+    end
+
+    describe ":log_level" do
+      include_examples "option" do
+        let(:option) { :log_level }
+        let(:value)  { :cheese }
+      end
+    end
+
+    describe ":log_location" do
+      include_examples "option" do
+        let(:option) { :log_location }
+        let(:value)  { "/etc/chef/cache/loooogs" }
+      end
+    end
+
+    describe ":plugin_path" do
+      include_examples "appendable option" do
+        let(:option) { :plugin_path }
+        let(:value)  { "/some/fantastic/plugins" }
+      end
+    end
+
+    describe ":version" do
+      include_examples "option" do
+        let(:option) { :version }
+        let(:value)  { "8.2.0" }
+      end
+    end
+  end
+
+  describe "::merge_deprecated_config" do
+    before(:each) do
+      allow(Ohai::Log).to receive(:warn)
+      configure_ohai
+    end
+
+    def configure_ohai
+      Ohai::Config[:directory] = "/some/fantastic/plugins"
+      Ohai::Config[:disabled_plugins] = [ :Foo, :Baz ]
+      Ohai::Config[:log_level] = :debug
+    end
+
+    it "merges top-level config values into the ohai config context" do
+      Ohai::Config.merge_deprecated_config
+      expect(Ohai::Config.ohai.configuration).to eq (Ohai::Config.configuration)
+    end
+
+    shared_examples_for "delayed warn" do
+      it "logs a deprecation warning and merges the value" do
+        expect(Ohai::Log).to receive(:warn).
+          with(/Ohai::Config\[:#{option}\] is deprecated/)
+        Ohai::Config[option] << value
+        Ohai::Config.merge_deprecated_config
+        expect(Ohai::Config.ohai[option]).to include(value)
+      end
+    end
+
+    context "when :hints_path is set" do
+      include_examples "delayed warn" do
+        let(:option) { :hints_path }
+        let(:value)  { "/some/helpful/hints" }
+      end
+    end
+
+    context "when :plugin_path is set" do
+      include_examples "delayed warn" do
+        let(:option) { :plugin_path }
+        let(:value)  { "/some/fantastic/plugins" }
+      end
+    end
+  end
+
+  describe "Ohai.config" do
+    it "returns the ohai config context" do
+      expect(Ohai.config).to eq(Ohai::Config.ohai)
+    end
+  end
+end

--- a/spec/unit/dsl/plugin_spec.rb
+++ b/spec/unit/dsl/plugin_spec.rb
@@ -38,7 +38,7 @@ shared_examples "Ohai::DSL::Plugin" do
 
     describe "when plugin is enabled" do
       before do
-        allow(Ohai::Config).to receive(:[]).with(:disabled_plugins).and_return([ ])
+        allow(Ohai.config).to receive(:[]).with(:disabled_plugins).and_return([ ])
       end
 
       it "should run the plugin" do
@@ -54,7 +54,7 @@ shared_examples "Ohai::DSL::Plugin" do
 
     describe "if the plugin is disabled" do
       before do
-        allow(Ohai::Config).to receive(:[]).with(:disabled_plugins).and_return([ :TestPlugin ])
+        allow(Ohai.config).to receive(:[]).with(:disabled_plugins).and_return([ :TestPlugin ])
       end
 
       it "should not run the plugin" do

--- a/spec/unit/hints_spec.rb
+++ b/spec/unit/hints_spec.rb
@@ -24,16 +24,16 @@ describe "Ohai::Hints" do
   extend IntegrationSupport
 
   before do
-    @original_hints = Ohai::Config[:hints_path]
+    @original_hints = Ohai.config[:hints_path]
   end
 
   after do
-    Ohai::Config[:hints_path] = @original_hints
+    Ohai.config[:hints_path] = @original_hints
   end
 
   when_plugins_directory "doesn't contain any hints" do
     before do
-      Ohai::Config[:hints_path] = [ path_to(".") ]
+      Ohai.config[:hints_path] = [ path_to(".") ]
     end
 
     it "hint? should return nil" do
@@ -50,7 +50,7 @@ EOF
 EOF
 
     before do
-      Ohai::Config[:hints_path] = [ path_to(".") ]
+      Ohai.config[:hints_path] = [ path_to(".") ]
     end
 
     it "hint? should return the data for full hints" do

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -51,8 +51,7 @@ provides 'fish'
 EOF
 
     before do
-      @original_config = Ohai::Config[:plugin_path]
-      Ohai::Config[:plugin_path] = [ path_to(".") ]
+      Ohai.config[:plugin_path] = [ path_to(".") ]
     end
 
     it "load_plugins() should load all the plugins" do
@@ -85,12 +84,7 @@ provides 'bear'
 EOF
 
     before do
-      @original_config = Ohai::Config[:plugin_path]
-      Ohai::Config[:plugin_path] = [ path_to("repo1"), path_to("repo2") ]
-    end
-
-    after do
-      Ohai::Config[:plugin_path] = @original_config
+      Ohai.config[:plugin_path] = [ path_to("repo1"), path_to("repo2") ]
     end
 
     it "load_plugins() should load all the plugins" do
@@ -106,14 +100,6 @@ EOF
   end
 
   describe "when running plugins" do
-    before do
-      @original_config = Ohai::Config[:plugin_path]
-    end
-
-    after do
-      Ohai::Config[:plugin_path] = @original_config
-    end
-
     when_plugins_directory "contains v6 plugins only" do
       with_plugin("zoo.rb", <<EOF)
 provides 'zoo'
@@ -126,7 +112,7 @@ park("plants")
 EOF
 
       it "should collect data from all the plugins" do
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
+        Ohai.config[:plugin_path] = [ path_to(".") ]
         ohai.all_plugins
         expect(ohai.data[:zoo]).to eq("animals")
         expect(ohai.data[:park]).to eq("plants")
@@ -134,15 +120,15 @@ EOF
 
       describe "when using :disabled_plugins" do
         before do
-          Ohai::Config[:disabled_plugins] = [ "zoo" ]
+          Ohai.config[:disabled_plugins] = [ "zoo" ]
         end
 
         after do
-          Ohai::Config[:disabled_plugins] = [ ]
+          Ohai.config[:disabled_plugins] = [ ]
         end
 
         it "shouldn't run disabled version 6 plugins" do
-          Ohai::Config[:plugin_path] = [ path_to(".") ]
+          Ohai.config[:plugin_path] = [ path_to(".") ]
           ohai.all_plugins
           expect(ohai.data[:zoo]).to be_nil
           expect(ohai.data[:park]).to eq("plants")
@@ -245,7 +231,7 @@ end
 EOF
 
       it "should collect platform specific" do
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
+        Ohai.config[:plugin_path] = [ path_to(".") ]
         ohai.all_plugins
         expect(ohai.data[:message]).to eq("platform_specific_message")
       end
@@ -272,14 +258,14 @@ end
 EOF
 
       it "should collect data from all the plugins" do
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
+        Ohai.config[:plugin_path] = [ path_to(".") ]
         ohai.all_plugins
         expect(ohai.data[:zoo]).to eq("animals")
         expect(ohai.data[:park]).to eq("plants")
       end
 
       it "should write an error to Ohai::Log" do
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
+        Ohai.config[:plugin_path] = [ path_to(".") ]
         # Make sure the stubbing of runner is not overriden with reset_system during test
         allow(ohai).to receive(:reset_system)
         allow(ohai.instance_variable_get("@runner")).to receive(:run_plugin).and_raise(Ohai::Exceptions::AttributeNotFound)
@@ -289,15 +275,15 @@ EOF
 
       describe "when using :disabled_plugins" do
         before do
-          Ohai::Config[:disabled_plugins] = [ :Zoo ]
+          Ohai.config[:disabled_plugins] = [ :Zoo ]
         end
 
         after do
-          Ohai::Config[:disabled_plugins] = [ ]
+          Ohai.config[:disabled_plugins] = [ ]
         end
 
         it "shouldn't run disabled plugins" do
-          Ohai::Config[:plugin_path] = [ path_to(".") ]
+          Ohai.config[:plugin_path] = [ path_to(".") ]
           ohai.all_plugins
           expect(ohai.data[:zoo]).to be_nil
           expect(ohai.data[:park]).to eq("plants")
@@ -338,15 +324,15 @@ EOF
 
       describe "when using :disabled_plugins" do
         before do
-          Ohai::Config[:disabled_plugins] = [ :Zoo, 'my_plugins::park' ]
+          Ohai.config[:disabled_plugins] = [ :Zoo, 'my_plugins::park' ]
         end
 
         after do
-          Ohai::Config[:disabled_plugins] = [ ]
+          Ohai.config[:disabled_plugins] = [ ]
         end
 
         it "shouldn't run disabled plugins" do
-          Ohai::Config[:plugin_path] = [ path_to(".") ]
+          Ohai.config[:plugin_path] = [ path_to(".") ]
           ohai.all_plugins
           expect(ohai.data[:zoo]).to be_nil
           expect(ohai.data[:nature]).to eq("cougars")
@@ -384,12 +370,7 @@ end
 EOF
 
       before do
-        @original_config = Ohai::Config[:plugin_path]
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
-      end
-
-      after do
-         Ohai::Config[:plugin_path] = @original_config
+        Ohai.config[:plugin_path] = [ path_to(".") ]
       end
 
       it "should collect all data" do
@@ -427,12 +408,7 @@ end
 EOF
 
       before do
-        @original_config = Ohai::Config[:plugin_path]
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
-      end
-
-      after do
-         Ohai::Config[:plugin_path] = @original_config
+        Ohai.config[:plugin_path] = [ path_to(".") ]
       end
 
       it "version 6 should run" do
@@ -475,12 +451,7 @@ end
 EOF
 
       before do
-        @original_config = Ohai::Config[:plugin_path]
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
-      end
-
-      after do
-         Ohai::Config[:plugin_path] = @original_config
+        Ohai.config[:plugin_path] = [ path_to(".") ]
       end
 
       it "should collect all the data properly" do
@@ -502,12 +473,7 @@ message v7message
 EOF
 
       before do
-        @original_config = Ohai::Config[:plugin_path]
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
-      end
-
-      after do
-         Ohai::Config[:plugin_path] = @original_config
+        Ohai.config[:plugin_path] = [ path_to(".") ]
       end
 
       it "should raise DependencyNotFound" do
@@ -525,12 +491,7 @@ EOF
       E
 
       before do
-        @original_config = Ohai::Config[:plugin_path]
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
-      end
-
-      after do
-        Ohai::Config[:plugin_path] = @original_config
+        Ohai.config[:plugin_path] = [ path_to(".") ]
       end
 
       it "reloads only the v6 plugin when given a specific plugin to load" do
@@ -552,12 +513,7 @@ EOF
       E
 
       before do
-        @original_config = Ohai::Config[:plugin_path]
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
-      end
-
-      after do
-        Ohai::Config[:plugin_path] = @original_config
+        Ohai.config[:plugin_path] = [ path_to(".") ]
       end
 
       it "should rerun the plugin providing the desired attributes" do
@@ -611,15 +567,10 @@ EOF
       E
 
       before do
-        @original_config = Ohai::Config[:plugin_path]
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
+        Ohai.config[:plugin_path] = [ path_to(".") ]
         Ohai::Log.init(STDOUT)
         Ohai::Log.level = :debug
         ohai.all_plugins
-      end
-
-      after do
-        Ohai::Config[:plugin_path] = @original_config
       end
 
       it "should rerun the plugin providing the desired attributes" do
@@ -682,12 +633,7 @@ EOF
       E
 
       before do
-        @original_config = Ohai::Config[:plugin_path]
-        Ohai::Config[:plugin_path] = [ path_to(".") ]
-      end
-
-      after do
-        Ohai::Config[:plugin_path] = @original_config
+        Ohai.config[:plugin_path] = [ path_to(".") ]
       end
 
       it "should run all the plugins when a top level attribute is specified" do


### PR DESCRIPTION
Implements the following from [rfc053](https://github.com/chef/chef-rfc/blob/master/rfc053-ohai-config.md):

- Create config context `Ohai::Config.ohai`
- Create shortcut `Ohai.config` for `Ohai::Config.ohai`
- Deprecates top-level attributes of `Ohai::Config`

@chef/client-maintainers @chef/client-core 