### PR TITLE
remove "warning: already initialized constant ETHERNET_ENCAPS"

### DIFF
--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -53,18 +53,19 @@
 # srcof qfe1
 # inet6 fe80::203:baff:fe17:4444/128
 
+# Extracted from http://illumos.org/hcl/
+ETHERNET_ENCAPS = %w{ afe amd8111s arn atge ath bfe bge bnx bnxe ce cxgbe
+                      dmfe e1000g efe elxl emlxs eri hermon hme hxge igb
+                      iprb ipw iwh iwi iwk iwp ixgb ixgbe mwl mxfe myri10ge
+                      nge ntxn nxge pcn platform qfe qlc ral rge rtls rtw rwd
+                      rwn sfe tavor vr wpi xge yge} unless defined?(ETHERNET_ENCAPS)
+
 Ohai.plugin(:Network) do
   provides "network", "network/interfaces"
   provides "counters/network", "counters/network/interfaces"
 
   def solaris_encaps_lookup(ifname)
-    ethernet_encaps = %w{ afe amd8111s arn atge ath bfe bge bnx bnxe ce cxgbe
-                          dmfe e1000g efe elxl emlxs eri hermon hme hxge igb
-                          iprb ipw iwh iwi iwk iwp ixgb ixgbe mwl mxfe myri10ge
-                          nge ntxn nxge pcn platform qfe qlc ral rge rtls rtw rwd
-                          rwn sfe tavor vr wpi xge yge}.freeze
-
-    return "Ethernet" if ethernet_encaps.include?(ifname)
+    return "Ethernet" if ETHERNET_ENCAPS.include?(ifname)
     return "Ethernet" if ifname.eql?("net")
     return "Loopback" if ifname.eql?("lo")
     "Unknown"

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -53,19 +53,18 @@
 # srcof qfe1
 # inet6 fe80::203:baff:fe17:4444/128
 
-# Extracted from http://illumos.org/hcl/
-ETHERNET_ENCAPS = %w{ afe amd8111s arn atge ath bfe bge bnx bnxe ce cxgbe
-                      dmfe e1000g efe elxl emlxs eri hermon hme hxge igb
-                      iprb ipw iwh iwi iwk iwp ixgb ixgbe mwl mxfe myri10ge
-                      nge ntxn nxge pcn platform qfe qlc ral rge rtls rtw rwd
-                      rwn sfe tavor vr wpi xge yge}
-
 Ohai.plugin(:Network) do
   provides "network", "network/interfaces"
   provides "counters/network", "counters/network/interfaces"
 
   def solaris_encaps_lookup(ifname)
-    return "Ethernet" if ETHERNET_ENCAPS.include?(ifname)
+    ethernet_encaps = %w{ afe amd8111s arn atge ath bfe bge bnx bnxe ce cxgbe
+                          dmfe e1000g efe elxl emlxs eri hermon hme hxge igb
+                          iprb ipw iwh iwi iwk iwp ixgb ixgbe mwl mxfe myri10ge
+                          nge ntxn nxge pcn platform qfe qlc ral rge rtls rtw rwd
+                          rwn sfe tavor vr wpi xge yge}.freeze
+
+    return "Ethernet" if ethernet_encaps.include?(ifname)
     return "Ethernet" if ifname.eql?("net")
     return "Loopback" if ifname.eql?("lo")
     "Unknown"


### PR DESCRIPTION
Remove definition of `ETHERNET_ENCAPS` as a constant and move it into the plugin body as a frozen array to avoid annoying warnings during test runs.