### PR TITLE
initial Cisco IOS-XR support

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -143,9 +143,13 @@ Ohai.plugin(:Platform) do
       # kernel release will be used - ex. 3.13
       platform_version `uname -r`.strip
     elsif os_release_file_is_cisco?
-      raise "unknown Cisco /etc/os-release ID field" unless os_release_info['ID'].include?('nexus')
+      raise "unknown Cisco /etc/os-release ID field" unless os_release_info['ID'] =~ /nexus|exr/i
       raise "unknown Cisco /etc/os-release ID-LIKE field" unless os_release_info['ID_LIKE'].include?('wrlinux')
-      platform 'nexus'
+      if os_release_info['ID'].include?('nexus')
+        platform 'nexus'
+      else
+        platform 'ios-xr'
+      end
       platform_family 'wrlinux'
       platform_version os_release_info['VERSION']
     elsif lsb[:id] =~ /RedHat/i

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -650,7 +650,7 @@ CISCO_RELEASE
     end
   end
 
-  describe "on Wind River Linux for Cisco Nexus" do
+  describe "on Wind River Linux 5 for Cisco Nexus" do
 
     let(:have_os_release) { true }
 
@@ -661,6 +661,20 @@ CISCO_RELEASE
       expect(@plugin[:platform]).to eq("nexus")
       expect(@plugin[:platform_family]).to eq("wrlinux")
       expect(@plugin[:platform_version]).to eq("7.0(3)I2(0.475E.6)")
+    end
+  end
+
+  describe "on Wind River Linux 7 for Cisco IOS-XR" do
+
+    let(:have_os_release) { true }
+
+    it "should set platform to ios-xr and platform_family to wrlinux" do
+      @plugin.lsb = nil
+      expect(File).to receive(:read).twice.with("/etc/os-release").and_return("ID=eXR\nID_LIKE=wrlinux\nNAME=IOS-XR\nVERSION=\"6.0.0.3I\"\nVERSION_ID=6.0.0.3I\nPRETTY_NAME=\"Cisco IOS XR Software, Version 6.0.0.03I\"\nHOME_URL=http://www.cisco.com\nBUILD_ID=TBD\nCISCO_RELEASE_INFO=/etc/os-release")
+      @plugin.run
+      expect(@plugin[:platform]).to eq("ios-xr")
+      expect(@plugin[:platform_family]).to eq("wrlinux")
+      expect(@plugin[:platform_version]).to eq("6.0.0.3I")
     end
   end
 end


### PR DESCRIPTION
This is for adding support for Cisco's IOS-XR platform on Wind River Linux 7 (Cisco's Nexus platform is on WRL5). This reads the /etc/os-release, checks for CISCO_RELEASE_INFO and if the ID_LIKE=wrlinux and the ID=eXR then the platform is 'ios-xr'. 

ios-xr's guestshell will be different from nexus_centos and added once we have access to that platform.