### PR TITLE
The mime must die

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_dependency "mime-types", "~> 3.0"
   s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "mixlib-cli"


### PR DESCRIPTION
We don't use this gem and pinning it is causing problems
with other things (chef-server). The issue is that
chef-server-ctl things are using rest-client, which requires
mime-types < 3.

cc @chef/client-core