### PR TITLE
Add swap space attributes for solaris memory plugin

### DIFF
--- a/lib/ohai/plugins/solaris2/memory.rb
+++ b/lib/ohai/plugins/solaris2/memory.rb
@@ -19,7 +19,14 @@ Ohai.plugin(:Memory) do
 
   collect_data(:solaris2) do
     memory Mash.new
+    memory[:swap] = Mash.new
     meminfo =  shell_out("prtconf | grep Memory").stdout
     memory[:total] = meminfo.split[2].to_i
+    
+    tokens = shell_out("swap -s").stdout.strip.split
+    used_swap = tokens[8][0..-1].to_i #strip k from end
+    free_swap = tokens[10][0..-1].to_i #strip k from end
+    memory[:swap][:total] = (used_swap + free_swap )/ 1024.0 #convert to MB
+    memory[:swap][:free] = free_swap / 1024.0 #convert to MB
   end
 end

--- a/spec/unit/plugins/solaris2/memory_spec.rb
+++ b/spec/unit/plugins/solaris2/memory_spec.rb
@@ -21,10 +21,23 @@ describe Ohai::System, "Solaris2.X memory plugin" do
     @plugin = get_plugin("solaris2/memory")
     allow(@plugin).to receive(:collect_os).and_return("solaris2")
     allow(@plugin).to receive(:shell_out).with("prtconf | grep Memory").and_return(mock_shell_out(0, "Memory size: 8194 Megabytes\n", ""))
+    @swap_s = "total: 112230656k bytes allocated + 357865576k reserved = 470096232k used, 47057688k available\n"
+    allow(@plugin).to receive(:shell_out).with("swap -s").and_return(mock_shell_out(0,@swap_s, ""))
   end
 
   it "should get the total memory" do
     @plugin.run
     expect(@plugin['memory']['total']).to eql(8194)
   end
+  
+  it "should get total swap" do
+    @plugin.run
+    expect(@plugin['memory']['swap']['total']).to eql((470096232 + 47057688) / 1024.0 )
+  end
+  
+  it "should get free swap" do
+    @plugin.run
+    expect(@plugin['memory']['swap']['free']).to eql(47057688 / 1024.0 )
+  end
+  
 end


### PR DESCRIPTION
This PR adds swap space attributes for solaris memory plugin. Swap space is computed using "swap -s" command and converted to megabytes to be consistent with memory[total] which is also in megabytes.