### PR TITLE
Only poll vmware attributes when on vmware

### DIFF
--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -1,7 +1,7 @@
 #
-# Author:: "Dan Robinson" <drobinson@getchef.com>
+# Author:: "Dan Robinson" <drobinson@chef.io>
 # Author:: "Christopher M. Luciano" <cmlucian@us.ibm.com>
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2014-2015 Chef Software, Inc.
 # Copyright (C) 2015 IBM Corp.
 # License:: Apache License, Version 2.0
 #
@@ -33,6 +33,7 @@
 
 Ohai.plugin(:VMware) do
   provides "vmware"
+  depends "virtualization"
 
   def from_cmd(cmd)
     so = shell_out(cmd)
@@ -67,7 +68,7 @@ Ohai.plugin(:VMware) do
   end
 
   collect_data(:linux) do
-    get_vm_attributes("/usr/bin/vmware-toolbox-cmd")
+    get_vm_attributes("/usr/bin/vmware-toolbox-cmd") if virtualization[:systems][:vmware]
   end
 
 end

--- a/spec/unit/plugins/vmware_spec.rb
+++ b/spec/unit/plugins/vmware_spec.rb
@@ -16,47 +16,63 @@
 # limitations under the License.
 require 'spec_helper'
 
-describe Ohai::System, "plugin vmware" do
+describe Ohai::System, 'plugin vmware' do
+  let(:plugin) { get_plugin('vmware') }
+  let(:path) { '/usr/bin/vmware-toolbox-cmd' }
 
-  let(:plugin) { get_plugin("vmware") }
-  let(:path) { "/usr/bin/vmware-toolbox-cmd" }
+  before(:each) do
+    allow(plugin).to receive(:collect_os).and_return(:linux)
+  end
 
-  context "vmware toolbox" do
-
-    def setup_stubs
-      allow(File).to receive(:exist?).and_return(true)
-      allow(plugin).to receive(:collect_os).and_return(:linux)
-      allow(plugin).to receive(:shell_out).with("#{path} stat speed").and_return(mock_shell_out(0, "2000 MHz", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat hosttime").and_return(mock_shell_out(0, "04 Jun 2015 19:21:16", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat sessionid").and_return(mock_shell_out(0, "0x0000000000000000", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat balloon").and_return(mock_shell_out(0, "0 MB", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat swap").and_return(mock_shell_out(0, "0 MB", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat memlimit").and_return(mock_shell_out(0, "4000000000 MB", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat memres").and_return(mock_shell_out(0, "0 MB", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat cpures").and_return(mock_shell_out(0, "0 MHz", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat cpulimit").and_return(mock_shell_out(0, "4000000000 MB", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} upgrade status").and_return(mock_shell_out(0, "VMware Tools are up-to-date.", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} timesync status").and_return(mock_shell_out(0, "Disabled", nil))
+  context 'on vmware guest with toolbox installed' do
+    before(:each) do
+      allow(File).to receive(:exist?).with('/usr/bin/vmware-toolbox-cmd').and_return(true)
+      allow(plugin).to receive(:shell_out).with("#{path} stat speed").and_return(mock_shell_out(0, '2000 MHz', nil))
+      allow(plugin).to receive(:shell_out).with("#{path} stat hosttime").and_return(mock_shell_out(0, '04 Jun 2015 19:21:16', nil))
+      allow(plugin).to receive(:shell_out).with("#{path} stat sessionid").and_return(mock_shell_out(0, '0x0000000000000000', nil))
+      allow(plugin).to receive(:shell_out).with("#{path} stat balloon").and_return(mock_shell_out(0, '0 MB', nil))
+      allow(plugin).to receive(:shell_out).with("#{path} stat swap").and_return(mock_shell_out(0, '0 MB', nil))
+      allow(plugin).to receive(:shell_out).with("#{path} stat memlimit").and_return(mock_shell_out(0, '4000000000 MB', nil))
+      allow(plugin).to receive(:shell_out).with("#{path} stat memres").and_return(mock_shell_out(0, '0 MB', nil))
+      allow(plugin).to receive(:shell_out).with("#{path} stat cpures").and_return(mock_shell_out(0, '0 MHz', nil))
+      allow(plugin).to receive(:shell_out).with("#{path} stat cpulimit").and_return(mock_shell_out(0, '4000000000 MB', nil))
+      allow(plugin).to receive(:shell_out).with("#{path} upgrade status").and_return(mock_shell_out(0, 'VMware Tools are up-to-date.', nil))
+      allow(plugin).to receive(:shell_out).with("#{path} timesync status").and_return(mock_shell_out(0, 'Disabled', nil))
+      plugin[:virtualization] = Mash.new
+      plugin[:virtualization][:systems] = Mash.new
+      plugin[:virtualization][:systems][:vmware] = Mash.new
       plugin.run
     end
 
-    before(:each) do
-      setup_stubs
+    it 'gets the speed' do
+      expect(plugin[:vmware][:speed]).to eq('2000 MHz')
     end
 
-    context "the vmware toolbox cmd" do
+    it 'gets the hosttime' do
+      expect(plugin[:vmware][:hosttime]).to eq('04 Jun 2015 19:21:16')
+    end
 
-      it "gets the speed" do
-        expect(plugin[:vmware][:speed]).to eq("2000 MHz")
-      end
+    it 'gets tools update status' do
+      expect(plugin[:vmware][:upgrade]).to eq('VMware Tools are up-to-date.')
+    end
+  end
 
-      it "gets the hosttime" do
-        expect(plugin[:vmware][:hosttime]).to eq("04 Jun 2015 19:21:16")
-      end
+  context 'on vmware guest without toolbox' do
+    it 'should not create a vmware attribute' do
+      plugin[:virtualization] = Mash.new
+      plugin[:virtualization][:systems] = Mash.new
+      plugin[:virtualization][:systems][:vmware] = Mash.new
+      allow(File).to receive(:exist?).with('/usr/bin/vmware-toolbox-cmd').and_return(false)
+      expect(plugin).not_to have_key(:vmware)
+    end
+  end
 
-      it "gets tools update status" do
-        expect(plugin[:vmware][:upgrade]).to eq("VMware Tools are up-to-date.")
-      end
+  context 'on vbox guest' do
+    it 'should not create a vmware attribute' do
+      plugin[:virtualization] = Mash.new
+      plugin[:virtualization][:systems] = Mash.new
+      plugin[:virtualization][:systems][:vbox] = Mash.new
+      expect(plugin).not_to have_key(:vmware)
     end
   end
 end


### PR DESCRIPTION
This will prevent Azure guests that contain the vmware toolbox CLI from being identified as vmware hosts.  We shouldn't even try to grab vmware values unless dmidecode has identified the host as vmware.  Added specs for when the CLI is missing and when we're not running on vmware.