### PR TITLE
"hostname/fqdn" returns nil for CentOS 6

### DIFF
--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -124,6 +124,15 @@ Ohai.plugin(:Hostname) do
         ourfqdn = from_cmd("hostname --fqdn")
       end
 
+      # Some IaaS providers (ie. DigitalOcean) don't set the server name in
+      # /etc/hosts, and so 'hostname --fqdn` fails. However, `hostname
+      # --all-fqdns` might still succeed.
+      if ourfqdn.nil? || ourfqdn.empty?
+        Ohai::Log.debug("hostname --fqdn returned an empty string, retrying " +
+                        "with --all-fqdns flag.")
+        ourfqdn = from_cmd("hostname --all-fqdns")
+      end
+
       if ourfqdn.nil? || ourfqdn.empty?
         Ohai::Log.debug("hostname --fqdn returned an empty string twice and " +
                         "will not be set.")

--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -124,6 +124,11 @@ Ohai.plugin(:Hostname) do
         ourfqdn = from_cmd("hostname --fqdn")
       end
 
+      if ourfqdn.nil? || ourfqdn.empty?
+        Ohai::Log.debug("hostname --fqdn returned an empty string twice and " +
+                        "will not be set.")
+      end
+
       # Some IaaS providers (ie. DigitalOcean) don't set the server name in
       # /etc/hosts, and so 'hostname --fqdn` fails. However, `hostname
       # --all-fqdns` might still succeed.
@@ -133,15 +138,12 @@ Ohai.plugin(:Hostname) do
         ourfqdn = from_cmd("hostname --all-fqdns")
       end
 
-      if ourfqdn.nil? || ourfqdn.empty?
-        Ohai::Log.debug("hostname --fqdn returned an empty string twice and " +
-                        "will not be set.")
-      else
-        fqdn ourfqdn
-      end
+      fqdn ourfqdn
     rescue
       Ohai::Log.debug(
         "hostname --fqdn returned an error, probably no domain set")
+
+      fqdn nil
     end
     domain collect_domain
   end


### PR DESCRIPTION
Seems that on a fresh centos 6.7 server on digital ocean, when someone names the server a full FQDN, there is some quirky behavior.

```
[root@jira ~]# hostname
example.blendive.com
[root@jira ~]# hostname --short
example
[root@jira ~]# hostname --fqdn
hostname: Unknown host
[root@jira ~]# hostname --all-fqdns
example.blendive.com
```

It probably has to the with the fact that nothing beyond localhost is set in the hosts file:

```
[root@jira ~]# cat /etc/hosts
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
```

(Setting the server name in the hosts file itself resolves the error. Not sure if that's an issue with how DigitalOcean provisions its images, or if that's expected and done similarly elsewhere.)

The error these circumstances, ohai chooses not to set the fqdn on the node object. I think it would be better to, in case where `hostname --fqdn` fails, that we use the output of `hostname --all-fqdns` which would make for a good last resort.

Thoughts?