### PR TITLE
Relax restriction on chef dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ gem "rspec_junit_formatter", :git => 'https://github.com/sj26/rspec_junit_format
                              :ref => "147836c41fab23ff7b92806f34122c8e5f2ddcad"
 
 group :development do
-  gem "chef", github: "opscode/chef", branch: "master"
-
   gem "sigar", :platform => "ruby"
   gem 'plist'
 

--- a/lib/ohai/version.rb
+++ b/lib/ohai/version.rb
@@ -18,5 +18,5 @@
 
 module Ohai
   OHAI_ROOT = File.expand_path(File.dirname(__FILE__))
-  VERSION = '8.5.0'
+  VERSION = '8.5.1'
 end


### PR DESCRIPTION
During omnibus builds, bundler --without development still downloads all
dependencies specified so that it can resolve versions consistently
regardless of which install groups are specified.  If ohai pins a
chef dependency to chef master, then any changes to chef master that
pull in a different version of ohai will impact our ability to bundle
install our dependencies.