### PR TITLE
Make AIX cpu plugin's output consistent with Solaris cpu plugin

### DIFF
--- a/spec/unit/plugins/aix/cpu_spec.rb
+++ b/spec/unit/plugins/aix/cpu_spec.rb
@@ -31,50 +31,69 @@ smt_threads 2              Processor SMT threads False
 state       enable         Processor state       False
 type        PowerPC_POWER5 Processor type        False
 LSATTR_EL
+
+    @pmcycles_m = <<-PMCYCLES_M
+CPU 0 runs at 1654 MHz
+CPU 1 runs at 1654 MHz
+CPU 2 runs at 1654 MHz
+CPU 3 runs at 1654 MHz
+PMCYCLES_M
+    
     @plugin = get_plugin("aix/cpu")
     allow(@plugin).to receive(:collect_os).and_return(:aix)
 
     allow(@plugin).to receive(:shell_out).with("lsdev -Cc processor").and_return(mock_shell_out(0, @lsdev_Cc_processor, nil))
     allow(@plugin).to receive(:shell_out).with("lsattr -El proc0").and_return(mock_shell_out(0, @lsattr_El_proc0, nil))
+    allow(@plugin).to receive(:shell_out).with("pmcycles -m").and_return(mock_shell_out(0, @pmcycles_m, nil))
     @plugin.run
   end
 
 
   it "sets the vendor id to IBM" do
-    expect(@plugin[:cpu][:vendor_id]).to eq("IBM")
+    expect(@plugin[:cpu]["0"][:vendor_id]).to eq("IBM")
   end
 
   it "sets the available attribute" do
     expect(@plugin[:cpu][:available]).to eq(1)
   end
 
-  it "sets the total number of devices" do
-    expect(@plugin[:cpu][:total]).to eq(2)
+  it "sets the total number of processors" do
+    expect(@plugin[:cpu][:total]).to eq(4)
+  end
+  
+  it "sets the real number of processors" do
+    expect(@plugin[:cpu][:real]).to eq(2)
+  end
+  
+  it "sets the number of cores" do
+    #from http://www-01.ibm.com/software/passportadvantage/pvu_terminology_for_customers.html
+    #on AIX number of cores and processors are considered same 
+    expect(@plugin[:cpu][:cores]).to eq(@plugin[:cpu][:real])
   end
 
   it "detects the model" do
-    expect(@plugin[:cpu][:model]).to eq("PowerPC_POWER5")
+    expect(@plugin[:cpu]["0"][:model_name]).to eq("PowerPC_POWER5")
   end
 
   it "detects the mhz" do
-    expect(@plugin[:cpu][:mhz]).to eq(1615570)
+    expect(@plugin[:cpu]["0"][:mhz]).to eq(1654)
   end
 
   it "detects the status of the device" do
-    expect(@plugin[:cpu][:proc0][:status]).to eq("Available")
+    expect(@plugin[:cpu]["0"][:status]).to eq("Available")
   end
 
   it "detects the location of the device" do
-    expect(@plugin[:cpu][:proc0][:location]).to eq("00-00")
+    expect(@plugin[:cpu]["0"][:location]).to eq("00-00")
   end
 
   context "lsattr -El device_name" do
     it "detects all the attributes of the device" do
-      expect(@plugin[:cpu][:proc0][:frequency]).to eq("1654344000")
-      expect(@plugin[:cpu][:proc0][:smt_enabled]).to eq("true")
-      expect(@plugin[:cpu][:proc0][:smt_threads]).to eq("2")
-      expect(@plugin[:cpu][:proc0][:state]).to eq("enable")
-      expect(@plugin[:cpu][:proc0][:type]).to eq("PowerPC_POWER5")
+      expect(@plugin[:cpu]["0"][:mhz]).to eq(1654)
+      expect(@plugin[:cpu]["0"][:smt_enabled]).to eq("true")
+      expect(@plugin[:cpu]["0"][:smt_threads]).to eq("2")
+      expect(@plugin[:cpu]["0"][:state]).to eq("enable")
+      expect(@plugin[:cpu]["0"][:model_name]).to eq("PowerPC_POWER5")
     end
   end
 end


### PR DESCRIPTION
1. Change cpu["total"] to give the total number of virtual processors a.k.a number of threads as in other  platforms.
2. Change processor index to be cpu["0"] instead of cpu["proc0"].
3. Move vendor_id,frequency and processor model attribute to within processor index output and give them same names as other platforms. Frequency is called mhz and model is called model_name.
4. Add cores attribute to be consistent with solaris cpu plugin.