### PR TITLE
rspec_junit_formatter has been released with RSpec3 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
-# https://github.com/sj26/rspec_junit_formatter/pull/14
-# rspec_junit_formatter isn't compatible with RSpec3 yet, but is fixed in
-# master. Once it's released we should remove this.
-gem "rspec_junit_formatter", :git => 'https://github.com/sj26/rspec_junit_formatter.git',
-                             :ref => "147836c41fab23ff7b92806f34122c8e5f2ddcad"
-
 group :development do
-  gem "chef", github: "opscode/chef", branch: "master"
+  gem "chef", github: "chef/chef", branch: "master"
 
   gem "sigar", :platform => "ruby"
   gem 'plist'

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.license = "Apache-2.0"
   s.author = "Adam Jacob"
-  s.email = "adam@opscode.com"
-  s.homepage = "https://docs.getchef.com/ohai.html"
+  s.email = "adam@chef.io"
+  s.homepage = "https://docs.chef.io/ohai.html"
 
   s.required_ruby_version = ">= 2.0.0"
 
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-expectations", "~> 3.0"
   s.add_development_dependency "rspec-mocks", "~> 3.0"
   s.add_development_dependency "rspec-collection_matchers", "~> 1.0"
-#  s.add_development_dependency "rspec_junit_formatter"
+  s.add_development_dependency "rspec_junit_formatter"
   s.add_development_dependency "chef"
   s.bindir = "bin"
   s.executables = %w(ohai)


### PR DESCRIPTION
Remove pinning.

Also clean up .gemspec for domain name, etc.