### PR TITLE
Fix aix memory plugin output

### DIFF
--- a/lib/ohai/plugins/aix/memory.rb
+++ b/lib/ohai/plugins/aix/memory.rb
@@ -20,7 +20,7 @@ Ohai.plugin(:Memory) do
   provides "memory"
 
   collect_data(:aix) do
-    memory = Mash.new
+    memory Mash.new
 
     meminfo = shell_out("svmon -G -O unit=MB,summary=longreal | grep '[0-9]'").stdout
     memory[:total], u, memory[:free] = meminfo.split

--- a/spec/unit/plugins/aix/memory_spec.rb
+++ b/spec/unit/plugins/aix/memory_spec.rb
@@ -1,0 +1,35 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper.rb')
+
+describe Ohai::System, "AIX memory plugin" do
+   before(:each) do
+    @plugin = get_plugin("aix/memory")
+    allow(@plugin).to receive(:collect_os).and_return(:aix)
+    allow(@plugin).to receive(:shell_out).with("svmon -G -O unit=MB,summary=longreal | grep '[0-9]'").and_return(mock_shell_out(0, " 513280.00 340034.17 173245.83   62535.17 230400.05 276950.14  70176.00\n", nil))
+  end
+
+  it "should get total memory" do
+    @plugin.run
+    expect(@plugin['memory']['total']).to eql("513280.00")
+  end
+  
+  it "should get free memory" do
+    @plugin.run
+    expect(@plugin['memory']['free']).to eql("173245.83")
+  end
+end 


### PR DESCRIPTION
Memory plugin does not return any memory attributes on aix due to a minor bug in definition of memory Mash. This pull request is to fix that and also adds unit tests for aix memory plugin