### PR TITLE
better KVM virtualization detection

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -146,6 +146,10 @@ Ohai.plugin(:Virtualization) do
         virtualization[:system] = "openstack"
         virtualization[:role] = "guest"
         virtualization[:systems][:openstack] = "guest"
+      when /Manufacturer: QEMU/
+        virtualization[:system] = "kvm"
+        virtualization[:role] = "guest"
+        virtualization[:systems][:kvm] = "guest"
       else
         nil
       end


### PR DESCRIPTION
Properly detect KVM using DMI, which is useful when the CPU vendor/model is masked (e.g. when mirroring the host CPU).