### PR TITLE
WIP: Fix detection of mac address on IPv6 systems

### DIFF
--- a/lib/ohai/mixin/network_constants.rb
+++ b/lib/ohai/mixin/network_constants.rb
@@ -1,6 +1,6 @@
 #
-# Author:: Serdar Sutay (<serdar@opscode.com>)
-# Copyright:: Copyright (c) 2014 Opscode, Inc.
+# Author:: Serdar Sutay (<serdar@chef.io>)
+# Copyright:: Copyright (c) 2014-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -26,19 +26,21 @@ Ohai.plugin(:NetworkAddresses) do
 
   depends "network/interfaces"
 
+  # from interf data create array of hashes with ipaddress, scope, and iface
+  # sorted by scope, prefixlen and then ip address where longest prefixes first
   def sorted_ips(family = "inet")
     raise "bad family #{family}" unless [ "inet", "inet6" ].include? family
 
-    # going to use that later to sort by scope
+    # priority of ipv6 link scopes to sort by later
     scope_prio = [ "global", "site", "link", "host", "node", nil ]
 
+    # grab ipaddress, scope, and iface for sorting later
     ipaddresses = []
-    # ipaddresses going to hold #{family} ipaddresses and their scope
     Mash[network['interfaces']].each do |iface, iface_v|
-      next if iface_v.nil? or not iface_v.has_key? 'addresses'
+      next if iface_v.nil? || !iface_v.has_key?('addresses')
       iface_v['addresses'].each do |addr, addr_v|
         next if addr_v.nil? or not addr_v.has_key? "family" or addr_v['family'] != family
-        ipaddresses <<  {
+        ipaddresses << {
           :ipaddress => addr_v["prefixlen"] ? IPAddress("#{addr}/#{addr_v["prefixlen"]}") : IPAddress("#{addr}/#{addr_v["netmask"]}"),
           :scope => addr_v["scope"].nil? ? nil : addr_v["scope"].downcase,
           :iface => iface
@@ -49,17 +51,20 @@ Ohai.plugin(:NetworkAddresses) do
     # sort ip addresses by scope, by prefixlen and then by ip address
     # 128 - prefixlen: longest prefixes first
     ipaddresses.sort_by do |v|
-      [ ( scope_prio.index(v[:scope]) or 999999 ),
+      [ ( scope_prio.index(v[:scope]) || 999999 ),
         128 - v[:ipaddress].prefix.to_i,
         ( family == "inet" ? v[:ipaddress].to_u32 : v[:ipaddress].to_u128 )
       ]
     end
   end
 
+  # finds ip address / interface for interface with default route based on
+  # passed in family.  returns [ipaddress, interface]  uses 1st ip if no default
+  # route is found
   def find_ip(family = "inet")
-    ips=sorted_ips(family)
+    ips = sorted_ips(family)
 
-    # return if there isn't any #{family} address !
+    # return if there aren't any #{family} addresses!
     return [ nil, nil ] if ips.empty?
 
     # shortcuts to access default #{family} interface and gateway
@@ -76,8 +81,8 @@ Ohai.plugin(:NetworkAddresses) do
       end
       if gw_if_ips.empty?
         Ohai::Log.warn("[#{family}] no ip address on #{network[int_attr]}")
-      elsif network[gw_attr] and
-          network["interfaces"][network[int_attr]] and
+      elsif network[gw_attr] &&
+          network["interfaces"][network[int_attr]] &&
           network["interfaces"][network[int_attr]]["addresses"]
         if [ "0.0.0.0", "::", /^fe80:/ ].any? { |pat| pat === network[gw_attr] }
           # link level default route
@@ -109,9 +114,10 @@ Ohai.plugin(:NetworkAddresses) do
     [ r[:ipaddress].to_s, r[:iface] ]
   end
 
+  # select mac address of first interface with family of lladdr
   def find_mac_from_iface(iface)
-    r = network["interfaces"][iface]["addresses"].select{|k,v| v["family"]=="lladdr"}
-    r.nil? or r.first.nil? ? nil : r.first.first
+    r = network["interfaces"][iface]["addresses"].select{|k,v| v["family"] == "lladdr"}
+    r.nil? || r.first.nil? ? nil : r.first.first
   end
 
   def network_contains_address(address_to_match, ipaddress, iface)
@@ -125,10 +131,10 @@ Ohai.plugin(:NetworkAddresses) do
     end
   end
 
-  # ipaddress, ip6address and macaddress are set by the #{os}::network plugin.
-  # atm it is expected macaddress is set at the same time as ipaddress
-  # if ipaddress is set and macaddress is nil, that means the interface
-  # ipaddress is bound to has the NOARP flag
+  # ipaddress, ip6address and macaddress are set for each interface by the
+  # #{os}::network plugin. atm it is expected macaddress is set at the same
+  # time as ipaddress. if ipaddress is set and macaddress is nil, that means
+  # the interface ipaddress is bound to has the NOARP flag
 
   collect_data do
     results = {}
@@ -138,9 +144,10 @@ Ohai.plugin(:NetworkAddresses) do
     counters Mash.new unless counters
     counters[:network] = Mash.new unless counters[:network]
 
-    # inet family is treated before inet6
+    # inet family is processed before inet6
     Ohai::Mixin::NetworkConstants::FAMILIES.keys.sort.each do |family|
       r = {}
+      # find the ip/interface with the default route for this family
       ( r["ip"], r["iface"] ) = find_ip(family)
       r["mac"] = find_mac_from_iface(r["iface"]) unless r["iface"].nil?
       # don't overwrite attributes if they've already been set by the "#{os}::network" plugin
@@ -159,7 +166,9 @@ Ohai.plugin(:NetworkAddresses) do
           Ohai::Log.debug("unable to detect ip6address")
         else
           ip6address r["ip"]
-          if r["mac"] and macaddress.nil? and ipaddress.nil?
+          # don't overwrite macaddress set by "#{os}::network" plugin
+          # and also
+          if r["mac"] and macaddress.nil? and ( ipaddress.nil? || ipaddress == "127.0.0.1" )
             Ohai::Log.debug("macaddress set to #{r["mac"]} from the ipv6 setup")
             macaddress r["mac"]
           end

--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -1,14 +1,14 @@
 #
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Copyright:: Copyright (c) 2008 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -125,8 +125,8 @@ Ohai.plugin(:NetworkAddresses) do
     end
   end
 
-  # ipaddress, ip6address and macaddress can be set by the #{os}::network plugin
-  # atm it is expected macaddress is set at the same time than ipaddress
+  # ipaddress, ip6address and macaddress are set by the #{os}::network plugin.
+  # atm it is expected macaddress is set at the same time as ipaddress
   # if ipaddress is set and macaddress is nil, that means the interface
   # ipaddress is bound to has the NOARP flag
 

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -1,7 +1,7 @@
 #
 #  Author:: Caleb Tennis <caleb.tennis@gmail.com>
 #  Author:: Chris Read <chris.read@gmail.com>
-#  Copyright:: Copyright (c) 2011 Opscode, Inc.
+#  Copyright:: Copyright (c) 2011-2015 Chef Software, Inc.
 #  License:: Apache License, Version 2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -798,7 +798,7 @@ default via 1111:2222:3333:4444::ffff dev eth0.11  metric 1023 src 1111:2222:333
         end
       end
 
-      describe "when there's a source field in a local route entry " do
+      describe "when there's a source field in a local route entry" do
         let(:linux_ip_route) {
 '10.116.201.0/24 dev eth0  proto kernel  src 10.116.201.76
 192.168.5.0/24 dev eth0  proto kernel  src 192.168.5.1

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -663,7 +663,7 @@ Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
         expect(plugin['network']['interfaces']['eth0.11']['routes']).to include Mash.new( :destination => "default", :via => "1111:2222:3333:4444::1", :metric => "1024", :family => "inet6")
       end
 
-      describe "when there isn't a source field in route entries " do
+      describe "when there isn't a source field in route entries" do
         before(:each) do
           plugin.run
         end

--- a/spec/unit/plugins/network_spec.rb
+++ b/spec/unit/plugins/network_spec.rb
@@ -388,10 +388,10 @@ describe Ohai::System, "Network Plugin" do
             expect(@plugin["ip6address"]).to eq("3ffe:1111:3333::1")
           end
 
-          it "doesn't set macaddress, ipv4 setup is valid and has precedence over ipv6" do
+          it "sets mac address to mac of eth1, skipping eth0 due to NOARP" do
             expect(Ohai::Log).not_to receive(:warn).with(/^unable to detect macaddress/)
             @plugin.run
-            expect(@plugin["macaddress"]).to be_nil
+            expect(@plugin["macaddress"]).to eq("00:16:3E:2F:36:80")
           end
 
           it "informs about this setup" do
@@ -827,13 +827,7 @@ describe Ohai::System, "Network Plugin" do
         it "can't detect ipaddress" do
           allow(Ohai::Log).to receive(:warn)
           @plugin.run
-          expect(@plugin["ipaddress"]).to be_nil
-        end
-
-        it "warns about not being able to set {ip,mac}address (ipv4)" do
-          expect(Ohai::Log).to receive(:warn).with(/^unable to detect ipaddress/).once
-          expect(Ohai::Log).to receive(:warn).with(/^unable to detect macaddress/).once
-          @plugin.run
+          expect(@plugin["ipaddress"]).to eq("127.0.0.1")
         end
 
         it "sets {ip6,mac}address" do

--- a/spec/unit/plugins/network_spec.rb
+++ b/spec/unit/plugins/network_spec.rb
@@ -26,8 +26,8 @@ def it_doesnt_fail
   end
 end
 
+# basic sanity check that is called in all describes below
 def it_populates_ipaddress_attributes
-
   source = caller[0]
 
   it "populates ipaddress, macaddress and ip6address" do
@@ -43,11 +43,11 @@ def it_populates_ipaddress_attributes
       raise
     end
   end
-
 end
 
 describe Ohai::System, "Network Plugin" do
 
+  # output of network plugins on particular platforms to mock plugin runs
   basic_data = {
     "freebsd" => {
       "network" => {
@@ -57,7 +57,9 @@ describe Ohai::System, "Network Plugin" do
             "number" => "0",
             "flags" => ["UP", "BROADCAST", "RUNNING", "SIMPLEX", "MULTICAST"],
             "addresses" => {
-              "00:00:24:c9:5e:b8" => {"family" => "lladdr"},
+              "00:00:24:c9:5e:b8" => {
+                "family" => "lladdr"
+              },
               "fe80::200:24ff:fec9:5eb8" => {
                 "family" => "inet6",
                 "zoneid" => "vr0",
@@ -80,7 +82,9 @@ describe Ohai::System, "Network Plugin" do
             "number" => "1",
             "flags" => ["UP", "BROADCAST", "RUNNING", "PROMISC", "SIMPLEX", "MULTICAST"],
             "addresses" => {
-              "00:00:24:c9:5e:b9" => {"family" => "lladdr"},
+              "00:00:24:c9:5e:b9" => {
+                "family" => "lladdr"
+              },
               "fe80::200:24ff:fec9:5eb9" => {
                 "family" => "inet6",
                 "zoneid" => "vr1",
@@ -94,7 +98,9 @@ describe Ohai::System, "Network Plugin" do
             "number" => "2",
             "flags" => ["UP", "BROADCAST", "RUNNING", "PROMISC", "SIMPLEX", "MULTICAST"],
             "addresses" => {
-              "00:00:24:c9:5e:ba" => {"family" => "lladdr"},
+              "00:00:24:c9:5e:ba" => {
+                "family" => "lladdr"
+              },
               "fe80::200:24ff:fec9:5eba" => {
                 "family" => "inet6",
                 "zoneid" => "vr2",
@@ -108,7 +114,9 @@ describe Ohai::System, "Network Plugin" do
             "number" => "3",
             "flags" => ["UP", "BROADCAST", "RUNNING", "PROMISC", "SIMPLEX", "MULTICAST"],
             "addresses" => {
-              "00:00:24:c9:5e:bb" => {"family" => "lladdr"},
+              "00:00:24:c9:5e:bb" => {
+                "family" => "lladdr"
+              },
               "fe80::200:24ff:fec9:5ebb" => {
                 "family" => "inet6",
                 "zoneid" => "vr3",
@@ -128,8 +136,14 @@ describe Ohai::System, "Network Plugin" do
             "number" => "0",
             "flags" => ["UP", "LOOPBACK", "RUNNING", "MULTICAST"],
             "addresses" => {
-              "127.0.0.1" => {"family" => "inet", "netmask" => "255.0.0.0"},
-              "::1" => {"family" => "inet6", "prefixlen" => "128"},
+              "127.0.0.1" => {
+                "family" => "inet",
+                "netmask" => "255.0.0.0"
+              },
+              "::1" => {
+                "family" => "inet6",
+                "prefixlen" => "128"
+              },
               "fe80::1" => {
                 "family" => "inet6",
                 "zoneid" => "lo0",
@@ -143,13 +157,18 @@ describe Ohai::System, "Network Plugin" do
             "number" => "0",
             "flags" => ["LEARNING", "DISCOVER", "AUTOEDGE", "AUTOPTP"],
             "addresses" => {
-              "02:20:6f:d2:c4:00" => {"family"=>"lladdr"},
+              "02:20:6f:d2:c4:00" => {
+                "family"=>"lladdr"
+              },
               "192.168.2.1" => {
                 "family" => "inet",
                 "netmask" => "255.255.255.0",
                 "broadcast" => "192.168.2.255"
               },
-              "2001:470:d:cb4::1" => {"family" => "inet6", "prefixlen" => "64"},
+              "2001:470:d:cb4::1" => {
+                "family" => "inet6",
+                "prefixlen" => "64"
+              },
               "fe80::cafe:babe:dead:beef" => {
                 "family" => "inet6",
                 "zoneid" => "bridge0",
@@ -188,7 +207,7 @@ describe Ohai::System, "Network Plugin" do
     },
     "linux" => {
       "network" => {
-        # pp Hash[node['network']] from  shef to get the network data
+        # pp Hash[node['network']] from chef-shell to get the network data
         # have just removed the neighbour and route entries by hand
         "interfaces" => {
           "lo" => {
@@ -207,7 +226,8 @@ describe Ohai::System, "Network Plugin" do
               }
             },
             "mtu" => "16436",
-            "encapsulation" => "Loopback"
+            "encapsulation" => "Loopback",
+            "state" => "unknown"
           },
           "eth0" => {
             "flags" => ["BROADCAST", "MULTICAST", "UP"],
@@ -218,7 +238,9 @@ describe Ohai::System, "Network Plugin" do
                 "prefixlen" => "64",
                 "family" => "inet6"
               },
-              "00:16:3E:2F:36:79" => {"family" => "lladdr"},
+              "00:16:3E:2F:36:79" => {
+                "family" => "lladdr"
+              },
               "192.168.66.33" => {
                 "scope" => "Global",
                 "netmask" => "255.255.255.0",
@@ -229,7 +251,8 @@ describe Ohai::System, "Network Plugin" do
               "3ffe:1111:2222::33" => {
                 "prefixlen" => "48",
                 "family" => "inet6",
-                "scope" => "Global"
+                "scope" => "Global",
+                "state" => "up"
               }
             },
             "mtu" => "1500",
@@ -245,7 +268,9 @@ describe Ohai::System, "Network Plugin" do
                 "prefixlen" => "64",
                 "family" => "inet6"
               },
-              "00:16:3E:2F:36:80" => {"family" => "lladdr"},
+              "00:16:3E:2F:36:80" => {
+                "family" => "lladdr"
+              },
               "192.168.99.11" => {
                 "scope" => "Global",
                 "netmask" => "255.255.255.0",
@@ -301,14 +326,14 @@ describe Ohai::System, "Network Plugin" do
     }
   }
 
-  describe "with linux" do
+  describe "on linux" do
     before(:each) do
       @plugin = get_plugin("network")
       @plugin["network"] = basic_data["linux"]["network"]
     end
 
     describe "when the linux::network plugin hasn't set any of {ip,ip6,mac}address attributes" do
-      describe "simple setup" do
+      describe "simple network setup" do
         it_populates_ipaddress_attributes
 
         it "detects {ip,ip6,mac}address" do
@@ -393,7 +418,7 @@ describe Ohai::System, "Network Plugin" do
             expect(@plugin["macaddress"]).to eq("00:16:3E:2F:36:80")
             expect(@plugin["ip6address"]).to eq("3ffe:1111:3333::1")
           end
-          
+
           it "warns about this conflict" do
             expect(Ohai::Log).to receive(:debug).with(/^\[inet\] no ipaddress\/mask on eth1/).once
             expect(Ohai::Log).to receive(:debug).with(/^\[inet6\] no ipaddress\/mask on eth1/).once
@@ -787,8 +812,46 @@ describe Ohai::System, "Network Plugin" do
         end
       end
 
+      describe "ipv6 only with ipv4 loopback" do
+        before do
+          @plugin["network"]["default_gateway"] = nil
+          @plugin["network"]["default_interface"] = nil
+          @plugin["network"]["interfaces"].each do |i,iv|
+            next if i == 'lo'
+            iv["addresses"].delete_if{|k,kv| kv["family"] == "inet" }
+          end
+        end
+
+        it_doesnt_fail
+
+        it "can't detect ipaddress" do
+          allow(Ohai::Log).to receive(:warn)
+          @plugin.run
+          expect(@plugin["ipaddress"]).to be_nil
+        end
+
+        it "warns about not being able to set {ip,mac}address (ipv4)" do
+          expect(Ohai::Log).to receive(:warn).with(/^unable to detect ipaddress/).once
+          expect(Ohai::Log).to receive(:warn).with(/^unable to detect macaddress/).once
+          @plugin.run
+        end
+
+        it "sets {ip6,mac}address" do
+          allow(Ohai::Log).to receive(:warn)
+          @plugin.run
+          expect(@plugin["ip6address"]).to eq("3ffe:1111:2222::33")
+          expect(@plugin["macaddress"]).to eq("00:16:3E:2F:36:79")
+        end
+
+        it "informs about macaddress being set using the ipv6 setup" do
+          expect(Ohai::Log).to receive(:debug).with(/^macaddress set to 00:16:3E:2F:36:79 from the ipv6 setup/).once
+          allow(Ohai::Log).to receive(:debug)
+          @plugin.run
+        end
+      end
     end
 
+    # specs using network plugin data for each mocked OS (freebsd,linux,windows)
     basic_data.keys.sort.each do |os|
       describe "the #{os}::network has already set some of the {ip,mac,ip6}address attributes" do
         before(:each) do

--- a/spec/unit/plugins/network_spec.rb
+++ b/spec/unit/plugins/network_spec.rb
@@ -388,10 +388,10 @@ describe Ohai::System, "Network Plugin" do
             expect(@plugin["ip6address"]).to eq("3ffe:1111:3333::1")
           end
 
-          it "sets mac address to mac of eth1, skipping eth0 due to NOARP" do
+          it "doesn't set macaddress, ipv4 setup is valid and has precedence over ipv6" do
             expect(Ohai::Log).not_to receive(:warn).with(/^unable to detect macaddress/)
             @plugin.run
-            expect(@plugin["macaddress"]).to eq("00:16:3E:2F:36:80")
+            expect(@plugin["macaddress"]).to be_nil
           end
 
           it "informs about this setup" do


### PR DESCRIPTION
We failed to detect the mac address when lo has ipv4/ipv6, but all other interfaces only have ipv6. This is just a simplified version of Phil's code from #685 with specs added.