### PR TITLE
Add instance_id to rackspace plugin

### DIFF
--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -96,6 +96,18 @@ Ohai.plugin(:Rackspace) do
     nil
   end
 
+  # Get the rackspace instance_id
+  #
+  def get_instance_id()
+    so = shell_out("xenstore-read name")
+    if so.exitstatus == 0
+      rackspace[:instance_id] = so.stdout.gsub(/instance-/, "")
+    end
+  rescue Errno::ENOENT
+    Ohai::Log.debug("Unable to find xenstore-read, cannot capture instance ID information for Rackspace cloud")
+    nil
+  end
+
   # Get the rackspace private networks
   #
   def get_private_networks()
@@ -127,6 +139,7 @@ Ohai.plugin(:Rackspace) do
       get_ip_address(:public_ip, :eth0)
       get_ip_address(:private_ip, :eth1)
       get_region()
+      get_instance_id()
       # public_ip + private_ip are deprecated in favor of public_ipv4 and local_ipv4 to standardize.
       rackspace[:public_ipv4] = rackspace[:public_ip]
       get_global_ipv6_address(:public_ipv6, :eth0)

--- a/spec/unit/plugins/rackspace_spec.rb
+++ b/spec/unit/plugins/rackspace_spec.rb
@@ -135,6 +135,13 @@ OUT
       @plugin.run
       expect(@plugin[:rackspace][:region]).to eq("dfw")
     end
+
+    it "should capture instance ID information" do
+      provider_data = "instance-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      allow(@plugin).to receive(:shell_out).with("xenstore-read name").and_return(mock_shell_out(0, provider_data, ""))
+      @plugin.run
+      expect(@plugin[:rackspace][:instance_id]).to eq("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+    end
   end
 
   describe "with rackspace cloud file" do


### PR DESCRIPTION
Hello,

It's a really useful information to correlate a Chef node with a Rackspace Server. 
It's the only way to be 100% sure a Chef node is the one you can see in your Rackspace cloud.
It would help for Chef deleted nodes cleaning jobs by example.

It will prevent to have to play with IP/Hostname to identify a node.