### PR TITLE
WIP: Adds the 'root_user' Ohai attribute.

### DIFF
--- a/lib/ohai/plugins/root_user.rb
+++ b/lib/ohai/plugins/root_user.rb
@@ -1,0 +1,28 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:RootUser) do
+  provides 'root_user'
+
+  collect_data do
+    case ::RbConfig::CONFIG['host_os']
+    when /mswin|mingw32|windows/
+      root_user 'SYSTEM'
+    else
+      root_user 'root'
+    end
+  end
+end

--- a/spec/unit/plugins/root_user_spec.rb
+++ b/spec/unit/plugins/root_user_spec.rb
@@ -1,0 +1,36 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper.rb')
+
+describe Ohai::System, 'root_user' do
+  before(:each) do
+    @plugin = get_plugin('root_user')
+    @plugin.run
+  end
+
+  describe 'with windows platform' do
+    it 'should return the user system' do
+      expect(@plugin[:root_user]).to eq('SYSTEM')
+    end
+  end
+
+  describe 'with posix platform' do
+    it 'should return the user root' do
+      expect(@plugin[:root_user]).to eq('root')
+    end
+  end
+end


### PR DESCRIPTION
This abstracts out the root user information just as the root group
information is. It makes the appropriate name available via the
root_user attribute.