### PR TITLE
Fix memory plugin output on solaris

### DIFF
--- a/lib/ohai/plugins/solaris2/memory.rb
+++ b/lib/ohai/plugins/solaris2/memory.rb
@@ -19,6 +19,7 @@ Ohai.plugin(:Memory) do
 
   collect_data(:solaris2) do
     memory Mash.new
-    memory[:total] = shell_out("prtconf -m").stdout.to_i
+    meminfo =  shell_out("prtconf | grep Memory").stdout
+    memory[:total] = meminfo.split[2].to_i
   end
 end

--- a/spec/unit/plugins/solaris2/memory_spec.rb
+++ b/spec/unit/plugins/solaris2/memory_spec.rb
@@ -20,7 +20,7 @@ describe Ohai::System, "Solaris2.X memory plugin" do
   before(:each) do
     @plugin = get_plugin("solaris2/memory")
     allow(@plugin).to receive(:collect_os).and_return("solaris2")
-    allow(@plugin).to receive(:shell_out).with("prtconf -m").and_return(mock_shell_out(0, "8194\n", ""))
+    allow(@plugin).to receive(:shell_out).with("prtconf | grep Memory").and_return(mock_shell_out(0, "Memory size: 8194 Megabytes\n", ""))
   end
 
   it "should get the total memory" do


### PR DESCRIPTION
Memory plugin does not return correct output.
Running ohai memory on a solaris machine gives output as
{
  "total": 0
}
This is because memory plugin on solaris uses "prtconf -m" to get memory which does not seem to be valid.
This pull request attempts to fix this. (Reference http://docs.oracle.com/cd/E23824_01/html/821-1451/gkkwk.html#enflm on how to get memory on a solaris machine)
