### PR TITLE
Add support for sparc based processors in solaris cpu plugin

### DIFF
--- a/lib/ohai/plugins/solaris2/cpu.rb
+++ b/lib/ohai/plugins/solaris2/cpu.rb
@@ -26,27 +26,27 @@ Ohai.plugin(:CPU) do
 
       index = i.to_s
       cpu[index] = Mash.new
-      cpu[index]['vendor_id'] = cpu_info[1]
-      cpu[index]['family'] = cpu_info[4]
-      cpu[index]['model'] = cpu_info[6]
-      cpu[index]['stepping'] = cpu_info[8]
-      cpu[index]['model_name'] = model_name.strip
-      cpu[index]['mhz'] = cpu_info[10]
+      cpu[index]["vendor_id"] = cpu_info[1]
+      cpu[index]["family"] = cpu_info[4]
+      cpu[index]["model"] = cpu_info[6]
+      cpu[index]["stepping"] = cpu_info[8]
+      cpu[index]["model_name"] = model_name.strip
+      cpu[index]["mhz"] = cpu_info[10]
     end
   end
 
   def get_sparc_processor_info
     i = 0
     cores = 0
-    shell_out('psrinfo -v -p').stdout.lines.each do |line|
+    shell_out("psrinfo -v -p").stdout.lines.each do |line|
       case  line.strip
         when /(\d+)\s+cores/
-          cores += "#{$1}".to_i
+          cores += $1.to_i
         when /^(\S+).*\b(\d+)\s+MHz\)$/
           index = i.to_s
           cpu[index] = Mash.new
-          cpu[index]['model_name'] = "#{$1}"
-          cpu[index]['mhz'] = "#{$2}"
+          cpu[index]["model_name"] = $1
+          cpu[index]["mhz"] = $2
           i += 1
       end
     end
@@ -59,7 +59,7 @@ Ohai.plugin(:CPU) do
     cpu[:real] = shell_out("psrinfo -p").stdout.to_i
     
     processor_type = shell_out("uname -p").stdout.strip
-    if processor_type.eql?('sparc')
+    if processor_type == "sparc"
         get_sparc_processor_info
     else
         get_x86_processor_info

--- a/lib/ohai/plugins/solaris2/cpu.rb
+++ b/lib/ohai/plugins/solaris2/cpu.rb
@@ -17,7 +17,7 @@
 Ohai.plugin(:CPU) do
   provides "cpu"
   
-  def get_x86_processor_info
+  def set_x86_processor_info
     processor_info = shell_out("psrinfo -v -p | grep Hz").stdout
     processors = processor_info.split(/^    [^\s]/)
     processors.each_with_index do |processor, i|
@@ -35,7 +35,7 @@ Ohai.plugin(:CPU) do
     end
   end
 
-  def get_sparc_processor_info
+  def set_sparc_processor_info
     i = 0
     cores = 0
     shell_out("psrinfo -v -p").stdout.lines.each do |line|
@@ -60,9 +60,9 @@ Ohai.plugin(:CPU) do
     
     processor_type = shell_out("uname -p").stdout.strip
     if processor_type == "sparc"
-        get_sparc_processor_info
+        set_sparc_processor_info
     else
-        get_x86_processor_info
+        set_x86_processor_info
     end
   end
 end

--- a/lib/ohai/plugins/solaris2/cpu.rb
+++ b/lib/ohai/plugins/solaris2/cpu.rb
@@ -16,12 +16,8 @@
 
 Ohai.plugin(:CPU) do
   provides "cpu"
-
-  collect_data(:solaris2) do
-    cpu Mash.new
-    cpu[:total] = shell_out("psrinfo | wc -l").stdout.to_i
-    cpu[:real] = shell_out("psrinfo -p").stdout.to_i
-
+  
+  def get_x86_processor_info
     processor_info = shell_out("psrinfo -v -p | grep Hz").stdout
     processors = processor_info.split(/^    [^\s]/)
     processors.each_with_index do |processor, i|
@@ -36,6 +32,37 @@ Ohai.plugin(:CPU) do
       cpu[index]['stepping'] = cpu_info[8]
       cpu[index]['model_name'] = model_name.strip
       cpu[index]['mhz'] = cpu_info[10]
+    end
+  end
+
+  def get_sparc_processor_info
+    i = 0
+    cores = 0
+    shell_out('psrinfo -v -p').stdout.lines.each do |line|
+      case  line.strip
+        when /(\d+)\s+cores/
+          cores += "#{$1}".to_i
+        when /^(\S+).*\b(\d+)\s+MHz\)$/
+          index = i.to_s
+          cpu[index] = Mash.new
+          cpu[index]['model_name'] = "#{$1}"
+          cpu[index]['mhz'] = "#{$2}"
+          i += 1
+      end
+    end
+    cpu[:cores] = cores
+  end
+
+  collect_data(:solaris2) do
+    cpu Mash.new
+    cpu[:total] = shell_out("psrinfo | wc -l").stdout.to_i
+    cpu[:real] = shell_out("psrinfo -p").stdout.to_i
+    
+    processor_type = shell_out("uname -p").stdout.strip
+    if processor_type.eql?('sparc')
+        get_sparc_processor_info
+    else
+        get_x86_processor_info
     end
   end
 end

--- a/spec/unit/plugins/solaris2/cpu_spec.rb
+++ b/spec/unit/plugins/solaris2/cpu_spec.rb
@@ -22,61 +22,128 @@ describe Ohai::System, "Solaris2.X cpu plugin" do
     allow(@plugin).to receive(:collect_os).and_return("solaris2")
     allow(@plugin).to receive(:shell_out).with("psrinfo | wc -l").and_return(mock_shell_out(0, "32\n", ""))
     allow(@plugin).to receive(:shell_out).with("psrinfo -p").and_return(mock_shell_out(0, "4\n", ""))
-
-    psrinfo_output = <<-END.strip
+  end
+  
+  describe 'on x86 processors' do
+    before(:each) do
+      allow(@plugin).to receive(:shell_out).with("uname -p").and_return(mock_shell_out(0, "i386\n", ""))
+      psrinfo_output = <<-END.strip
     x86 (GenuineIntel 206D7 family 6 model 45 step 7 clock 2600 MHz)
       Intel(r) Xeon(r) CPU E5-2670 0 @ 2.60GHz
     x86 (CrazyTown 206D7 family 12 model 93 step 9 clock 2900 MHz)
       Intel(r) Xeon(r) CPU E5-2690 0 @ 2.90GHz
 END
-    allow(@plugin).to receive(:shell_out).with('psrinfo -v -p | grep Hz').and_return(mock_shell_out(0, psrinfo_output, ""))
+      allow(@plugin).to receive(:shell_out).with('psrinfo -v -p | grep Hz').and_return(mock_shell_out(0, psrinfo_output, ""))
+   end
+
+    it "should get the total virtual processor count" do
+      @plugin.run
+      expect(@plugin['cpu']['total']).to eql(32)
+    end
+
+    it 'should get the total processor count' do
+      @plugin.run
+      expect(@plugin['cpu']['real']).to eql(4)
+    end
+
+    describe 'per-cpu information' do
+      it "should include vendor_id for processors" do
+        @plugin.run
+        expect(@plugin['cpu']['0']['vendor_id']).to eql('GenuineIntel')
+        expect(@plugin['cpu']['1']['vendor_id']).to eql('CrazyTown')
+      end
+
+      it "should include family for processors" do
+        @plugin.run
+        expect(@plugin['cpu']["0"]["family"]).to eql("6")
+        expect(@plugin['cpu']["1"]["family"]).to eql("12")
+      end
+
+      it "should include model for processors" do
+        @plugin.run
+        expect(@plugin['cpu']["0"]["model"]).to eql("45")
+        expect(@plugin['cpu']["1"]["model"]).to eql("93")
+      end
+
+      it "should include stepping for processors" do
+        @plugin.run
+        expect(@plugin['cpu']["0"]["stepping"]).to eql("7")
+        expect(@plugin['cpu']["1"]["stepping"]).to eql("9")
+      end
+
+      it "should include model name for processors" do
+        @plugin.run
+        expect(@plugin['cpu']["0"]["model_name"]).to eql("Intel(r) Xeon(r) CPU E5-2670 0 @ 2.60GHz")
+        expect(@plugin['cpu']["1"]["model_name"]).to eql("Intel(r) Xeon(r) CPU E5-2690 0 @ 2.90GHz")
+      end
+
+      it "should include mhz name for processors" do
+        @plugin.run
+        expect(@plugin['cpu']["0"]["mhz"]).to eql("2600")
+        expect(@plugin['cpu']["1"]["mhz"]).to eql("2900")
+      end
+    end
   end
   
-  it "should get the total virtual processor count" do
-    @plugin.run
-    expect(@plugin['cpu']['total']).to eql(32)
-  end
-
-  it 'should get the total processor count' do
-    @plugin.run
-    expect(@plugin['cpu']['real']).to eql(4)
-  end
-
-  describe 'per-cpu information' do
-    it "should include vendor_id for processors" do
+  
+  describe 'on sparc processors' do
+    before(:each) do
+        allow(@plugin).to receive(:shell_out).with("uname -p").and_return(mock_shell_out(0, "sparc\n", ""))
+        psrinfo_output = <<-END.strip
+The physical processor has 4 cores and 8 virtual processors (32-39)
+  The core has 2 virtual processors (32 33)
+  The core has 2 virtual processors (34 35)
+  The core has 2 virtual processors (36 37)
+  The core has 2 virtual processors (38 39)
+    SPARC64-VII (portid 1056 impl 0x7 ver 0x91 clock 2400 MHz)
+The physical processor has 4 cores and 8 virtual processors (40-47)
+  The core has 2 virtual processors (40 41)
+  The core has 2 virtual processors (42 43)
+  The core has 2 virtual processors (44 45)
+  The core has 2 virtual processors (46 47)
+    SPARC64-VII (portid 1064 impl 0x7 ver 0x91 clock 2400 MHz)
+The physical processor has 4 cores and 8 virtual processors (48-55)
+  The core has 2 virtual processors (48 49)
+  The core has 2 virtual processors (50 51)
+  The core has 2 virtual processors (52 53)
+  The core has 2 virtual processors (54 55)
+    SPARC64-VII (portid 1072 impl 0x7 ver 0x91 clock 2400 MHz)
+The physical processor has 4 cores and 8 virtual processors (56-63)
+  The core has 2 virtual processors (56 57)
+  The core has 2 virtual processors (58 59)
+  The core has 2 virtual processors (60 61)
+  The core has 2 virtual processors (62 63)
+    SPARC64-VII (portid 1080 impl 0x7 ver 0x91 clock 2400 MHz)
+END
+        allow(@plugin).to receive(:shell_out).with('psrinfo -v -p').and_return(mock_shell_out(0, psrinfo_output, ""))
+    end
+    
+    it "should get the total virtual processor count" do
       @plugin.run
-      expect(@plugin['cpu']['0']['vendor_id']).to eql('GenuineIntel')
-      expect(@plugin['cpu']['1']['vendor_id']).to eql('CrazyTown')
+      expect(@plugin['cpu']['total']).to eql(32)
     end
 
-    it "should include family for processors" do
+    it 'should get the total processor count' do
       @plugin.run
-      expect(@plugin['cpu']["0"]["family"]).to eql("6")
-      expect(@plugin['cpu']["1"]["family"]).to eql("12")
+      expect(@plugin['cpu']['real']).to eql(4)
     end
+  
+    describe 'per-cpu information' do
+      it "should include model name for processors" do
+        @plugin.run
+        expect(@plugin['cpu']["0"]["model_name"]).to eql("SPARC64-VII")
+        expect(@plugin['cpu']["1"]["model_name"]).to eql("SPARC64-VII")
+        expect(@plugin['cpu']["2"]["model_name"]).to eql("SPARC64-VII")
+        expect(@plugin['cpu']["3"]["model_name"]).to eql("SPARC64-VII")
+      end
 
-    it "should include model for processors" do
-      @plugin.run
-      expect(@plugin['cpu']["0"]["model"]).to eql("45")
-      expect(@plugin['cpu']["1"]["model"]).to eql("93")
-    end
-
-    it "should include stepping for processors" do
-      @plugin.run
-      expect(@plugin['cpu']["0"]["stepping"]).to eql("7")
-      expect(@plugin['cpu']["1"]["stepping"]).to eql("9")
-    end
-
-    it "should include model name for processors" do
-      @plugin.run
-      expect(@plugin['cpu']["0"]["model_name"]).to eql("Intel(r) Xeon(r) CPU E5-2670 0 @ 2.60GHz")
-      expect(@plugin['cpu']["1"]["model_name"]).to eql("Intel(r) Xeon(r) CPU E5-2690 0 @ 2.90GHz")
-    end
-
-    it "should include mhz name for processors" do
-      @plugin.run
-      expect(@plugin['cpu']["0"]["mhz"]).to eql("2600")
-      expect(@plugin['cpu']["1"]["mhz"]).to eql("2900")
+      it "should include mhz for processors" do
+        @plugin.run
+        expect(@plugin['cpu']["0"]["mhz"]).to eql("2400")
+        expect(@plugin['cpu']["1"]["mhz"]).to eql("2400")
+        expect(@plugin['cpu']["2"]["mhz"]).to eql("2400")
+        expect(@plugin['cpu']["3"]["mhz"]).to eql("2400")
+      end
     end
   end
 end

--- a/spec/unit/plugins/solaris2/cpu_spec.rb
+++ b/spec/unit/plugins/solaris2/cpu_spec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper.rb')
+require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
 
 describe Ohai::System, "Solaris2.X cpu plugin" do
   before(:each) do
@@ -24,7 +24,7 @@ describe Ohai::System, "Solaris2.X cpu plugin" do
     allow(@plugin).to receive(:shell_out).with("psrinfo -p").and_return(mock_shell_out(0, "4\n", ""))
   end
   
-  describe 'on x86 processors' do
+  describe "on x86 processors" do
     before(:each) do
       allow(@plugin).to receive(:shell_out).with("uname -p").and_return(mock_shell_out(0, "i386\n", ""))
       psrinfo_output = <<-END.strip
@@ -33,60 +33,60 @@ describe Ohai::System, "Solaris2.X cpu plugin" do
     x86 (CrazyTown 206D7 family 12 model 93 step 9 clock 2900 MHz)
       Intel(r) Xeon(r) CPU E5-2690 0 @ 2.90GHz
 END
-      allow(@plugin).to receive(:shell_out).with('psrinfo -v -p | grep Hz').and_return(mock_shell_out(0, psrinfo_output, ""))
+      allow(@plugin).to receive(:shell_out).with("psrinfo -v -p | grep Hz").and_return(mock_shell_out(0, psrinfo_output, ""))
    end
 
     it "should get the total virtual processor count" do
       @plugin.run
-      expect(@plugin['cpu']['total']).to eql(32)
+      expect(@plugin["cpu"]["total"]).to eql(32)
     end
 
-    it 'should get the total processor count' do
+    it "should get the total processor count" do
       @plugin.run
-      expect(@plugin['cpu']['real']).to eql(4)
+      expect(@plugin["cpu"]["real"]).to eql(4)
     end
 
-    describe 'per-cpu information' do
+    describe "per-cpu information" do
       it "should include vendor_id for processors" do
         @plugin.run
-        expect(@plugin['cpu']['0']['vendor_id']).to eql('GenuineIntel')
-        expect(@plugin['cpu']['1']['vendor_id']).to eql('CrazyTown')
+        expect(@plugin["cpu"]["0"]["vendor_id"]).to eql("GenuineIntel")
+        expect(@plugin["cpu"]["1"]["vendor_id"]).to eql("CrazyTown")
       end
 
       it "should include family for processors" do
         @plugin.run
-        expect(@plugin['cpu']["0"]["family"]).to eql("6")
-        expect(@plugin['cpu']["1"]["family"]).to eql("12")
+        expect(@plugin["cpu"]["0"]["family"]).to eql("6")
+        expect(@plugin["cpu"]["1"]["family"]).to eql("12")
       end
 
       it "should include model for processors" do
         @plugin.run
-        expect(@plugin['cpu']["0"]["model"]).to eql("45")
-        expect(@plugin['cpu']["1"]["model"]).to eql("93")
+        expect(@plugin["cpu"]["0"]["model"]).to eql("45")
+        expect(@plugin["cpu"]["1"]["model"]).to eql("93")
       end
 
       it "should include stepping for processors" do
         @plugin.run
-        expect(@plugin['cpu']["0"]["stepping"]).to eql("7")
-        expect(@plugin['cpu']["1"]["stepping"]).to eql("9")
+        expect(@plugin["cpu"]["0"]["stepping"]).to eql("7")
+        expect(@plugin["cpu"]["1"]["stepping"]).to eql("9")
       end
 
       it "should include model name for processors" do
         @plugin.run
-        expect(@plugin['cpu']["0"]["model_name"]).to eql("Intel(r) Xeon(r) CPU E5-2670 0 @ 2.60GHz")
-        expect(@plugin['cpu']["1"]["model_name"]).to eql("Intel(r) Xeon(r) CPU E5-2690 0 @ 2.90GHz")
+        expect(@plugin["cpu"]["0"]["model_name"]).to eql("Intel(r) Xeon(r) CPU E5-2670 0 @ 2.60GHz")
+        expect(@plugin["cpu"]["1"]["model_name"]).to eql("Intel(r) Xeon(r) CPU E5-2690 0 @ 2.90GHz")
       end
 
       it "should include mhz name for processors" do
         @plugin.run
-        expect(@plugin['cpu']["0"]["mhz"]).to eql("2600")
-        expect(@plugin['cpu']["1"]["mhz"]).to eql("2900")
+        expect(@plugin["cpu"]["0"]["mhz"]).to eql("2600")
+        expect(@plugin["cpu"]["1"]["mhz"]).to eql("2900")
       end
     end
   end
   
   
-  describe 'on sparc processors' do
+  describe "on sparc processors" do
     before(:each) do
         allow(@plugin).to receive(:shell_out).with("uname -p").and_return(mock_shell_out(0, "sparc\n", ""))
         psrinfo_output = <<-END.strip
@@ -115,34 +115,34 @@ The physical processor has 4 cores and 8 virtual processors (56-63)
   The core has 2 virtual processors (62 63)
     SPARC64-VII (portid 1080 impl 0x7 ver 0x91 clock 2400 MHz)
 END
-        allow(@plugin).to receive(:shell_out).with('psrinfo -v -p').and_return(mock_shell_out(0, psrinfo_output, ""))
+        allow(@plugin).to receive(:shell_out).with("psrinfo -v -p").and_return(mock_shell_out(0, psrinfo_output, ""))
     end
     
     it "should get the total virtual processor count" do
       @plugin.run
-      expect(@plugin['cpu']['total']).to eql(32)
+      expect(@plugin["cpu"]["total"]).to eql(32)
     end
 
-    it 'should get the total processor count' do
+    it "should get the total processor count" do
       @plugin.run
-      expect(@plugin['cpu']['real']).to eql(4)
+      expect(@plugin["cpu"]["real"]).to eql(4)
     end
   
-    describe 'per-cpu information' do
+    describe "per-cpu information" do
       it "should include model name for processors" do
         @plugin.run
-        expect(@plugin['cpu']["0"]["model_name"]).to eql("SPARC64-VII")
-        expect(@plugin['cpu']["1"]["model_name"]).to eql("SPARC64-VII")
-        expect(@plugin['cpu']["2"]["model_name"]).to eql("SPARC64-VII")
-        expect(@plugin['cpu']["3"]["model_name"]).to eql("SPARC64-VII")
+        expect(@plugin["cpu"]["0"]["model_name"]).to eql("SPARC64-VII")
+        expect(@plugin["cpu"]["1"]["model_name"]).to eql("SPARC64-VII")
+        expect(@plugin["cpu"]["2"]["model_name"]).to eql("SPARC64-VII")
+        expect(@plugin["cpu"]["3"]["model_name"]).to eql("SPARC64-VII")
       end
 
       it "should include mhz for processors" do
         @plugin.run
-        expect(@plugin['cpu']["0"]["mhz"]).to eql("2400")
-        expect(@plugin['cpu']["1"]["mhz"]).to eql("2400")
-        expect(@plugin['cpu']["2"]["mhz"]).to eql("2400")
-        expect(@plugin['cpu']["3"]["mhz"]).to eql("2400")
+        expect(@plugin["cpu"]["0"]["mhz"]).to eql("2400")
+        expect(@plugin["cpu"]["1"]["mhz"]).to eql("2400")
+        expect(@plugin["cpu"]["2"]["mhz"]).to eql("2400")
+        expect(@plugin["cpu"]["3"]["mhz"]).to eql("2400")
       end
     end
   end

--- a/spec/unit/plugins/solaris2/cpu_spec.rb
+++ b/spec/unit/plugins/solaris2/cpu_spec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper.rb')
 
 describe Ohai::System, "Solaris2.X cpu plugin" do
   before(:each) do

--- a/spec/unit/plugins/solaris2/cpu_spec.rb
+++ b/spec/unit/plugins/solaris2/cpu_spec.rb
@@ -127,6 +127,11 @@ END
       @plugin.run
       expect(@plugin["cpu"]["real"]).to eql(4)
     end
+    
+    it "should get the total core count" do
+      @plugin.run
+      expect(@plugin["cpu"]["cores"]).to eql(16)
+    end
   
     describe "per-cpu information" do
       it "should include model name for processors" do


### PR DESCRIPTION
Solaris cpu plugin does not return correct per processor data on systems that have sparc processor as the current plugin is targeted towards systems that have x86 processor. From solaris 11.2 documentation (https://docs.oracle.com/cd/E36784_01/html/E36819/frcbd.html#ADSYSeqbug), output of  "psrinfo -p -v"  is different based on sparc vs x86 systems. This PR adds support for sparc based systems.