### PR TITLE
Determine real, total, and cores for BSD

### DIFF
--- a/lib/ohai/plugins/freebsd/cpu.rb
+++ b/lib/ohai/plugins/freebsd/cpu.rb
@@ -36,6 +36,9 @@ Ohai.plugin(:CPU) do
     #   AMD Features2=0x21<LAHF,ABM>
     #   Structured Extended Features=0x2000<NFPUSG>
     #   TSC: P-state invariant
+    #   ...
+    #   FreeBSD/SMP: Multiprocessor System Detected: 8 CPUs
+    #   FreeBSD/SMP: 1 package(s) x 4 core(s) x 2 SMT threads
 
     File.open("/var/run/dmesg.boot").each do |line|
       case line
@@ -54,13 +57,14 @@ Ohai.plugin(:CPU) do
         # Features2=0x80000001<SSE3,<b31>>
       when /Features2=[a-f\dx]+<(.+)>/
         cpuinfo["flags"].concat($1.downcase.split(','))
-      when /Logical CPUs per core: (\d+)/
-        cpuinfo["cores"] = $1
+      when /FreeBSD\/SMP: Multiprocessor System Detected: (\d*) CPUs/
+        cpuinfo["total"] = $1.to_i
+      when /FreeBSD\/SMP: (\d*) package\(s\) x (\d*) core\(s\)/
+        cpuinfo["real"] = $1.to_i
+        cpuinfo["cores"] = $2.to_i
       end
     end
 
     cpu cpuinfo
-    so = shell_out("sysctl -n hw.ncpu")
-    cpu[:total] = so.stdout.split($/)[0].to_i
   end
 end

--- a/lib/ohai/plugins/freebsd/cpu.rb
+++ b/lib/ohai/plugins/freebsd/cpu.rb
@@ -37,8 +37,8 @@ Ohai.plugin(:CPU) do
     #   Structured Extended Features=0x2000<NFPUSG>
     #   TSC: P-state invariant
     #   ...
-    #   FreeBSD/SMP: Multiprocessor System Detected: 8 CPUs
-    #   FreeBSD/SMP: 1 package(s) x 4 core(s) x 2 SMT threads
+    #   FreeBSD/SMP: Multiprocessor System Detected: 16 CPUs
+    #   FreeBSD/SMP: 2 package(s) x 4 core(s) x 2 SMT threads
 
     File.open("/var/run/dmesg.boot").each do |line|
       case line
@@ -61,7 +61,7 @@ Ohai.plugin(:CPU) do
         cpuinfo["total"] = $1.to_i
       when /FreeBSD\/SMP: (\d*) package\(s\) x (\d*) core\(s\)/
         cpuinfo["real"] = $1.to_i
-        cpuinfo["cores"] = $2.to_i
+        cpuinfo["cores"] = $1.to_i * $2.to_i
       end
     end
 

--- a/spec/unit/plugins/freebsd/cpu_spec.rb
+++ b/spec/unit/plugins/freebsd/cpu_spec.rb
@@ -36,8 +36,8 @@ describe Ohai::System, "FreeBSD cpu plugin on FreeBSD >=10.2" do
       and_yield('avail memory = 1010253824 (963 MB)').
       and_yield('Event timer "LAPIC" quality 400').
       and_yield('ACPI APIC Table: <VBOX   VBOXAPIC>').
-      and_yield('FreeBSD/SMP: Multiprocessor System Detected: 8 CPUs').
-      and_yield('FreeBSD/SMP: 1 package(s) x 4 core(s) x 2 SMT threads')
+      and_yield('FreeBSD/SMP: Multiprocessor System Detected: 16 CPUs').
+      and_yield('FreeBSD/SMP: 2 package(s) x 4 core(s) x 2 SMT threads')
     allow(File).to receive(:open).with("/var/run/dmesg.boot").and_return(@double_file)
   end
 
@@ -78,17 +78,17 @@ describe Ohai::System, "FreeBSD cpu plugin on FreeBSD >=10.2" do
 
   it "detects real CPUs" do
     @plugin.run
-    expect(@plugin[:cpu][:real]).to eq(1)
+    expect(@plugin[:cpu][:real]).to eq(2)
   end
 
   it "detects total real CPU cores" do
     @plugin.run
-    expect(@plugin[:cpu][:cores]).to eq(4)
+    expect(@plugin[:cpu][:cores]).to eq(8)
   end
 
   it "detects total HT CPU cores" do
     @plugin.run
-    expect(@plugin[:cpu][:total]).to eq(8)
+    expect(@plugin[:cpu][:total]).to eq(16)
   end
 
 end

--- a/spec/unit/plugins/freebsd/cpu_spec.rb
+++ b/spec/unit/plugins/freebsd/cpu_spec.rb
@@ -22,7 +22,6 @@ describe Ohai::System, "FreeBSD cpu plugin on FreeBSD >=10.2" do
   before(:each) do
     @plugin = get_plugin("freebsd/cpu")
     allow(@plugin).to receive(:collect_os).and_return(:freebsd)
-    allow(@plugin).to receive(:shell_out).with("sysctl -n hw.ncpu").and_return(mock_shell_out(0, "2", ""))
     @double_file = double("/var/run/dmesg.boot")
     allow(@double_file).to receive(:each).
       and_yield('CPU: Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz (2793.59-MHz K8-class CPU)').
@@ -32,7 +31,13 @@ describe Ohai::System, "FreeBSD cpu plugin on FreeBSD >=10.2" do
       and_yield('  AMD Features=0x28100800<SYSCALL,NX,RDTSCP,LM>').
       and_yield('  AMD Features2=0x21<LAHF,ABM>').
       and_yield('  Structured Extended Features=0x2000<NFPUSG>').
-      and_yield('  TSC: P-state invariant')
+      and_yield('  TSC: P-state invariant').
+      and_yield('real memory  = 1073676288 (1023 MB)').
+      and_yield('avail memory = 1010253824 (963 MB)').
+      and_yield('Event timer "LAPIC" quality 400').
+      and_yield('ACPI APIC Table: <VBOX   VBOXAPIC>').
+      and_yield('FreeBSD/SMP: Multiprocessor System Detected: 8 CPUs').
+      and_yield('FreeBSD/SMP: 1 package(s) x 4 core(s) x 2 SMT threads')
     allow(File).to receive(:open).with("/var/run/dmesg.boot").and_return(@double_file)
   end
 
@@ -71,9 +76,19 @@ describe Ohai::System, "FreeBSD cpu plugin on FreeBSD >=10.2" do
     expect(@plugin[:cpu][:stepping]).to eq("1")
   end
 
-  it "detects CPU total" do
+  it "detects real CPUs" do
     @plugin.run
-    expect(@plugin[:cpu][:total]).to eq(2)
+    expect(@plugin[:cpu][:real]).to eq(1)
+  end
+
+  it "detects total real CPU cores" do
+    @plugin.run
+    expect(@plugin[:cpu][:cores]).to eq(4)
+  end
+
+  it "detects total HT CPU cores" do
+    @plugin.run
+    expect(@plugin[:cpu][:total]).to eq(8)
   end
 
 end


### PR DESCRIPTION
Use dmesg to correctly determine the number of real CPUs, the number of
real cores, and the number of HT cores.  This aligns CPU count data with
what we collect on Linux.