### PR TITLE
Create kernel[:processor] from uname -p output

### DIFF
--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -29,7 +29,8 @@ Ohai.plugin(:Kernel) do
   def init_kernel
     kernel Mash.new
     [["uname -s", :name], ["uname -r", :release],
-     ["uname -v", :version], ["uname -m", :machine]].each do |cmd, property|
+     ["uname -v", :version], ["uname -m", :machine],
+     ["uname -p", :processor]].each do |cmd, property|
       so = shell_out(cmd)
       kernel[property] = so.stdout.split($/)[0]
     end

--- a/spec/unit/plugins/kernel_spec.rb
+++ b/spec/unit/plugins/kernel_spec.rb
@@ -28,12 +28,14 @@ describe Ohai::System, "plugin kernel" do
     allow(@plugin).to receive(:shell_out).with("uname -v").and_return(mock_shell_out(0, "Darwin Kernel Version 9.5.0: Wed Sep  3 11:29:43 PDT 2008; root:xnu-1228.7.58~1\/RELEASE_I386\n", ""))
     allow(@plugin).to receive(:shell_out).with("uname -m").and_return(mock_shell_out(0, "i386\n", ""))
     allow(@plugin).to receive(:shell_out).with("uname -o").and_return(mock_shell_out(0, "Linux\n", ""))
+    allow(@plugin).to receive(:shell_out).with("uname -p").and_return(mock_shell_out(0, "i386\n", ""))
   end
 
   it_should_check_from_mash("kernel", "name", "uname -s", [0, "Darwin\n", ""])
   it_should_check_from_mash("kernel", "release", "uname -r", [0, "9.5.0\n", ""])
   it_should_check_from_mash("kernel", "version", "uname -v", [0, "Darwin Kernel Version 9.5.0: Wed Sep  3 11:29:43 PDT 2008; root:xnu-1228.7.58~1\/RELEASE_I386\n", ""])
   it_should_check_from_mash("kernel", "machine", "uname -m", [0, "i386\n", ""])
+  it_should_check_from_mash("kernel", "processor", "uname -p", [0, "i386\n", ""])
 
   describe "when running on windows", :windows_only do
     before do


### PR DESCRIPTION
An important distiction on solaris servers is x86 vs. sparc processor
architecture.  Using uname -m to report the machine type does make that
distinction explicitly.  The uname -p value is explicit about the
difference.