### PR TITLE
Fix Windows cpu enumeration, add tests

### DIFF
--- a/lib/ohai/plugins/windows/cpu.rb
+++ b/lib/ohai/plugins/windows/cpu.rb
@@ -29,7 +29,7 @@ Ohai.plugin(:CPU) do
     wmi = WmiLite::Wmi.new
     processors = wmi.instances_of('Win32_Processor')
 
-    processors.find(:all).each do |processor|
+    processors.each do |processor|
       #
       # On Windows Server 2003 R2 (i.e. 5.2.*), numberofcores property 
       # doesn't exist on the Win32_Processor class unless the user has

--- a/spec/unit/plugins/windows/cpu_spec.rb
+++ b/spec/unit/plugins/windows/cpu_spec.rb
@@ -1,0 +1,112 @@
+#
+# Author:: Salim Alam (<salam@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper.rb')
+
+shared_examples 'a cpu' do |cpu_no|
+  describe "cpu #{cpu_no}" do
+    it "should set physical_id to CPU#{cpu_no}" do
+      expect(@plugin[:cpu]["#{cpu_no}"][:physical_id]).to eq("CPU#{cpu_no}")
+    end
+
+    it 'should set mhz to 2793' do
+      expect(@plugin[:cpu]["#{cpu_no}"][:mhz]).to eq('2793')
+    end
+
+    it 'should set vendor_id to GenuineIntel' do
+      expect(@plugin[:cpu]["#{cpu_no}"][:vendor_id]).to eq('GenuineIntel')
+    end
+
+    it 'should set model_name to Intel64 Family 6 Model 70 Stepping 1' do
+      expect(@plugin[:cpu]["#{cpu_no}"][:model_name])
+        .to eq('Intel64 Family 6 Model 70 Stepping 1')
+    end
+
+    it 'should set model to 17921' do
+      expect(@plugin[:cpu]["#{cpu_no}"][:model]).to eq('17921')
+    end
+
+    it 'should set family to 2' do
+      expect(@plugin[:cpu]["#{cpu_no}"][:family]).to eq('2')
+    end
+
+    it 'should set stepping to 9' do
+      expect(@plugin[:cpu]["#{cpu_no}"][:stepping]).to eq(9)
+    end
+
+    it 'should set cache_size to 64 KB' do
+      expect(@plugin[:cpu]["#{cpu_no}"][:cache_size]).to eq('64 KB')
+    end
+  end
+end
+
+describe Ohai::System, 'Windows cpu plugin' do
+  before(:each) do
+    @plugin = get_plugin('windows/cpu')
+    allow(@plugin).to receive(:collect_os).and_return(:windows)
+
+    @double_wmi = double(WmiLite::Wmi)
+    @double_wmi_instance = instance_double(WmiLite::Wmi)
+
+    @processors = [{ 'description' => 'Intel64 Family 6 Model 70 Stepping 1',
+                     'deviceid' => 'CPU0',
+                     'family' => 2,
+                     'l2cachesize' => 0,
+                     'manufacturer' => 'GenuineIntel',
+                     'maxclockspeed' => 2793,
+                     'numberofcores' => 1,
+                     'revision' => 17_921,
+                     'stepping' => 9,
+                     'l2cachesize' => 64 },
+
+                   { 'description' => 'Intel64 Family 6 Model 70 Stepping 1',
+                     'deviceid' => 'CPU1',
+                     'family' => 2,
+                     'l2cachesize' => 0,
+                     'manufacturer' => 'GenuineIntel',
+                     'maxclockspeed' => 2793,
+                     'numberofcores' => 1,
+                     'revision' => 17_921,
+                     'stepping' => 9,
+                     'l2cachesize' => 64 }]
+
+    allow(WmiLite::Wmi).to receive(:new).and_return(@double_wmi_instance)
+
+    allow(@double_wmi_instance).to receive(:instances_of)
+      .with('Win32_Processor')
+      .and_return(@processors)
+
+    @plugin.run
+  end
+
+  it 'should set total cpu to 2' do
+    expect(@plugin[:cpu][:total]).to eq(2)
+  end
+
+  it 'should set real cpu to 2' do
+    expect(@plugin[:cpu][:real]).to eq(2)
+  end
+
+  it 'should set 2 distinct cpus numbered 0 and 1' do
+    expect(@plugin[:cpu]).to have_key('0')
+    expect(@plugin[:cpu]).to have_key('1')
+  end
+
+  it_behaves_like 'a cpu', 0
+  it_behaves_like 'a cpu', 1
+end


### PR DESCRIPTION
Windows CPU enumeration was only looking at the first CPU. Hence the core and CPU counts were incorrect. This change also adds unit tests for the Windows CPU plug-in. This fixes issue#623 (https://github.com/chef/ohai/issues/623)

@adamedx @mcquin @thommay @chef/client-core 