### PR TITLE
Fix and extend CPU detection on FreeBSD

### DIFF
--- a/lib/ohai/plugins/freebsd/cpu.rb
+++ b/lib/ohai/plugins/freebsd/cpu.rb
@@ -41,7 +41,7 @@ Ohai.plugin(:CPU) do
       when /CPU:\s+(.+) \(([\d.]+).+\)/
         cpuinfo["model_name"] = $1
         cpuinfo["mhz"] = $2
-      when /\s+Origin="(.*)"\s.*Family=(?:0x)?(\S+)\s.*Model=(?:0x)?(\S+)\s+Stepping=(?:0x)?(\S+)/
+      when /\s+Origin.*"(.*)".*Family.*0x(\S+).*Model.*0x(\S+).*Stepping.*(\S+)/
         cpuinfo["vendor_id"] = $1
         cpuinfo["family"] = $2
         cpuinfo["model"] = $3

--- a/lib/ohai/plugins/freebsd/cpu.rb
+++ b/lib/ohai/plugins/freebsd/cpu.rb
@@ -1,5 +1,6 @@
 #
 # Author:: Bryan McLellan (btm@loftninjas.org)
+# Author:: Tim Smith (tsmith@chef.io)
 # Copyright:: Copyright (c) 2008 Bryan McLellan
 # License:: Apache License, Version 2.0
 #
@@ -43,8 +44,9 @@ Ohai.plugin(:CPU) do
         cpuinfo["mhz"] = $2
       when /Origin.*"(.*)".*Family.*0x(\S+).*Model.*0x(\S+).*Stepping.*(\S+)/
         cpuinfo["vendor_id"] = $1
-        cpuinfo["family"] = $2
-        cpuinfo["model"] = $3
+        # convert from hex value to int, but keep a string to match Linux ohai
+        cpuinfo["family"] = $2.to_i(16).to_s
+        cpuinfo["model"] = $3.to_i(16).to_s
         cpuinfo["stepping"] = $4
         # These _should_ match /AMD Features2?/ lines as well
       when /Features=.+<(.+)>/

--- a/lib/ohai/plugins/freebsd/cpu.rb
+++ b/lib/ohai/plugins/freebsd/cpu.rb
@@ -27,21 +27,25 @@ Ohai.plugin(:CPU) do
     cpuinfo["flags"] = []
 
     # /var/run/dmesg.boot
-    # CPU: Intel(R) Core(TM) i7-3615QM CPU @ 2.30GHz (3516.61-MHz K8-class CPU)
-    # Origin = "GenuineIntel"  Id = 0x306a9  Family = 6  Model = 3a  Stepping = 9
-    # Features=0x783fbff<FPU,VME,DE,PSE,TSC,MSR,PAE,MCE,CX8,APIC,SEP,MTRR,PGE,MCA,CMOV,PAT,PSE36,MMX,FXSR,SSE,SSE2>
-    # Features2=0x209<SSE3,MON,SSSE3>
-    # AMD Features=0x28100800<SYSCALL,NX,RDTSCP,LM>
-    # AMD Features2=0x1<LAHF>
+    # CPU: Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz (2793.59-MHz K8-class CPU)
+    #   Origin="GenuineIntel"  Id=0x40661  Family=0x6  Model=0x46  Stepping=1
+    #   Features=0x783fbff<FPU,VME,DE,PSE,TSC,MSR,PAE,MCE,CX8,APIC,SEP,MTRR,PGE,MCA,CMOV,PAT,PSE36,MMX,FXSR,SSE,SSE2>
+    #   Features2=0x5ed8220b<SSE3,PCLMULQDQ,MON,SSSE3,CX16,SSE4.1,SSE4.2,MOVBE,POPCNT,AESNI,XSAVE,OSXSAVE,AVX,RDRAND>
+    #   AMD Features=0x28100800<SYSCALL,NX,RDTSCP,LM>
+    #   AMD Features2=0x21<LAHF,ABM>
+    #   Structured Extended Features=0x2000<NFPUSG>
+    #   TSC: P-state invariant
 
     File.open("/var/run/dmesg.boot").each do |line|
       case line
       when /CPU:\s+(.+) \(([\d.]+).+\)/
         cpuinfo["model_name"] = $1
         cpuinfo["mhz"] = $2
-      when /Origin = "(.+)"\s+Id = (.+)\s+Stepping = (.+)/
+      when /\s+Origin="(.*)"\s.*Family=(?:0x)?(\S+)\s.*Model=(?:0x)?(\S+)\s+Stepping=(?:0x)?(\S+)/
         cpuinfo["vendor_id"] = $1
-        cpuinfo["stepping"] = $3
+        cpuinfo["family"] = $2
+        cpuinfo["model"] = $3
+        cpuinfo["stepping"] = $4
         # These _should_ match /AMD Features2?/ lines as well
       when /Features=.+<(.+)>/
         cpuinfo["flags"].concat($1.downcase.split(','))

--- a/lib/ohai/plugins/freebsd/cpu.rb
+++ b/lib/ohai/plugins/freebsd/cpu.rb
@@ -41,7 +41,7 @@ Ohai.plugin(:CPU) do
       when /CPU:\s+(.+) \(([\d.]+).+\)/
         cpuinfo["model_name"] = $1
         cpuinfo["mhz"] = $2
-      when /\s+Origin.*"(.*)".*Family.*0x(\S+).*Model.*0x(\S+).*Stepping.*(\S+)/
+      when /Origin.*"(.*)".*Family.*0x(\S+).*Model.*0x(\S+).*Stepping.*(\S+)/
         cpuinfo["vendor_id"] = $1
         cpuinfo["family"] = $2
         cpuinfo["model"] = $3

--- a/spec/unit/plugins/freebsd/cpu_spec.rb
+++ b/spec/unit/plugins/freebsd/cpu_spec.rb
@@ -25,42 +25,53 @@ describe Ohai::System, "FreeBSD cpu plugin" do
     allow(@plugin).to receive(:shell_out).with("sysctl -n hw.ncpu").and_return(mock_shell_out(0, "2", ""))
     @double_file = double("/var/run/dmesg.boot")
     allow(@double_file).to receive(:each).
-      and_yield('CPU: Intel(R) Core(TM) i7-3615QM CPU @ 2.30GHz (3516.61-MHz K8-class CPU)').
-      and_yield('  Origin = "GenuineIntel"  Id = 0x306a9  Family = 6  Model = 3a  Stepping = 9').
+      and_yield('CPU: Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz (2793.59-MHz K8-class CPU)').
+      and_yield('  Origin="GenuineIntel"  Id=0x40661  Family=0x6  Model=0x46  Stepping=1').
       and_yield('  Features=0x783fbff<FPU,VME,DE,PSE,TSC,MSR,PAE,MCE,CX8,APIC,SEP,MTRR,PGE,MCA,CMOV,PAT,PSE36,MMX,FXSR,SSE,SSE2>').
-      and_yield('  Features2=0x209<SSE3,MON,SSSE3>').
+      and_yield('  Features2=0x5ed8220b<SSE3,PCLMULQDQ,MON,SSSE3,CX16,SSE4.1,SSE4.2,MOVBE,POPCNT,AESNI,XSAVE,OSXSAVE,AVX,RDRAND>').
       and_yield('  AMD Features=0x28100800<SYSCALL,NX,RDTSCP,LM>').
-      and_yield('  AMD Features2=0x1<LAHF>').
+      and_yield('  AMD Features2=0x21<LAHF,ABM>').
+      and_yield('  Structured Extended Features=0x2000<NFPUSG>').
       and_yield('  TSC: P-state invariant')
     allow(File).to receive(:open).with("/var/run/dmesg.boot").and_return(@double_file)
   end
 
   it "detects all CPU flags" do
     @plugin.run
-    expect(@plugin[:cpu][:flags]).to eq(%w{fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 mmx fxsr sse sse2 sse3 mon ssse3 syscall nx rdtscp lm lahf})
+    expect(@plugin[:cpu][:flags]).to eq(%w{fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 mmx fxsr sse sse2 sse3 pclmulqdq mon ssse3 cx16 sse4.1 sse4.2 movbe popcnt aesni xsave osxsave avx rdrand syscall nx rdtscp lm lahf abm nfpusg})
   end
 
-  it "detects all CPU model_name" do
+  it "detects CPU model_name" do
     @plugin.run
-    expect(@plugin[:cpu][:model_name]).to eq("Intel(R) Core(TM) i7-3615QM CPU @ 2.30GHz")
+    expect(@plugin[:cpu][:model_name]).to eq("Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz")
   end
 
-  it "detects all CPU mhz" do
+  it "detects CPU mhz" do
     @plugin.run
-    expect(@plugin[:cpu][:mhz]).to eq("3516.61")
+    expect(@plugin[:cpu][:mhz]).to eq("2793.59")
   end
 
-  it "detects all CPU vendor_id" do
+  it "detects CPU vendor_id" do
     @plugin.run
     expect(@plugin[:cpu][:vendor_id]).to eq("GenuineIntel")
   end
 
-  it "detects all CPU stepping" do
+  it "detects CPU family" do
     @plugin.run
-    expect(@plugin[:cpu][:stepping]).to eq("9")
+    expect(@plugin[:cpu][:family]).to eq("6")
   end
 
-  it "detects all CPU total" do
+  it "detects CPU model" do
+    @plugin.run
+    expect(@plugin[:cpu][:model]).to eq("46")
+  end
+
+  it "detects CPU stepping" do
+    @plugin.run
+    expect(@plugin[:cpu][:stepping]).to eq("1")
+  end
+
+  it "detects CPU total" do
     @plugin.run
     expect(@plugin[:cpu][:total]).to eq(2)
   end

--- a/spec/unit/plugins/freebsd/cpu_spec.rb
+++ b/spec/unit/plugins/freebsd/cpu_spec.rb
@@ -63,7 +63,7 @@ describe Ohai::System, "FreeBSD cpu plugin on FreeBSD >=10.2" do
 
   it "detects CPU model" do
     @plugin.run
-    expect(@plugin[:cpu][:model]).to eq("46")
+    expect(@plugin[:cpu][:model]).to eq("70")
   end
 
   it "detects CPU stepping" do
@@ -102,7 +102,8 @@ describe Ohai::System, "FreeBSD cpu plugin on FreeBSD <=10.1" do
 
   it "detects CPU model" do
     @plugin.run
-    expect(@plugin[:cpu][:model]).to eq("1c")
+
+    expect(@plugin[:cpu][:model]).to eq("28")
   end
 
   it "detects CPU stepping" do


### PR DESCRIPTION
The comment block and the tests had an incorrect sample of what
dmesg.boot looked like.  I got 68 different people to send me samples of
what the output looks like, with about 100 samples total.  The Origin
line is always indented and the spacing around the equals
signs differ.  On 10.2+ there are not spaces, but on 10.1 and earlier there are 
spaces.  I updated the regex to properly detect the existing fields and
also added family/model values, which we already gathered on Linux.