### PR TITLE
Add total cores to linux cpu plugin

### DIFF
--- a/lib/ohai/plugins/linux/cpu.rb
+++ b/lib/ohai/plugins/linux/cpu.rb
@@ -80,5 +80,6 @@ Ohai.plugin(:CPU) do
     cpu cpuinfo
     cpu[:total] = cpu_number
     cpu[:real] = real_cpu.keys.length
+    cpu[:cores] = real_cpu.keys.length * cpu["0"]["cores"].to_i
   end
 end

--- a/spec/unit/plugins/linux/cpu_spec.rb
+++ b/spec/unit/plugins/linux/cpu_spec.rb
@@ -89,6 +89,11 @@ describe Ohai::System, "General Linux cpu plugin" do
   end
   
   it_behaves_like "Common cpu info", 1, 0
+  
+  it "gets total cores" do
+    @plugin.run
+    expect(@plugin[:cpu][:cores]).to eql(0)
+  end
 
   it "doesn't have a cpu 1" do
     @plugin.run


### PR DESCRIPTION
Add a cores attributes to get total number of cores on linux machines.