### PR TITLE
Remove config logging, resolve :auto log-level.

### DIFF
--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -17,12 +17,8 @@
 # limitations under the License.
 #
 
-require 'ohai/log'
-require 'chef-config/logger'
-
-ChefConfig::Logger = Ohai::Log
-
 require 'chef-config/config'
+require 'ohai/log'
 
 module Ohai
   Config = ChefConfig::Config

--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -54,7 +54,7 @@ module Ohai
     # (e.g., Ohai::Config[:plugin_path] << some_path) in their config files.
     default :disabled_plugins, []
     default :hints_path, default_hints_path
-    default :log_level, :info
+    default :log_level, :auto
     default :log_location, STDERR
     default :plugin_path, default_plugin_path
 
@@ -91,7 +91,7 @@ module Ohai
     config_context :ohai do
       default :disabled_plugins, []
       default :hints_path, Ohai::Config.default_hints_path
-      default :log_level, :info
+      default :log_level, :auto
       default :log_location, STDERR
       default :plugin_path, Ohai::Config.default_plugin_path
     end

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -50,6 +50,7 @@ module Ohai
       @v6_dependency_solver = Hash.new
 
       configure_ohai
+      configure_logging
 
       @loader = Ohai::Loader.new(self)
       @runner = Ohai::Runner.new(self, true)
@@ -213,9 +214,16 @@ module Ohai
           !Ohai.config[:plugin_path].include?(Ohai::Config[:directory])
         Ohai.config[:plugin_path] << Ohai.config[:directory]
       end
+    end
 
+    def configure_logging
       Ohai::Log.init(Ohai.config[:log_location])
-      Ohai::Log.level = Ohai.config[:log_level]
+
+      if Ohai.config[:log_level] == :auto
+        Ohai::Log.level = :info
+      else
+        Ohai::Log.level = Ohai.config[:log_level]
+      end
     end
   end
 end

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -96,8 +96,15 @@ describe "Ohai::System" do
     end
 
     it 'configures logging' do
+      log_level = :debug
+      Ohai.config[:log_level] = log_level
       expect(Ohai::Log).to receive(:init).with(Ohai.config[:log_location])
-      expect(Ohai::Log).to receive(:level=).with(Ohai.config[:log_level])
+      expect(Ohai::Log).to receive(:level=).with(log_level)
+      Ohai::System.new
+    end
+
+    it 'resolves log_level when set to :auto' do
+      expect(Ohai::Log).to receive(:level=).with(:info)
       Ohai::System.new
     end
   end


### PR DESCRIPTION
Two things I discovered while plugging the new ohai config system into chef (https://github.com/chef/chef/pull/3689):

1. It's unnecessary to set `ChefConfig.logger = Ohai::Log`. Chef sets this logger to `Chef::Log` for [reasons which aren't applicable to ohai](https://github.com/chef/chef/blob/master/lib/chef/config.rb#L25-L27), IMO. Ohai will only use the configuration settings in its config context, none of which use a logger. Besides, setting `ChefConfig.logger` in ohai will override the setting by chef. Removing this setting reduces headache.

2. Chef allows an `:auto` log-level, which gets [resolved when `chef-client` runs](https://github.com/chef/chef/blob/master/lib/chef/application.rb#L141). Test Kitchen [explicitly configures log_level to `:auto`](https://github.com/test-kitchen/test-kitchen/blob/dp_chefignore/lib/kitchen/provisioner/chef_solo.rb#L50). This causes `'log_level' => :auto` to appear in the [configuration hash which is merged into the ohai configuration context](https://github.com/chef/ohai/blob/31d6b0e30659557080dcfd66ec6223aef4fecc1f/lib/ohai/config.rb#L49). Ohai does not currently support `:auto`, and so Test Kitchen converges would fail. I've added config support for `log_level :auto` and `ohai.log_level :auto`, which resolves to `:info`.

@chef/client-core 