### PR TITLE
Properly detect WPAR networking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 .DS_Store
 .bundle
 *~
+vendor


### PR DESCRIPTION
Previously `ohai` running within a WPAR completely failed to detect any networking information. Now it does. /cc @chef/client-aix @scotthain 

Before:
```
bash-4.2# ohai network
{
  "interfaces": {

  }
}
```

After:
```
bash-4.2# ohai network
{
  "interfaces": {
    "en0": {
      "state": "up",
      "flags": [
        "UP",
        "BROADCAST",
        "NOTRAILERS",
        "RUNNING",
        "SIMPLEX",
        "MULTICAST",
        "GROUPRT",
        "64BIT",
        "CHECKSUM_OFFLOAD(ACTIVE)",
        "CHAIN"
      ],
      "addresses": {
        "172.31.10.211": {
          "family": "inet",
          "prefixlen": null,
          "netmask": "255.255.252.0",
          "broadcast": "172.31.11.255"
        }
      },
      "tcp_sendspace": "262144",
      "tcp_recvspace": "262144",
      "rfc1323": "1"
    },
    "lo0": {
      "state": "up",
      "flags": [
        "UP",
        "BROADCAST",
        "LOOPBACK",
        "RUNNING",
        "SIMPLEX",
        "MULTICAST",
        "GROUPRT",
        "64BIT",
        "LARGESEND",
        "CHAIN"
      ],
      "addresses": {
        "127.0.0.1": {
          "family": "inet",
          "prefixlen": null,
          "netmask": "255.0.0.0",
          "broadcast": "127.255.255.255"
        },
        "::1": {
          "family": "inet6",
          "zone_index": "1",
          "prefixlen": "0"
        }
      },
      "tcp_sendspace": "131072",
      "tcp_recvspace": "131072",
      "rfc1323": "1"
    }
  }
}
```