### PR TITLE
Improve EC2 detection when hint isn't present

### DIFF
--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -43,8 +43,10 @@ Ohai.plugin(:EC2) do
   end
 
   # look for amazon string in dmi bios data
+  # this only works on hvm instances as paravirt instances have no dmi data
   def has_ec2_dmi?
     begin
+      # detect a version of '4.2.amazon'
       if dmi[:bios][:all_records][0][:Version] =~ /amazon/
         Ohai::Log.debug("has_ec2_dmi? == true")
         true

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -60,7 +60,7 @@ Ohai.plugin(:EC2) do
       end
       ec2[:userdata] = self.fetch_userdata
       #ASCII-8BIT is equivalent to BINARY in this case
-      if ec2[:userdata].encoding.to_s == "ASCII-8BIT"
+      if ec2[:userdata] && ec2[:userdata].encoding.to_s == "ASCII-8BIT"
         Ohai::Log.debug("Binary UserData Found. Storing in base64")
         ec2[:userdata] = Base64.encode64(ec2[:userdata])
       end

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -270,6 +270,22 @@ end
     end
   end
 
+  describe "with ec2 dmi data" do
+    it_should_behave_like "ec2"
+
+    before(:each) do
+      @plugin[:dmi] = { :bios => { :all_records => [  { :Version => "4.2.amazon" } ] } }
+    end
+  end
+
+  describe "without ec2 dmi data" do
+    it_should_behave_like "!ec2"
+
+    before(:each) do
+      @plugin[:dmi] = nil
+    end
+  end
+
   describe "with ec2 cloud file" do
     it_should_behave_like "ec2"
 


### PR DESCRIPTION
This allows us to detect Linux hosts based on the DMI data as it includes amazon specific strings.  The present method of looking for an arp address fails when hosts are in a VPC, which they all are by default now.