### PR TITLE
Change windows cpu plugin to be consistent with other plaforms, add spec test

### DIFF
--- a/lib/ohai/plugins/windows/cpu.rb
+++ b/lib/ohai/plugins/windows/cpu.rb
@@ -54,7 +54,9 @@ Ohai.plugin(:CPU) do
       cpu[current_cpu]["vendor_id"] = processor['manufacturer']
       cpu[current_cpu]["family"] = processor['family'].to_s
       cpu[current_cpu]["model"] = processor['revision'].to_s
-      cpu[current_cpu]["stepping"] = processor['stepping']
+      cpu[current_cpu]["stepping"] = processor['stepping'].nil? \
+                  ? processor['description'].match(/Stepping\s+(\d+)/)[1] \
+                  : processor['stepping']
       cpu[current_cpu]["physical_id"] = processor['deviceid']
       cpu[current_cpu]["model_name"] = processor['description']
       cpu[current_cpu]["mhz"] = processor['maxclockspeed'].to_s

--- a/lib/ohai/plugins/windows/cpu.rb
+++ b/lib/ohai/plugins/windows/cpu.rb
@@ -22,50 +22,47 @@ Ohai.plugin(:CPU) do
   collect_data(:windows) do
     require 'wmi-lite/wmi'
 
-    cpuinfo = Mash.new
-    cpu_number = 0
-    index = 0
+    cpu Mash.new
+    cores = 0
+    logical_processors = 0
 
     wmi = WmiLite::Wmi.new
     processors = wmi.instances_of('Win32_Processor')
 
-    processors.find(:all).each do |processor|
+    processors.each_with_index do |processor, index|
+      current_cpu = index.to_s
+      cpu[current_cpu] = Mash.new
       #
       # On Windows Server 2003 R2 (i.e. 5.2.*), numberofcores property 
       # doesn't exist on the Win32_Processor class unless the user has
       # patched their system with:
       # http://support.microsoft.com/kb/932370
       # 
-      # We're returning nil for cpu["cores"] and cpu["count"]
+      # We're returning nil for cpu["cores"]
       # when we don't see numberofcores property
       #
 
-      number_of_cores = nil
       begin
-        number_of_cores = processor['numberofcores']
-        cpu_number += number_of_cores
+        cpu[current_cpu]["cores"] = processor['numberofcores']
+        cores += processor['numberofcores']
       rescue NoMethodError => e
         Ohai::Log.info("Can not find numberofcores property on Win32_Processor. Consider applying this patch: http://support.microsoft.com/kb/932370")
+        cpu[current_cpu]["cores"] = nil
       end
 
-      current_cpu = index.to_s
-      index += 1
-      cpuinfo[current_cpu] = Mash.new
-      cpuinfo[current_cpu]["vendor_id"] = processor['manufacturer']
-      cpuinfo[current_cpu]["family"] = processor['family'].to_s
-      cpuinfo[current_cpu]["model"] = processor['revision'].to_s
-      cpuinfo[current_cpu]["stepping"] = processor['stepping']
-      cpuinfo[current_cpu]["physical_id"] = processor['deviceid']
-      #cpuinfo[current_cpu]["core_id"] = XXX
-      cpuinfo[current_cpu]["cores"] = number_of_cores
-      cpuinfo[current_cpu]["model_name"] = processor['description']
-      cpuinfo[current_cpu]["mhz"] = processor['maxclockspeed'].to_s
-      cpuinfo[current_cpu]["cache_size"] = "#{processor['l2cachesize']} KB"
-      #cpuinfo[current_cpu]["flags"] = XXX
+      logical_processors += processor['numberoflogicalprocessors']
+      cpu[current_cpu]["vendor_id"] = processor['manufacturer']
+      cpu[current_cpu]["family"] = processor['family'].to_s
+      cpu[current_cpu]["model"] = processor['revision'].to_s
+      cpu[current_cpu]["stepping"] = processor['stepping']
+      cpu[current_cpu]["physical_id"] = processor['deviceid']
+      cpu[current_cpu]["model_name"] = processor['description']
+      cpu[current_cpu]["mhz"] = processor['maxclockspeed'].to_s
+      cpu[current_cpu]["cache_size"] = "#{processor['l2cachesize']} KB"
     end
 
-    cpu cpuinfo
-    cpu[:total] = (cpu_number == 0) ? nil : cpu_number
-    cpu[:real] = index
+    cpu[:total] = logical_processors
+    cpu[:cores] = cores
+    cpu[:real] =  processors.length
   end
 end

--- a/spec/unit/plugins/windows/cpu_spec.rb
+++ b/spec/unit/plugins/windows/cpu_spec.rb
@@ -1,0 +1,109 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper.rb')
+
+describe Ohai::System, "Windows cpu plugin", :windows_only do
+  before do
+    require "wmi-lite/wmi"
+    @plugin = get_plugin("windows/cpu")
+    mock_processor = { 
+                "description"=>"Intel64 Family 6 Model 60 Stepping 3", 
+                "deviceid"=>"CPU0", 
+                "family"=>198, 
+                "maxclockspeed"=>3401,
+                "manufacturer"=>"GenuineIntel",
+                "numberofcores"=>4, 
+                "numberoflogicalprocessors"=>8,  
+                "l2cachesize"=>1024,
+                "revision"=>15363, 
+                "stepping"=>"3"
+              }
+    mock_processors = [mock_processor,mock_processor]
+    expect_any_instance_of(WmiLite::Wmi).to receive(:instances_of).
+      with('Win32_Processor').and_return(mock_processors)
+  end
+
+  it "should get total processors" do
+    @plugin.run
+    expect(@plugin[:cpu][:total]).to eql(16)
+  end
+
+  it "should get total cores" do
+    @plugin.run
+    expect(@plugin[:cpu][:cores]).to eql(8)
+  end
+
+  it "should get real processors" do
+    @plugin.run
+    expect(@plugin[:cpu][:real]).to eql(2)
+  end
+
+  it "should have 2 cpus" do
+    @plugin.run
+    expect(@plugin[:cpu]).to have_key("0")
+    expect(@plugin[:cpu]).to have_key("1")
+  end
+
+  it "has a vendor_id for cpu 0" do
+    @plugin.run
+    expect(@plugin[:cpu]["0"]).to have_key("vendor_id")
+    expect(@plugin[:cpu]["0"]["vendor_id"]).to eql("GenuineIntel")
+  end
+
+  it "has a family for cpu 0" do
+    @plugin.run
+    expect(@plugin[:cpu]["0"]).to have_key("family")
+    expect(@plugin[:cpu]["0"]["family"]).to eql("198")
+  end
+
+  it "has a model for cpu 0" do
+    @plugin.run
+    expect(@plugin[:cpu]["0"]).to have_key("model")
+    expect(@plugin[:cpu]["0"]["model"]).to eql("15363")
+  end
+
+  it "has a stepping for cpu 0" do
+    @plugin.run
+    expect(@plugin[:cpu]["0"]).to have_key("stepping")
+    expect(@plugin[:cpu]["0"]["stepping"]).to eql("3")
+  end
+
+   it "has a physical_id for cpu 0" do
+    @plugin.run
+    expect(@plugin[:cpu]["0"]).to have_key("physical_id")
+    expect(@plugin[:cpu]["0"]["physical_id"]).to eql("CPU0")
+  end
+
+  it "has a model name for cpu 0" do
+    @plugin.run
+    expect(@plugin[:cpu]["0"]).to have_key("model_name")
+    expect(@plugin[:cpu]["0"]["model_name"]).to eql("Intel64 Family 6 Model 60 Stepping 3")
+  end
+
+  it "has a mhz for cpu 0" do
+    @plugin.run
+    expect(@plugin[:cpu]["0"]).to have_key("mhz")
+    expect(@plugin[:cpu]["0"]["mhz"]).to eql("3401")
+  end
+
+  it "has a cache_size for cpu 0" do
+    @plugin.run
+    expect(@plugin[:cpu]["0"]).to have_key("cache_size")
+    expect(@plugin[:cpu]["0"]["cache_size"]).to eql("1024 KB")
+  end
+
+end


### PR DESCRIPTION
1. Change cpu[:total] to return total number of logical processors instead of cores as in other platforms like Linux,Solaris
2. Add cpu[:cores] to return total number of cores
3. Add spec tests for the cpu plugin on windows