### PR TITLE
Windows memory plugin

### DIFF
--- a/lib/ohai/plugins/windows/memory.rb
+++ b/lib/ohai/plugins/windows/memory.rb
@@ -27,12 +27,12 @@ Ohai.plugin(:Memory) do
     os = wmi.first_of("Win32_OperatingSystem")
 
     # MemTotal
-    memory[:total] = os["TotalVisibleMemorySize"].to_i / 1024.0
+    memory[:total] = os["TotalVisibleMemorySize"] + "kB"
     # MemFree
-    memory[:free] = os["FreePhysicalMemory"].to_i / 1024.0
+    memory[:free] = os["FreePhysicalMemory"] + "kB"
     # SwapTotal
-    memory[:swap][:total] = os["SizeStoredInPagingFiles"].to_i / 1024.0
+    memory[:swap][:total] = os["SizeStoredInPagingFiles"] + "kB"
     # SwapFree
-    memory[:swap][:free] = os["FreeSpaceInPagingFiles"].to_i / 1024.0
+    memory[:swap][:free] = os["FreeSpaceInPagingFiles"] + "kB"
   end
 end

--- a/lib/ohai/plugins/windows/memory.rb
+++ b/lib/ohai/plugins/windows/memory.rb
@@ -1,0 +1,38 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+Ohai.plugin(:Memory) do
+  provides "memory"
+
+  collect_data(:windows) do
+    require "wmi-lite/wmi"
+
+    memory Mash.new
+    memory[:swap] = Mash.new
+
+    wmi = WmiLite::Wmi.new
+
+    os = wmi.first_of("Win32_OperatingSystem")
+
+    # MemTotal
+    memory[:total] = os["TotalVisibleMemorySize"].to_i / 1024.0
+    # MemFree
+    memory[:free] = os["FreePhysicalMemory"].to_i / 1024.0
+    # SwapTotal
+    memory[:swap][:total] = os["SizeStoredInPagingFiles"].to_i / 1024.0
+    # SwapFree
+    memory[:swap][:free] = os["FreeSpaceInPagingFiles"].to_i / 1024.0
+  end
+end

--- a/spec/unit/plugins/windows/memory_spec.rb
+++ b/spec/unit/plugins/windows/memory_spec.rb
@@ -1,0 +1,52 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper.rb')
+
+describe Ohai::System, "Windows memory plugin", :windows_only do
+	before do
+    require "wmi-lite/wmi"
+    @plugin = get_plugin("windows/memory")
+    mock_os = { 
+                "TotalVisibleMemorySize" => "10485760",
+                "FreePhysicalMemory" => "5242880",
+                "SizeStoredInPagingFiles" => "20971520",
+                "FreeSpaceInPagingFiles" =>  "15728640"
+              }
+    expect_any_instance_of(WmiLite::Wmi).to receive(:first_of).with('Win32_OperatingSystem').and_return(mock_os)
+  end
+
+  it "should get total memory" do
+    @plugin.run
+    expect(@plugin["memory"]["total"]).to eql(10485760 / 1024.0)
+  end
+
+  it "should get free memory" do
+    @plugin.run
+    expect(@plugin["memory"]["free"]).to eql(5242880 / 1024.0)
+  end
+
+  it "should get total swap" do
+    @plugin.run
+    expect(@plugin["memory"]["swap"]["total"]).to eql(20971520 / 1024.0)
+  end
+
+  it "should get free memory" do
+    @plugin.run
+    expect(@plugin["memory"]["swap"]["free"]).to eql(15728640 / 1024.0)
+  end
+
+end

--- a/spec/unit/plugins/windows/memory_spec.rb
+++ b/spec/unit/plugins/windows/memory_spec.rb
@@ -31,22 +31,22 @@ describe Ohai::System, "Windows memory plugin", :windows_only do
 
   it "should get total memory" do
     @plugin.run
-    expect(@plugin["memory"]["total"]).to eql(10485760 / 1024.0)
+    expect(@plugin["memory"]["total"]).to eql("10485760kB")
   end
 
   it "should get free memory" do
     @plugin.run
-    expect(@plugin["memory"]["free"]).to eql(5242880 / 1024.0)
+    expect(@plugin["memory"]["free"]).to eql("5242880kB")
   end
 
   it "should get total swap" do
     @plugin.run
-    expect(@plugin["memory"]["swap"]["total"]).to eql(20971520 / 1024.0)
+    expect(@plugin["memory"]["swap"]["total"]).to eql("20971520kB")
   end
 
   it "should get free memory" do
     @plugin.run
-    expect(@plugin["memory"]["swap"]["free"]).to eql(15728640 / 1024.0)
+    expect(@plugin["memory"]["swap"]["free"]).to eql("15728640kB")
   end
 
 end

--- a/spec/unit/plugins/windows/memory_spec.rb
+++ b/spec/unit/plugins/windows/memory_spec.rb
@@ -17,7 +17,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper.rb')
 
 describe Ohai::System, "Windows memory plugin", :windows_only do
-	before do
+  before do
     require "wmi-lite/wmi"
     @plugin = get_plugin("windows/memory")
     mock_os = { 


### PR DESCRIPTION
This PR builds on top of #452 and adds tests. All memory attributes are converted to MB to be consistent with other platforms like Solaris,Unix. Thanks to @webframp for the initial pull request.