### PR TITLE
Handle old kernels where we can't determine the init system

### DIFF
--- a/lib/ohai/plugins/init_package.rb
+++ b/lib/ohai/plugins/init_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Caleb Tennis (<caleb.tennis@gmail.com>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) 2012-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,12 +20,6 @@ Ohai.plugin(:InitPackage) do
   provides "init_package"
 
   collect_data(:linux) do
-    package_name = nil
-
-    if File.exists?("/proc/1/comm")
-      package_name = File.open("/proc/1/comm").gets.chomp
-    end
-
-    init_package package_name
+    init_package File.exists?("/proc/1/comm") ? File.open("/proc/1/comm").gets.chomp : 'init'
   end
 end

--- a/spec/unit/plugins/init_package_spec.rb
+++ b/spec/unit/plugins/init_package_spec.rb
@@ -26,11 +26,12 @@ describe Ohai::System, "Init package" do
   }
 
   let(:proc1_content) { "init\n" }
+  let(:proc1_exists) { true }
   let(:proc_1_file_path) { "/proc/1/comm" }
   let(:proc_1_file) { double(proc_1_file_path, :gets => proc1_content) }
 
   before(:each) do
-    allow(File).to receive(:exists?).with(proc_1_file_path).and_return(true)
+    allow(File).to receive(:exists?).with(proc_1_file_path).and_return(proc1_exists)
     allow(File).to receive(:open).with(proc_1_file_path).and_return(proc_1_file)
   end
 
@@ -45,6 +46,15 @@ describe Ohai::System, "Init package" do
     it "should set init_package to systemd" do
       plugin.run
       expect(plugin[:init_package]).to eq("systemd")
+    end
+  end
+
+  describe "when /proc/1/comm doesn't exist" do
+    let(:proc1_exists) { false }
+
+    it "should set init_package to init" do
+      plugin.run
+      expect(plugin[:init_package]).to eq("init")
     end
   end
 end


### PR DESCRIPTION
New kernels will always have /proc/1/comm, but older kernels don't.
Those systems are all init based (debian 6, ubuntu 10.04, centos 5.11).
A good number of these systems are EoL, but some like CentOS 5.11 are
going to be around for several more years.  We should probably support
detecting init on them properly.