### PR TITLE
Update the chef-config dependency version to be compatible with chef

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -25,7 +25,15 @@ Gem::Specification.new do |s|
   s.add_dependency "ipaddress"
   s.add_dependency "wmi-lite", "~> 1.0"
   s.add_dependency "ffi", "~> 1.9"
-  s.add_dependency "chef-config", "~> 12.4"
+  # Note for ohai developers: If chef-config causes you grief, try:
+  #     bundle install --with development
+  # this should work as long as chef is a development dependency in Gemfile.
+  #
+  # Chef depends on ohai and chef-config. Ohai depends on chef-config. The
+  # version of chef-config that chef depends on is whatver version chef
+  # happens to be on master. This will need to be updated again once work on
+  # Chef 13 starts, otherwise builds will break.
+  s.add_dependency "chef-config", ">= 12.5.0.current.0", "< 13"
 
   s.add_dependency "rake", "~> 10.1"
   s.add_development_dependency "rspec-core", "~> 3.0"


### PR DESCRIPTION
Fixing things that I broke...

Chef will always depend on [an unreleased version of `chef-config`](https://github.com/chef/chef/blob/master/chef.gemspec#L18). Chef also depends on `ohai`. To prevent dependency conflicts we have to ensure the version of `chef-config` that Ohai depends on is compatible with whatever the current version of Chef is on master. This will be fine and good until we start working on Chef 13.

Yay.

Apparently, the desire is to keep the `chef-config` version the same as the Chef version, so we can't relax the constraint there.

@chef/client-core 

PS: Working on omnibus changes to get this to build correctly.