### PR TITLE
Collect inode data on FreeBSD and add filesystem specs

### DIFF
--- a/lib/ohai/plugins/freebsd/filesystem.rb
+++ b/lib/ohai/plugins/freebsd/filesystem.rb
@@ -44,9 +44,9 @@ Ohai.plugin(:Filesystem) do
     so = shell_out("df -iP")
     so.stdout.lines do |line|
       case line
-      when /^Filesystem\s+Size/
+      when /^Filesystem/
         next
-      when /^(.+?)\s.*\d+\%\s+(\d+)\s+(\d+)\s+(\d+\%)\s+(.+)$/
+      when /^(\S+)\s.+%\s+(\d+)\s+(\d+)\s+(\d+\%)\s+(\S+)/
         filesystem = $1
         fs[filesystem] ||= Mash.new
         fs[filesystem][:total_inodes] = ($2.to_i + $3.to_i).to_s

--- a/lib/ohai/plugins/freebsd/filesystem.rb
+++ b/lib/ohai/plugins/freebsd/filesystem.rb
@@ -40,20 +40,20 @@ Ohai.plugin(:Filesystem) do
       end
     end
 
-    # Grab filesystem inode data from df
+    # inode parsing from 'df -iP'
     so = shell_out("df -iP")
     so.stdout.lines do |line|
       case line
-      when /^Filesystem/
+      when /^Filesystem/ # skip the header
         next
-      when /^(\S+)\s.+%\s+(\d+)\s+(\d+)\s+(\d+\%)\s+(\S+)/
-        filesystem = $1
+      when /^(.+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\%\s+(\d+)\s+(\d+)\s+(\d+)%(.+)$/
+        filesystem = $1.strip
         fs[filesystem] ||= Mash.new
-        fs[filesystem][:total_inodes] = ($2.to_i + $3.to_i).to_s
-        fs[filesystem][:inodes_used] = $2
-        fs[filesystem][:inodes_available] = $3
-        fs[filesystem][:inodes_percent_used] = $4
-        fs[filesystem][:mount] = $5
+        fs[filesystem][:inodes_used] = $6
+        fs[filesystem][:inodes_available] = $7
+        fs[filesystem][:total_inodes] = ($6.to_i + $7.to_i).to_s
+        fs[filesystem][:inodes_percent_used] = $8
+        fs[filesystem][:mount] = $9.strip
       end
     end
 

--- a/lib/ohai/plugins/freebsd/filesystem.rb
+++ b/lib/ohai/plugins/freebsd/filesystem.rb
@@ -1,6 +1,7 @@
 #
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Copyright:: Copyright (c) 2008 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Tim Smith (<tsmith@chef.io>)
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +37,23 @@ Ohai.plugin(:Filesystem) do
         fs[filesystem][:kb_available] = $4
         fs[filesystem][:percent_used] = $5
         fs[filesystem][:mount] = $6
+      end
+    end
+
+    # Grab filesystem inode data from df
+    so = shell_out("df -iP")
+    so.stdout.lines do |line|
+      case line
+      when /^Filesystem\s+Size/
+        next
+      when /^(.+?)\s.*\d+\%\s+(\d+)\s+(\d+)\s+(\d+\%)\s+(.+)$/
+        filesystem = $1
+        fs[filesystem] ||= Mash.new
+        fs[filesystem][:total_inodes] = ($2.to_i + $3.to_i).to_s
+        fs[filesystem][:inodes_used] = $2
+        fs[filesystem][:inodes_available] = $3
+        fs[filesystem][:inodes_percent_used] = $4
+        fs[filesystem][:mount] = $5
       end
     end
 

--- a/lib/ohai/plugins/freebsd/os.rb
+++ b/lib/ohai/plugins/freebsd/os.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:OS) do
   collect_data(:freebsd) do
     os collect_os
 
-    # This is __FreeBSD_version. See sys/param.h or 
+    # This is __FreeBSD_version. See sys/param.h or
     # http://www.freebsd.org/doc/en/books/porters-handbook/freebsd-versions.html.
     os_version shell_out("sysctl -n kern.osreldate").stdout.split($/)[0]
   end

--- a/spec/unit/plugins/freebsd/filesystem_spec.rb
+++ b/spec/unit/plugins/freebsd/filesystem_spec.rb
@@ -1,0 +1,126 @@
+#
+# Author:: Matthew Kent (<mkent@magoazul.com>)
+# Author:: Tim Smith (<tsmith@chef.io>)
+# Copyright:: Copyright (c) 2011-2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper.rb')
+
+describe Ohai::System, "FreeBSD filesystem plugin" do
+  let(:plugin) { get_plugin("freebsd/filesystem") }
+  before(:each) do
+    allow(plugin).to receive(:collect_os).and_return(:freebsd)
+
+    allow(plugin).to receive(:shell_out).with("df").and_return(mock_shell_out(0, "", ""))
+    allow(plugin).to receive(:shell_out).with("df -iP").and_return(mock_shell_out(0, "", ""))
+    allow(plugin).to receive(:shell_out).with("mount -l").and_return(mock_shell_out(0, "", ""))
+  end
+
+  describe "when gathering filesystem usage data from df" do
+    before(:each) do
+      @stdout = <<-DF
+Filesystem  1K-blocks    Used   Avail Capacity  Mounted on
+/dev/ada0p2   9637788 3313504 5553264    37%    /
+devfs               1       1       0   100%    /dev
+DF
+      allow(plugin).to receive(:shell_out).with("df").and_return(mock_shell_out(0, @stdout, ""))
+
+      @inode_stdout = <<-DFi
+Filesystem  512-blocks    Used   Avail Capacity iused  ifree %iused  Mounted on
+/dev/ada0p2   15411832 5109256 9069632    36%  252576 790750   24%   /
+devfs                2       2       0   100%       0      0  100%   /dev
+DFi
+      allow(plugin).to receive(:shell_out).with("df -iP").and_return(mock_shell_out(0, @inode_stdout, ""))
+    end
+
+    it "should run df and df -iP" do
+      expect(plugin).to receive(:shell_out).ordered.with("df").and_return(mock_shell_out(0, @stdout, ""))
+      expect(plugin).to receive(:shell_out).ordered.with("df -iP").and_return(mock_shell_out(0, @inode_stdout, ""))
+      plugin.run
+    end
+
+    it "should set kb_size to value from df" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:kb_size]).to eq("9637788")
+    end
+
+    it "should set kb_used to value from df" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:kb_used]).to eq("3313504")
+    end
+
+    it "should set kb_available to value from df" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:kb_available]).to eq("5553264")
+    end
+
+    it "should set percent_used to value from df" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:percent_used]).to eq("37%")
+    end
+
+    it "should set mount to value from df" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:mount]).to eq("/")
+    end
+
+    it "should set total_inodes to value from df -iP" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:total_inodes]).to eq("1043326")
+    end
+
+    it "should set inodes_used to value from df -iP" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:inodes_used]).to eq("252576")
+    end
+
+    it "should set inodes_available to value from df -iP" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:inodes_available]).to eq("790750")
+    end
+  end
+
+  describe "when gathering mounted filesystem data from mount" do
+    before(:each) do
+      @stdout = <<-MOUNT
+/dev/ada0p2 on / (ufs, local, journaled soft-updates)
+devfs on /dev (devfs, local, multilabel)
+MOUNT
+      allow(plugin).to receive(:shell_out).with("mount -l").and_return(mock_shell_out(0, @stdout, ""))
+    end
+
+    it "should run mount" do
+      expect(plugin).to receive(:shell_out).with("mount -l").and_return(mock_shell_out(0, @stdout, ""))
+      plugin.run
+    end
+
+    it "should set mount to value from mount" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:mount]).to eq("/")
+    end
+
+    it "should set fs_type to value from mount" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:fs_type]).to eq("ufs")
+    end
+
+    it "should set mount_options to an array of values from mount" do
+      plugin.run
+      expect(plugin[:filesystem]["/dev/ada0p2"][:mount_options]).to eq(["local", "journaled soft-updates"])
+    end
+  end
+
+end


### PR DESCRIPTION
Modified version of the inode collection code from the Linux plugin.
Also add a filesystem spec for FreeBSD which is about 1/3 the specs from
the Linux filesystem spec, but modified for command output on FreeBSD