### PR TITLE
mime-types 3 is Ruby 2.0+ only

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_dependency "mime-types", "~> 2.0"
+  s.add_dependency "mime-types", "~> 3.0"
   s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "mixlib-cli"


### PR DESCRIPTION
This was released on the 2015-11-21.