### PR TITLE
Add detection for RHEV (on Linux guests) to virtualization plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Ohai Changelog
 
 ## Unreleased
+* [**James Flemer, NDP LLC**](https://github.com/jflemer-ndp):
+  - Add detection for RHEV (on Linux guests) to virtualization plugin
 * [**Shahul Khajamohideen**](https://github.com/sh9189):
   - Fixes Windows :CPU plugin inconsistencies with other platforms: modifies
   `cpu[:total]` to return total number of logical processors, adds `cpu[:cores]`

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -146,7 +146,7 @@ Ohai.plugin(:Virtualization) do
         virtualization[:system] = "openstack"
         virtualization[:role] = "guest"
         virtualization[:systems][:openstack] = "guest"
-      when /Manufacturer: QEMU|Product Name: KVM/
+      when /Manufacturer: QEMU|Product Name: (KVM|RHEV)/
         virtualization[:system] = "kvm"
         virtualization[:role] = "guest"
         virtualization[:systems][:kvm] = "guest"

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -246,6 +246,25 @@ KVM
       expect(plugin[:virtualization][:systems][:kvm]).to eq("guest")
     end
 
+    it "sets kvm guest if dmidecode detects RHEV" do
+      kvm_dmidecode=<<-RHEV
+System Information
+  Manufacturer: Red Hat
+  Product Name: RHEV Hypervisor
+  Version: 6.7-20150911.0.el6ev
+  Serial Number: 00000000-0000-0000-0000-000000000000
+  UUID: E7F1DC93-3DA1-4EC3-A6AB-F6904BA87985
+  Wake-up Type: Power Switch
+  SKU Number: Not Specified
+  Family: Red Hat Enterprise Linux
+RHEV
+      allow(plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, kvm_dmidecode, ""))
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("kvm")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+      expect(plugin[:virtualization][:systems][:kvm]).to eq("guest")
+    end
+
     it "should run dmidecode and not set virtualization if nothing is detected" do
       allow(plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, "", ""))
       plugin.run


### PR DESCRIPTION
### Version:
chef-12.1.1-1.el6 (but also tested with https://github.com/chef/ohai/blob/ae08e09da6d96b7977584ca42dd14c45b51f6e5e/lib/ohai/plugins/linux/virtualization.rb)

### Environment:
RHEL 6 server virtual machine running under RHEV hypervisor

### Scenario:
Detect running in a VM via the `node[:virtualization]` attribute

### Steps to Reproduce:
Run `ohai` in a Linux VM running under RHEL and see that `virtualization` is empty

### Expected Result:
Ok. This is bit up for debate I suppose.  To have the least ripple and the most compatiblity with existing cookbooks, I would think the expected result should be the same when running under the RHEV hypervisor as running under KVM (this is what I implemented).  But I could see some interest it differentiating KVM and RHEV even though the RHEV hypervisor is KVM.  However, someone interested in RHEV specifically can still check for RHEV in their own cookbook.  So I think the implemented solution has the broadest use.
```
  "virtualization": {
    "systems": {
      "kvm": "guest"
    },
    "system": "kvm",
    "role": "guest"
  },
```

### Actual Result:
```
  "virtualization": {
    "systems": {

    }
  },
```