### PR TITLE
Adding support for Wind River Linux 7.

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -143,9 +143,17 @@ Ohai.plugin(:Platform) do
       # kernel release will be used - ex. 3.13
       platform_version `uname -r`.strip
     elsif os_release_file_is_cisco?
-      raise "unknown Cisco /etc/os-release ID field" unless os_release_info['ID'].include?('nexus')
-      raise "unknown Cisco /etc/os-release ID-LIKE field" unless os_release_info['ID_LIKE'].include?('wrlinux')
-      platform 'nexus'
+      raise 'unknown Cisco /etc/os-release ID-LIKE field' unless os_release_info['ID_LIKE'].include?('wrlinux')
+
+      case os_release_info['ID']
+      when 'nexus'
+        platform 'nexus'
+      when 'ios_xr'
+        platform 'ios_xr'
+      else
+        raise 'unknown Cisco /etc/os-release ID field'
+      end
+
       platform_family 'wrlinux'
       platform_version os_release_info['VERSION']
     elsif lsb[:id] =~ /RedHat/i

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -143,7 +143,8 @@ Ohai.plugin(:Platform) do
       # kernel release will be used - ex. 3.13
       platform_version `uname -r`.strip
     elsif os_release_file_is_cisco?
-      raise 'unknown Cisco /etc/os-release ID-LIKE field' unless os_release_info['ID_LIKE'].include?('wrlinux')
+      raise 'unknown Cisco /etc/os-release or /etc/cisco-release ID-LIKE field' if
+        os_release_info['ID_LIKE'].nil? || ! os_release_info['ID_LIKE'].include?('wrlinux')
 
       case os_release_info['ID']
       when 'nexus'
@@ -151,7 +152,7 @@ Ohai.plugin(:Platform) do
       when 'ios_xr'
         platform 'ios_xr'
       else
-        raise 'unknown Cisco /etc/os-release ID field'
+        raise 'unknown Cisco /etc/os-release or /etc/cisco-release ID field'
       end
 
       platform_family 'wrlinux'

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -143,7 +143,7 @@ Ohai.plugin(:Platform) do
       # kernel release will be used - ex. 3.13
       platform_version `uname -r`.strip
     elsif os_release_file_is_cisco?
-      raise 'unknown Cisco /etc/os-release or /etc/cisco-release ID-LIKE field' if
+      raise 'unknown Cisco /etc/os-release or /etc/cisco-release ID_LIKE field' if
         os_release_info['ID_LIKE'].nil? || ! os_release_info['ID_LIKE'].include?('wrlinux')
 
       case os_release_info['ID']

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -650,31 +650,116 @@ CISCO_RELEASE
     end
   end
 
-  describe "on Wind River Linux 5 for Cisco Nexus" do
+  describe '#read_os_release_info' do
+    let(:file_contents) { "COW=MOO\nDOG=\"BARK\"" }
+    it 'returns nil if the file does not exist' do
+      allow(File).to receive(:exist?).with('/etc/test-release').and_return(false)
+      expect(@plugin.read_os_release_info('/etc/test-release')).to be nil
+    end
 
-    let(:have_os_release) { true }
+    it 'returns a hash of expected contents' do
+      allow(File).to receive(:exist?).with('/etc/test-release').and_return(true)
+      allow(File).to receive(:read).with('/etc/test-release').and_return(file_contents)
+      release_info = @plugin.read_os_release_info('/etc/test-release')
 
-    it "should set platform to nexus and platform_family to wrlinux" do
-      @plugin.lsb = nil
-      expect(File).to receive(:read).twice.with("/etc/os-release").and_return("ID=nexus\nID_LIKE=wrlinux\nNAME=Nexus\nVERSION=\"7.0(3)I2(0.475E.6)\"\nVERSION_ID=\"7.0(3)I2\"\nPRETTY_NAME=\"Nexus 7.0(3)I2\"\nHOME_URL=http://www.cisco.com\nBUILD_ID=6\nCISCO_RELEASE_INFO=/etc/os-release")
-      @plugin.run
-      expect(@plugin[:platform]).to eq("nexus")
-      expect(@plugin[:platform_family]).to eq("wrlinux")
-      expect(@plugin[:platform_version]).to eq("7.0(3)I2(0.475E.6)")
+      expect(release_info['COW']).to eq('MOO')
+      expect(release_info['DOG']).to eq('BARK')
     end
   end
 
-  describe "on Wind River Linux 7 for Cisco IOS-XR" do
+  describe '#os_release_info' do
+    context 'when CISCO_RELEASE_INFO is not populated' do
+      let(:release_info) { { 'ID' => 'os_id' } }
 
+      before do
+        allow(File).to receive(:exist?).with('/etc/os-release').and_return(true)
+        allow(@plugin).to receive(:read_os_release_info).with('/etc/os-release').and_return(release_info)
+      end
+
+      it 'reads the os-release file' do
+        expect(@plugin).to receive(:read_os_release_info).with('/etc/os-release').and_return(release_info)
+        @plugin.os_release_info
+      end
+
+      it 'returns a hash of expected contents' do
+        expect(@plugin.os_release_info['ID']).to eq('os_id')
+      end
+    end
+
+    context 'when CISCO_RELEASE_INFO is populated' do
+      let(:release_info) { { 'ID' => 'os_id', 'CISCO_RELEASE_INFO' => '/etc/cisco-release' } }
+      let(:cisco_release_info) { { 'ID' => 'cisco_id' } }
+
+      before do
+        allow(File).to receive(:exist?).with('/etc/os-release').and_return(true)
+        allow(File).to receive(:exist?).with('/etc/cisco-release').and_return(true)
+        allow(@plugin).to receive(:read_os_release_info).with('/etc/os-release').and_return(release_info)
+        allow(@plugin).to receive(:read_os_release_info).with('/etc/cisco-release').and_return(cisco_release_info)
+      end
+
+      it 'reads the os-release AND the cisco-release file' do
+        expect(@plugin).to receive(:read_os_release_info).with('/etc/os-release').and_return(release_info)
+        expect(@plugin).to receive(:read_os_release_info).with('/etc/cisco-release').and_return(release_info)
+        @plugin.os_release_info
+      end
+
+      it 'returns the ID from the cisco-release file instead of the os-release file' do
+        expect(@plugin.os_release_info['ID']).to eq('cisco_id')
+      end
+    end
+  end
+
+  describe 'on Wind River Linux 5 for Cisco Nexus' do
     let(:have_os_release) { true }
+    let(:os_release_info) do
+      {
+        'ID'                 => 'nexus',
+        'ID_LIKE'            => 'wrlinux',
+        'NAME'               => 'Nexus',
+        'VERSION'            => '7.0(3)I2(0.475E.6)',
+        'VERSION_ID'         => '7.0(3)I2',
+        'PRETTY_NAME'        => 'Nexus 7.0(3)I2',
+        'HOME_URL'           => 'http://www.cisco.com',
+        'BUILD_ID'           => '6',
+        'CISCO_RELEASE_INFO' => '/etc/os-release'
+      }
+    end
 
-    it "should set platform to ios_xr and platform_family to wrlinux" do
+    it 'should set platform to nexus and platform_family to wrlinux' do
+      allow(@plugin).to receive(:os_release_info).and_return(os_release_info)
       @plugin.lsb = nil
-      expect(File).to receive(:read).twice.with("/etc/os-release").and_return("ID=ios_xr\nID_LIKE=cisco-wrlinux\nNAME=\"IOS XR\"\nVERSION=\"6.0.0.3I\"\nVERSION_ID=6.0.0.3I\nPRETTY_NAME=\"Cisco IOS XR Software, Version 6.0.0.03I\"\nHOME_URL=http://www.cisco.com\nCISCO_RELEASE_INFO=/etc/os-release")
       @plugin.run
-      expect(@plugin[:platform]).to eq("ios_xr")
-      expect(@plugin[:platform_family]).to eq("wrlinux")
-      expect(@plugin[:platform_version]).to eq("6.0.0.3I")
+
+      expect(@plugin[:platform]).to eq('nexus')
+      expect(@plugin[:platform_family]).to eq('wrlinux')
+      expect(@plugin[:platform_version]).to eq('7.0(3)I2(0.475E.6)')
+    end
+  end
+
+  describe 'on Wind River Linux 7 for Cisco IOS-XR' do
+    let(:have_os_release) { true }
+    let(:os_release_info) do
+      {
+        'ID'          => 'ios_xr',
+        'ID_LIKE'     => 'cisco-wrlinux wrlinux',
+        'NAME'        => 'IOS XR',
+        'VERSION'     => '6.0.0.14I',
+        'VERSION_ID'  => '6.0.0.14I',
+        'PRETTY_NAME' => 'Cisco IOS XR Software, Version 6.0.0.14I',
+        'BUILD_ID'    => '2015-09-10-15-50-17',
+        'HOME_URL'    => 'http://www.cisco.com',
+        'CISCO_RELEASE_INFO' => '/etc/os-release'
+      }
+    end
+
+    it 'should set platform to ios_xr and platform_family to wrlinux' do
+      allow(@plugin).to receive(:os_release_info).and_return(os_release_info)
+      @plugin.lsb = nil
+      @plugin.run
+
+      expect(@plugin[:platform]).to eq('ios_xr')
+      expect(@plugin[:platform_family]).to eq('wrlinux')
+      expect(@plugin[:platform_version]).to eq('6.0.0.14I')
     end
   end
 end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -650,7 +650,7 @@ CISCO_RELEASE
     end
   end
 
-  describe "on Wind River Linux for Cisco Nexus" do
+  describe "on Wind River Linux 5 for Cisco Nexus" do
 
     let(:have_os_release) { true }
 
@@ -661,6 +661,20 @@ CISCO_RELEASE
       expect(@plugin[:platform]).to eq("nexus")
       expect(@plugin[:platform_family]).to eq("wrlinux")
       expect(@plugin[:platform_version]).to eq("7.0(3)I2(0.475E.6)")
+    end
+  end
+
+  describe "on Wind River Linux 7 for Cisco IOS-XR" do
+
+    let(:have_os_release) { true }
+
+    it "should set platform to ios_xr and platform_family to wrlinux" do
+      @plugin.lsb = nil
+      expect(File).to receive(:read).twice.with("/etc/os-release").and_return("ID=ios_xr\nID_LIKE=cisco-wrlinux\nNAME=\"IOS XR\"\nVERSION=\"6.0.0.3I\"\nVERSION_ID=6.0.0.3I\nPRETTY_NAME=\"Cisco IOS XR Software, Version 6.0.0.03I\"\nHOME_URL=http://www.cisco.com\nCISCO_RELEASE_INFO=/etc/os-release")
+      @plugin.run
+      expect(@plugin[:platform]).to eq("ios_xr")
+      expect(@plugin[:platform_family]).to eq("wrlinux")
+      expect(@plugin[:platform_version]).to eq("6.0.0.3I")
     end
   end
 end


### PR DESCRIPTION
WRL7 is used by Cisco on the IOS-XR platform.  This PR adds
additional checks to the os-release and cisco-release files
to properly detect this new platform.