### PR TITLE
Ohai::Application loads configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   Fix Darwin filesystem plugin on newer MacOSX
 * [**Claire McQuin**](https://github.com/mcquin):
   Deprecate Ohai::Config in favor of Ohai::Config.ohai.
+* [**Claire McQuin**](https://github.com/mcquin):
+  Load a configuration file while running as an application.
 
 ## Release 8.5.0
 

--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -20,3 +20,13 @@ subsection of the `client.rb` documentation should be updated to use
 If there is any mention of the ability to access configuration options via
 `Ohai::Config`, it should be updated to `Ohai::Config.ohai`. Additionally, it
 should be mentioned that `Ohai.config` is an alias for `Ohai::Config.ohai`.
+
+## Load a configuration file while running ohai as an application
+You can specify a configuration file for ohai to load while running as an
+application. For example, if your configuration file is located at
+`~/.chef/config.rb` you can run ohai with that configuration file with
+`ohai -c ~/.chef/config.rb`.
+
+When running ohai as an application and no configuration file is specified
+as a command line parameter, ohai will load a configuration file from your
+workstation (`config.rb` or `knife.rb`) if one is found.

--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -73,7 +73,6 @@ class Ohai::Application
 
   def run
     configure_ohai
-    configure_logging
     run_application
   end
 
@@ -82,20 +81,10 @@ class Ohai::Application
     @attributes = nil if @attributes.empty?
 
     load_workstation_config
-    Ohai::Config.merge_deprecated_config
-    Ohai.config.merge!(config)
-    if Ohai.config[:directory]
-      Ohai.config[:plugin_path] << Ohai.config[:directory]
-    end
-  end
-
-  def configure_logging
-    Ohai::Log.init(Ohai.config[:log_location])
-    Ohai::Log.level = Ohai.config[:log_level]
   end
 
   def run_application
-    ohai = Ohai::System.new
+    ohai = Ohai::System.new(config)
     ohai.all_plugins(@attributes)
 
     if @attributes

--- a/spec/functional/application_spec.rb
+++ b/spec/functional/application_spec.rb
@@ -1,0 +1,154 @@
+#
+# Author:: Claire McQuin <claire@chef.io>
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative '../spec_helper'
+
+require 'ohai/application'
+
+RSpec.describe 'Ohai::Application' do
+
+  let(:app) { Ohai::Application.new }
+  let(:argv) { [] }
+  let(:stderr) { StringIO.new }
+
+  before(:each) do
+    @original_argv = ARGV.dup
+    ARGV.replace(argv)
+  end
+
+  after(:each) do
+    ARGV.replace(@original_argv)
+  end
+
+  describe '#configure_ohai' do
+
+    let(:config_content) { '' }
+    let(:config_dir) { Dir.mktmpdir('.chef') }
+    let(:config_location) { File.join(config_dir, 'config.rb') }
+
+    before(:each) do
+      File.open(config_location, 'w+') do |f|
+        f.write(config_content)
+      end
+    end
+
+    after(:each) do
+      FileUtils.rm_rf(config_dir)
+    end
+
+    context 'when a configuration file is provided as a command line option' do
+
+      let(:argv) { [ '-c', config_location + '.oops' ] }
+
+      context 'and the configuration file does not exist' do
+
+        it 'logs an error and terminates the application' do
+          expect(STDERR).to receive(:puts).with(/FATAL:/)
+          expect(Ohai::Log).to receive(:fatal).
+            with(/Specified config file #{argv[1]} does not exist/)
+          expect { app.configure_ohai }.to raise_error(SystemExit)
+        end
+      end
+    end
+
+    context 'when a workstation configuration file exists' do
+
+      let(:config_content) { 'ohai.disabled_plugins = [ :Foo, :Baz ]' }
+
+      # env['KNIFE_HOME']/config.rb is the first config file the workstation
+      # config loader looks for:
+      # https://github.com/chef/chef/blob/master/chef-config/lib/chef-config/workstation_config_loader.rb#L102
+      let(:env) { { 'KNIFE_HOME' => config_dir } }
+
+      before(:each) do
+        allow_any_instance_of(ChefConfig::WorkstationConfigLoader).
+          to receive(:env).and_return(env)
+      end
+
+      it 'loads the workstation configuration file' do
+        app.configure_ohai
+        expect(Ohai.config[:disabled_plugins]).to eq([ :Foo, :Baz ])
+      end
+    end
+
+    context 'when the configuration file contains deprecated config options' do
+      # For the purpose of these tests it doesn't matter if the configuration
+      # file was specified via command line or discovered on the local
+      # workstation. It's easier if we pass the configuration file as a cli
+      # argument (there's less to stub).
+
+      let(:argv) { [ '-c', config_location ] }
+
+      let(:config_content) do
+        <<-CONFIG
+log_location "#{log_location}"
+log_level    :#{log_level}
+Ohai::Config[:disabled_plugins] = #{disabled_plugins}
+Ohai::Config[:plugin_path] << "#{plugin_path}"
+CONFIG
+      end
+
+      # config settings
+      let(:disabled_plugins) { [ :Foo, :Baz ] }
+
+      let(:log_level) { :debug }
+
+      let(:log_location) { 'path/to/log' }
+
+      let(:plugin_path) { '/path/to/plugins' }
+
+      it 'logs warnings for deprecated options and merges with Ohai.config' do
+        # deprecation warnings for options need to be stubbed in the order
+        # they are received, in this case it's the order they appear in the
+        # configuration file.
+        options = [ :log_location, :log_level, :disabled_plugins, :plugin_path ]
+        options.each do |option|
+          expect(Ohai::Log).to receive(:warn).
+            with(/Ohai::Config\[:#{option}\] is deprecated/)
+        end
+        app.configure_ohai
+        options.each do |option|
+          if option == :plugin_path
+            expect(Ohai.config[option]).to include(self.send(option))
+          else
+            expect(Ohai.config[option]).to eq(self.send(option))
+          end
+        end
+      end
+    end
+
+    context 'when the configuration file has a syntax error' do
+      # For the purpose of these tests it doesn't matter if the configuration
+      # file was specified via command line or discovered on the local
+      # workstation. It's easier if we pass the configuration file as a cli
+      # argument (there's less to stub).
+
+      let(:argv) { [ '-c', config_location ] }
+
+      let(:config_content) { 'config_location "blaaaaa' }
+
+      it 'logs an error and terminates the application' do
+        expect(STDERR).to receive(:puts).with(/FATAL:/)
+        expect(Ohai::Log).to receive(:fatal).
+          with(/You have invalid ruby syntax in your config file/)
+        expect { app.configure_ohai }.to raise_error(SystemExit)
+      end
+    end
+
+  end
+end

--- a/spec/functional/application_spec.rb
+++ b/spec/functional/application_spec.rb
@@ -112,23 +112,16 @@ CONFIG
 
       let(:plugin_path) { '/path/to/plugins' }
 
-      it 'logs warnings for deprecated options and merges with Ohai.config' do
+      it 'logs warnings for deprecated top-level options' do
         # deprecation warnings for options need to be stubbed in the order
         # they are received, in this case it's the order they appear in the
         # configuration file.
-        options = [ :log_location, :log_level, :disabled_plugins, :plugin_path ]
+        options = [ :log_location, :log_level, :disabled_plugins ]
         options.each do |option|
           expect(Ohai::Log).to receive(:warn).
             with(/Ohai::Config\[:#{option}\] is deprecated/)
         end
         app.configure_ohai
-        options.each do |option|
-          if option == :plugin_path
-            expect(Ohai.config[option]).to include(self.send(option))
-          else
-            expect(Ohai.config[option]).to eq(self.send(option))
-          end
-        end
       end
     end
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -34,17 +34,7 @@ RSpec.describe 'Ohai::Application' do
     ARGV.replace(@original_argv)
   end
 
-  def stub_fatal!(expected_message)
-    expect(STDERR).to receive(:puts).with(expected_message)
-    expect(Ohai::Log).to receive(:fatal).with(expected_message)
-  end
-
   describe '#configure_ohai' do
-    it 'merges deprecated config settings into the ohai config context' do
-      expect(Ohai::Config).to receive(:merge_deprecated_config)
-      app.configure_ohai
-    end
-
     describe 'loading configuration from a file' do
       let(:config_file) { '/local/workstation/config' }
       let(:config_loader) { instance_double('ChefConfig::WorkstationConfigLoader') }
@@ -59,28 +49,15 @@ RSpec.describe 'Ohai::Application' do
         end
 
         it 'loads the configuration file' do
-          expect(config_loader).to receive(:path_exists?).
-            with(config_file).
-            and_return(true)
-          expect(config_loader).to receive(:config_location).
-            and_return(config_file)
-          expect(Ohai::Config).to receive(:from_file).
-            with(config_file)
+          expect(config_loader).to receive(:load)
           app.configure_ohai
         end
 
         context 'when the configuration file does not exist' do
-          let(:expected_message) { Regexp.new("#{config_file} does not exist") }
-
           it 'terminates the application' do
-            expect(config_loader).to receive(:path_exists?).
-              with(config_file).
-              and_return(false)
-            expect(Ohai::Application).to receive(:fatal!).
-              with(expected_message).
-              and_call_original
-            stub_fatal!(expected_message)
-            expect { app.configure_ohai }.to raise_error(SystemExit)
+            expect(config_loader).to receive(:load).and_raise(ChefConfig::ConfigurationError)
+            expect(Ohai::Application).to receive(:fatal!)
+            app.configure_ohai
           end
         end
       end
@@ -93,10 +70,7 @@ RSpec.describe 'Ohai::Application' do
         end
 
         it 'loads the configuration file' do
-          expect(config_loader).to receive(:config_location).
-            and_return(config_file)
-          expect(Ohai::Config).to receive(:from_file).
-            with(config_file)
+          expect(config_loader).to receive(:load)
           app.configure_ohai
         end
       end
@@ -111,40 +85,7 @@ RSpec.describe 'Ohai::Application' do
           with(/Ohai::Config\[:directory\] is deprecated/)
         app.configure_ohai
       end
-
-      it 'merges CLI options into the ohai config context' do
-        app.configure_ohai
-        expect(Ohai.config[:directory]).to eq(directory)
-      end
-    end
-
-    context 'when directory is configured' do
-      let(:directory) { '/some/fantastic/plugins' }
-
-      shared_examples_for 'directory' do
-        it 'adds directory to plugin_path' do
-          app.configure_ohai
-          expect(Ohai.config[:plugin_path]).to include(directory)
-        end
-      end
-
-      context 'in a configuration file' do
-        before do
-          allow(Ohai::Log).to receive(:warn).
-            with(/Ohai::Config\[:directory\] is deprecated/)
-          Ohai::Config[:directory] = directory
-        end
-
-        include_examples 'directory'
-      end
-
-      context 'as a command line option' do
-        let(:argv) { ['-d', directory] }
-
-        include_examples 'directory'
-      end
     end
 
   end
-
 end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -34,10 +34,72 @@ RSpec.describe 'Ohai::Application' do
     ARGV.replace(@original_argv)
   end
 
+  def stub_fatal!(expected_message)
+    expect(STDERR).to receive(:puts).with(expected_message)
+    expect(Ohai::Log).to receive(:fatal).with(expected_message)
+  end
+
   describe '#configure_ohai' do
     it 'merges deprecated config settings into the ohai config context' do
       expect(Ohai::Config).to receive(:merge_deprecated_config)
       app.configure_ohai
+    end
+
+    describe 'loading configuration from a file' do
+      let(:config_file) { '/local/workstation/config' }
+      let(:config_loader) { instance_double('ChefConfig::WorkstationConfigLoader') }
+
+      context 'when specified on the command line' do
+        let(:argv) { [ '-c', config_file ] }
+
+        before(:each) do
+          expect(ChefConfig::WorkstationConfigLoader).to receive(:new).
+            with(config_file, Ohai::Log).
+            and_return(config_loader)
+        end
+
+        it 'loads the configuration file' do
+          expect(config_loader).to receive(:path_exists?).
+            with(config_file).
+            and_return(true)
+          expect(config_loader).to receive(:config_location).
+            and_return(config_file)
+          expect(Ohai::Config).to receive(:from_file).
+            with(config_file)
+          app.configure_ohai
+        end
+
+        context 'when the configuration file does not exist' do
+          let(:expected_message) { Regexp.new("#{config_file} does not exist") }
+
+          it 'terminates the application' do
+            expect(config_loader).to receive(:path_exists?).
+              with(config_file).
+              and_return(false)
+            expect(Ohai::Application).to receive(:fatal!).
+              with(expected_message).
+              and_call_original
+            stub_fatal!(expected_message)
+            expect { app.configure_ohai }.to raise_error(SystemExit)
+          end
+        end
+      end
+
+      context 'when a local workstation config exists' do
+        before(:each) do
+          expect(ChefConfig::WorkstationConfigLoader).to receive(:new).
+            with(nil, Ohai::Log).
+            and_return(config_loader)
+        end
+
+        it 'loads the configuration file' do
+          expect(config_loader).to receive(:config_location).
+            and_return(config_file)
+          expect(Ohai::Config).to receive(:from_file).
+            with(config_file)
+          app.configure_ohai
+        end
+      end
     end
 
     context 'when CLI options are provided' do


### PR DESCRIPTION
Adds support for loading a configuration file when `ohai` is run as an application, as specified in [rfc053](https://github.com/chef/chef-rfc/blob/master/rfc053-ohai-config.md#configuration-files)

@chef/client-core @chef/client-maintainers 