### PR TITLE
ipaddress on Linux - default route pointing to unaddressed interface, with route src

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -117,7 +117,7 @@ Ohai.plugin(:Network) do
         if route_entry[:src]
           addr = iface[route_int][:addresses]
           unless addr.nil? || addr.has_key?(route_entry[:src]) ||
-                 addr.values.all? { |a| a['family'] != family[:name] }
+              addr.values.all? { |a| a["family"] != family[:name] }
             Ohai::Log.debug("Skipping route entry whose src does not match the interface IP")
             next
           end
@@ -333,7 +333,7 @@ Ohai.plugin(:Network) do
 
   def interface_has_no_addresses_in_family?(iface, family)
     return true if iface[:addresses].nil?
-    iface[:addresses].values.all? { |addr| addr['family'] != family }
+    iface[:addresses].values.all? { |addr| addr["family"] != family }
   end
 
   def interface_have_address?(iface, address)
@@ -465,10 +465,10 @@ Ohai.plugin(:Network) do
 
         if default_route.nil? or default_route.empty?
           attribute_name = if family[:name] == "inet"
-                              "default_interface"
-                            else
-                              "default_#{family[:name]}_interface"
-                            end
+                             "default_interface"
+                           else
+                             "default_#{family[:name]}_interface"
+                           end
           Ohai::Log.debug("Unable to determine '#{attribute_name}' as no default routes were found for that interface family")
         else
           network["#{default_prefix}_interface"] = default_route[:dev]

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -376,114 +376,114 @@ EOM
   end
 
   describe '#interface_has_no_addresses_in_family?' do
-    context 'when interface has no addresses' do
+    context "when interface has no addresses" do
       let(:iface) { {} }
 
-      it 'returns true' do
-        expect(plugin.interface_has_no_addresses_in_family?(iface, 'inet')).to eq(true)
+      it "returns true" do
+        expect(plugin.interface_has_no_addresses_in_family?(iface, "inet")).to eq(true)
       end
     end
 
-    context 'when an interface has no addresses in family' do
-      let(:iface) { { addresses: { '1.2.3.4' => { 'family' => 'inet6' } } } }
+    context "when an interface has no addresses in family" do
+      let(:iface) { { addresses: { "1.2.3.4" => { "family" => "inet6" } } } }
 
-      it 'returns true' do
-        expect(plugin.interface_has_no_addresses_in_family?(iface, 'inet')).to eq(true)
+      it "returns true" do
+        expect(plugin.interface_has_no_addresses_in_family?(iface, "inet")).to eq(true)
       end
     end
 
-    context 'when an interface has addresses in family' do
-      let(:iface) { { addresses: { '1.2.3.4' => { 'family' => 'inet' } } } }
+    context "when an interface has addresses in family" do
+      let(:iface) { { addresses: { "1.2.3.4" => { "family" => "inet" } } } }
 
-      it 'returns false' do
-        expect(plugin.interface_has_no_addresses_in_family?(iface, 'inet')).to eq(false)
+      it "returns false" do
+        expect(plugin.interface_has_no_addresses_in_family?(iface, "inet")).to eq(false)
       end
     end
   end
 
   describe '#interface_have_address?' do
-    context 'when interface has no addresses' do
+    context "when interface has no addresses" do
       let(:iface) { {} }
 
-      it 'returns false' do
-        expect(plugin.interface_have_address?(iface, '1.2.3.4')).to eq(false)
+      it "returns false" do
+        expect(plugin.interface_have_address?(iface, "1.2.3.4")).to eq(false)
       end
     end
 
-    context 'when interface has a matching address' do
-      let(:iface) { { addresses: { '1.2.3.4' => {} } } }
+    context "when interface has a matching address" do
+      let(:iface) { { addresses: { "1.2.3.4" => {} } } }
 
-      it 'returns true' do
-        expect(plugin.interface_have_address?(iface, '1.2.3.4')).to eq(true)
+      it "returns true" do
+        expect(plugin.interface_have_address?(iface, "1.2.3.4")).to eq(true)
       end
     end
 
-    context 'when interface does not have a matching address' do
-      let(:iface) { { addresses: { '4.3.2.1' => { } } } }
+    context "when interface does not have a matching address" do
+      let(:iface) { { addresses: { "4.3.2.1" => {} } } }
 
-      it 'returns false' do
-        expect(plugin.interface_have_address?(iface, '1.2.3.4')).to eq(false)
+      it "returns false" do
+        expect(plugin.interface_have_address?(iface, "1.2.3.4")).to eq(false)
       end
     end
   end
 
   describe '#interface_address_not_link_level?' do
-    context 'when the address scope is link' do
-      let(:iface) { { addresses: { '1.2.3.4' => { scope: 'Link' } } } }
+    context "when the address scope is link" do
+      let(:iface) { { addresses: { "1.2.3.4" => { scope: "Link" } } } }
 
-      it 'returns false' do
-        expect(plugin.interface_address_not_link_level?(iface, '1.2.3.4')).to eq(false)
+      it "returns false" do
+        expect(plugin.interface_address_not_link_level?(iface, "1.2.3.4")).to eq(false)
       end
     end
 
-    context 'when the address scope is global' do
-      let(:iface) { { addresses: { '1.2.3.4' => { scope: 'Global' } } } }
+    context "when the address scope is global" do
+      let(:iface) { { addresses: { "1.2.3.4" => { scope: "Global" } } } }
 
-      it 'returns true' do
-        expect(plugin.interface_address_not_link_level?(iface, '1.2.3.4')).to eq(true)
+      it "returns true" do
+        expect(plugin.interface_address_not_link_level?(iface, "1.2.3.4")).to eq(true)
       end
     end
   end
 
   describe '#interface_valid_for_route?' do
-    let(:iface)   { double('iface') }
-    let(:address) { '1.2.3.4'}
-    let(:family)  { 'inet' }
+    let(:iface)   { double("iface") }
+    let(:address) { "1.2.3.4" }
+    let(:family)  { "inet" }
 
-    context 'when interface has no addresses' do
-      it 'returns true' do
+    context "when interface has no addresses" do
+      it "returns true" do
         expect(plugin).to receive(:interface_has_no_addresses_in_family?).with(iface, family).and_return(true)
         expect(plugin.interface_valid_for_route?(iface, address, family)).to eq(true)
       end
     end
 
-    context 'when interface has addresses' do
+    context "when interface has addresses" do
       before do
         expect(plugin).to receive(:interface_has_no_addresses_in_family?).with(iface, family).and_return(false)
       end
 
-      context 'when interface contains the address' do
+      context "when interface contains the address" do
         before do
           expect(plugin).to receive(:interface_have_address?).with(iface, address).and_return(true)
         end
 
-        context 'when interface address is not a link-level address' do
-          it 'returns true' do
+        context "when interface address is not a link-level address" do
+          it "returns true" do
             expect(plugin).to receive(:interface_address_not_link_level?).with(iface, address).and_return(true)
             expect(plugin.interface_valid_for_route?(iface, address, family)).to eq(true)
           end
         end
 
-        context 'when the interface address is a link-level address' do
-          it 'returns false' do
+        context "when the interface address is a link-level address" do
+          it "returns false" do
             expect(plugin).to receive(:interface_address_not_link_level?).with(iface, address).and_return(false)
             expect(plugin.interface_valid_for_route?(iface, address, family)).to eq(false)
           end
         end
       end
 
-      context 'when interface does not contain the address' do
-        it 'returns false' do
+      context "when interface does not contain the address" do
+        it "returns false" do
           expect(plugin).to receive(:interface_have_address?).with(iface, address).and_return(false)
           expect(plugin.interface_valid_for_route?(iface, address, family)).to eq(false)
         end
@@ -492,44 +492,43 @@ EOM
   end
 
   describe '#route_is_valid_default_route?' do
-    context 'when the route destination is default' do
-      let(:route)         { { destination: 'default' } }
-      let(:default_route) { double('default_route') }
+    context "when the route destination is default" do
+      let(:route)         { { destination: "default" } }
+      let(:default_route) { double("default_route") }
 
-      it 'returns true' do
+      it "returns true" do
         expect(plugin.route_is_valid_default_route?(route, default_route)).to eq(true)
       end
     end
 
-    context 'when the route destination is not default' do
-      let(:route) { { destination: '10.0.0.0/24' } }
+    context "when the route destination is not default" do
+      let(:route) { { destination: "10.0.0.0/24" } }
 
-      context 'when the default route does not have a gateway' do
+      context "when the default route does not have a gateway" do
         let(:default_route) { {} }
 
-        it 'returns false' do
+        it "returns false" do
           expect(plugin.route_is_valid_default_route?(route, default_route)).to eq(false)
         end
       end
 
-      context 'when the gateway is within the destination' do
-        let(:default_route) { { via: '10.0.0.1' } }
+      context "when the gateway is within the destination" do
+        let(:default_route) { { via: "10.0.0.1" } }
 
-        it 'returns true' do
+        it "returns true" do
           expect(plugin.route_is_valid_default_route?(route, default_route)).to eq(true)
         end
       end
 
-      context 'when the gateway is not within the destination' do
-        let(:default_route) { { via: '20.0.0.1' } }
+      context "when the gateway is not within the destination" do
+        let(:default_route) { { via: "20.0.0.1" } }
 
-        it 'returns false' do
+        it "returns false" do
           expect(plugin.route_is_valid_default_route?(route, default_route)).to eq(false)
         end
       end
     end
   end
-
 
   %w{ifconfig iproute2}.each do |network_method|
     describe "gathering IP layer address info via #{network_method}" do
@@ -545,7 +544,7 @@ EOM
       end
 
       it "detects the interfaces" do
-        expect(plugin['network']['interfaces'].keys.sort).to eq(["eth0", "eth0.11", "eth0.151", "eth0.152", "eth0.153", "eth0:5", "eth3", "foo:veth0@eth0", "fwdintf", "lo", "ovs-system",  "tun0", "venet0", "venet0:0", "xapi1"])
+        expect(plugin["network"]["interfaces"].keys.sort).to eq(["eth0", "eth0.11", "eth0.151", "eth0.152", "eth0.153", "eth0:5", "eth3", "foo:veth0@eth0", "fwdintf", "lo", "ovs-system", "tun0", "venet0", "venet0:0", "xapi1"])
       end
 
       it "detects the layer one details of an ethernet interface" do
@@ -1079,15 +1078,15 @@ EOM
 
         it "completes the run" do
           expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
-          expect(plugin['network']).not_to be_nil
+          expect(plugin["network"]).not_to be_nil
         end
 
         it "sets default_interface" do
-          expect(plugin['network']['default_interface']).to eq('eth3')
+          expect(plugin["network"]["default_interface"]).to eq("eth3")
         end
 
         it "doesn't set ipaddress" do
-          expect(plugin['ipaddress']).to be_nil
+          expect(plugin["ipaddress"]).to be_nil
         end
       end
 
@@ -1103,15 +1102,15 @@ EOM
 
         it "completes the run" do
           expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
-          expect(plugin['network']).not_to be_nil
+          expect(plugin["network"]).not_to be_nil
         end
 
         it "sets default_interface" do
-          expect(plugin['network']['default_interface']).to eq('fwdintf')
+          expect(plugin["network"]["default_interface"]).to eq("fwdintf")
         end
 
         it "sets ipaddress" do
-          expect(plugin['ipaddress']).to eq('2.2.2.2')
+          expect(plugin["ipaddress"]).to eq("2.2.2.2")
         end
       end
 

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -1068,9 +1068,9 @@ EOM
       end
 
       describe "with a link level default route to an unaddressed int" do
-        let(:linux_ip_route) {
-'default dev eth3 scope link
-'
+        let(:linux_ip_route) { <<-EOM
+default dev eth3 scope link
+EOM
         }
 
         before(:each) do
@@ -1092,9 +1092,9 @@ EOM
       end
 
       describe "with a link level default route with a source" do
-        let(:linux_ip_route) {
-'default dev fwdintf scope link src 2.2.2.2
-'
+        let(:linux_ip_route) { <<-EOM
+default dev fwdintf scope link src 2.2.2.2
+EOM
         }
 
         before(:each) do


### PR DESCRIPTION
### Version: 8.5.1

### Environment: Cisco IOS XR (Windriver Linux 7)

### Scenario:
```
bash-4.3# ifconfig
Gi0_0_0_0 Link encap:Ethernet  HWaddr 52:46:0b:98:d2:51  
          inet addr:192.168.122.222  Mask:255.255.255.0
          inet6 addr: fe80::5046:bff:fe98:d251/64 Scope:Link
          UP RUNNING NOARP MULTICAST  MTU:1514  Metric:1
          RX packets:30965 errors:0 dropped:0 overruns:0 frame:0
          TX packets:3 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:45928110 (43.8 MiB)  TX bytes:210 (210.0 B)

Mg0_RP0_CPU0_0 Link encap:Ethernet  HWaddr 52:46:07:10:c6:14  
          inet addr:10.1.1.1  Mask:255.255.255.0
          inet6 addr: fe80::5046:7ff:fe10:c614/64 Scope:Link
          UP RUNNING NOARP MULTICAST  MTU:1514  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:3 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:210 (210.0 B)

fwd_ew    Link encap:Ethernet  HWaddr 00:00:00:00:00:0b  
          inet6 addr: fe80::200:ff:fe00:b/64 Scope:Link
          UP RUNNING NOARP MULTICAST  MTU:1500  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:2 errors:0 dropped:1 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:140 (140.0 B)

fwdintf   Link encap:Ethernet  HWaddr 00:00:00:00:00:0a  
          inet6 addr: fe80::200:ff:fe00:a/64 Scope:Link
          UP RUNNING NOARP MULTICAST  MTU:1496  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:8916 errors:0 dropped:1 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:631885 (617.0 KiB)

lo        Link encap:Local Loopback  
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

lo:0      Link encap:Local Loopback  
          inet addr:1.1.1.1  Mask:255.255.255.255
          UP LOOPBACK RUNNING  MTU:65536  Metric:1

lo:2      Link encap:Local Loopback  
          inet addr:2.2.2.2  Mask:255.255.255.255
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
```

```
bash-4.3# ip route show
default dev fwdintf  scope link  src 192.168.122.222 
10.1.1.0/24 dev Mg0_RP0_CPU0_0  proto kernel  scope link  src 10.1.1.1 
```

### Expected Result:
`ohai ipaddress` should report 192.168.122.222 (the configured `src` for the default route) and `ohai network` should include `"default_interface": "fwdintf"`


### Actual Result:
`ohai ipaddress` ignores the default route (because of existing logic that says 'ignore default route if its src is not an address configured on the default interface') and reports 1.1.1.1 (lowest global scope IP address found). No value is reported for `default_interface`.

### Fix
If the default route src is not a configured address on the default interface, but the default interface has *no* addresses of this type, then do not ignore the default route when determining the ipaddress. 