### PR TITLE
Update Ohai::VERSION

### DIFF
--- a/lib/ohai/version.rb
+++ b/lib/ohai/version.rb
@@ -18,5 +18,5 @@
 
 module Ohai
   OHAI_ROOT = File.expand_path(File.dirname(__FILE__))
-  VERSION = '8.5.0'
+  VERSION = '8.6.0.current.0'
 end


### PR DESCRIPTION
Updates `Ohai::VERSION` to 8.6.0.current.0. I pushed a 8.6.0.alpha.0 of ohai earlier this morning so that chef could start using some of the new ohai config features. This change fixes the failing pedant specs (https://travis-ci.org/chef/chef/jobs/72513548)

@chef/client-core 