### PR TITLE
Detect Azure using the Azure agent and DHCP options

### DIFF
--- a/lib/ohai/mixin/dmi_decode.rb
+++ b/lib/ohai/mixin/dmi_decode.rb
@@ -22,10 +22,10 @@ module ::Ohai::Mixin::DmiDecode
       case line
       when /Manufacturer: Microsoft/
         if dmi_data =~ /Product Name: Virtual Machine/
-          if dmi_data =~ /Version: (VS2005R2|6.0)/
-            return 'virtualpc'
-          elsif dmi_data =~ /Version: (7.0|Hyper-V)/
+          if dmi_data =~ /Version: (7.0|Hyper-V)/
             return 'hyperv'
+          elsif dmi_data =~ /Version: (VS2005R2|6.0)/
+            return 'virtualpc'
           elsif dmi_data =~ /Version: 5.0/
             return 'virtualserver'
           end

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -19,7 +19,7 @@ Ohai.plugin(:Azure) do
 
   collect_data do
     # The azure hints are populated by the knife plugin for Azure.
-    # The project is located at https://github.com/opscode/knife-azure
+    # The project is located at https://github.com/chef/knife-azure
     # Please see the lib/chef/knife/azure_server_create.rb file in that
     # project for details
     azure_metadata_from_hints = hint?('azure')
@@ -27,9 +27,28 @@ Ohai.plugin(:Azure) do
       Ohai::Log.debug("azure_metadata_from_hints is present.")
       azure Mash.new
       azure_metadata_from_hints.each {|k, v| azure[k] = v }
+    elsif looks_like_azure?
+      Ohai::Log.debug("No hints present, but system appears to be on azure.")
+      azure Mash.new
     else
-      Ohai::Log.debug("No hints present for azure.")
+      Ohai::Log.debug("No hints present for azure and doesn't appear to be azure.")
       false
+    end
+  end
+
+  # check for either the waagent or the unknown-245 DHCP option that Azure uses
+  # http://blog.mszcool.com/index.php/2015/04/detecting-if-a-virtual-machine-runs-in-microsoft-azure-linux-windows-to-protect-your-software-when-distributed-via-the-azure-marketplace/
+  def looks_like_azure?
+    if ::File.exist?('/usr/sbin/waagent') || ::Dir.exist?('C:\WindowsAzure')
+      Ohai::Log.debug("Found waagent used by MS Azure.")
+      return true
+    elsif File.exist?('/var/lib/dhcp/dhclient.eth0.leases')
+      File.open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
+        if line =~ /unknown-245/
+          Ohai::Log.debug("Found unknown-245 DHCP option used by MS Azure.")
+          return true
+        end
+      end
     end
   end
 end

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -24,14 +24,14 @@ Ohai.plugin(:Azure) do
     # project for details
     azure_metadata_from_hints = hint?('azure')
     if azure_metadata_from_hints
-      Ohai::Log.debug("azure_metadata_from_hints is present.")
+      Ohai::Log.debug("azure plugin: azure_metadata_from_hints is present.")
       azure Mash.new
       azure_metadata_from_hints.each {|k, v| azure[k] = v }
     elsif looks_like_azure?
-      Ohai::Log.debug("No hints present, but system appears to be on azure.")
+      Ohai::Log.debug("azure plugin: No hints present, but system appears to be on azure.")
       azure Mash.new
     else
-      Ohai::Log.debug("No hints present for azure and doesn't appear to be azure.")
+      Ohai::Log.debug("azure plugin: No hints present for azure and doesn't appear to be azure.")
       false
     end
   end
@@ -39,13 +39,13 @@ Ohai.plugin(:Azure) do
   # check for either the waagent or the unknown-245 DHCP option that Azure uses
   # http://blog.mszcool.com/index.php/2015/04/detecting-if-a-virtual-machine-runs-in-microsoft-azure-linux-windows-to-protect-your-software-when-distributed-via-the-azure-marketplace/
   def looks_like_azure?
-    if ::File.exist?('/usr/sbin/waagent') || ::Dir.exist?('C:\WindowsAzure')
-      Ohai::Log.debug("Found waagent used by MS Azure.")
+    if File.exist?('/usr/sbin/waagent') || Dir.exist?('C:\WindowsAzure')
+      Ohai::Log.debug("azure plugin: Found waagent used by MS Azure.")
       return true
     elsif File.exist?('/var/lib/dhcp/dhclient.eth0.leases')
       File.open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
         if line =~ /unknown-245/
-          Ohai::Log.debug("Found unknown-245 DHCP option used by MS Azure.")
+          Ohai::Log.debug("azure plugin: Found unknown-245 DHCP option used by MS Azure.")
           return true
         end
       end

--- a/spec/unit/plugins/azure_spec.rb
+++ b/spec/unit/plugins/azure_spec.rb
@@ -25,7 +25,7 @@ describe Ohai::System, "plugin azure" do
     @plugin = get_plugin("azure")
   end
 
-  describe "with azure cloud file" do
+  describe "with azure hint file" do
     before(:each) do
       allow(File).to receive(:exist?).with('/etc/chef/ohai/hints/azure.json').and_return(true)
       allow(File).to receive(:read).with('/etc/chef/ohai/hints/azure.json').and_return('{"public_ip":"137.135.46.202","vm_name":"test-vm","public_fqdn":"service.cloudapp.net","public_ssh_port":"22", "public_winrm_port":"5985"}')
@@ -45,10 +45,14 @@ describe Ohai::System, "plugin azure" do
 
   end
 
-  describe "without azure cloud file" do
+  describe "without azure hint file or agent or dhcp options" do
     before(:each) do
       allow(File).to receive(:exist?).with('/etc/chef/ohai/hints/azure.json').and_return(false)
       allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(false)
+      allow(File).to receive(:exist?).with('/usr/sbin/waagent').and_return(false)
+      allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
+      allow(File).to receive(:exist?).with('/var/lib/dhcp/dhclient.eth0.leases').and_return(false)
+      @plugin.run
     end
 
     it 'should not behave like azure' do
@@ -56,16 +60,89 @@ describe Ohai::System, "plugin azure" do
     end
   end
 
-  describe "with rackspace cloud file" do
+  describe "with rackspace hint file no agent and no dhcp options" do
     before(:each) do
       allow(File).to receive(:exist?).with('/etc/chef/ohai/hints/rackspace.json').and_return(true)
       allow(File).to receive(:read).with('/etc/chef/ohai/hints/rackspace.json').and_return('')
       allow(File).to receive(:exist?).with('C:\chef\ohai\hints/rackspace.json').and_return(true)
       allow(File).to receive(:read).with('C:\chef\ohai\hints/rackspace.json').and_return('')
+      allow(File).to receive(:exist?).with('/usr/sbin/waagent').and_return(false)
+      allow(File).to receive(:exist?).with('/etc/chef/ohai/hints/azure.json').and_return(false)
+      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(false)
+      allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
+      allow(File).to receive(:exist?).with('/var/lib/dhcp/dhclient.eth0.leases').and_return(false)
+      @plugin.run
     end
 
     it 'should not behave like azure' do
       expect(@plugin[:azure]).to be_nil
+    end
+  end
+
+  describe "without azure hint file but with agent on linux" do
+    before(:each) do
+      allow(File).to receive(:exist?).with('/etc/chef/ohai/hints/azure.json').and_return(false)
+      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(false)
+      allow(File).to receive(:exist?).with('/usr/sbin/waagent').and_return(true)
+      allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
+      @plugin.run
+    end
+
+    it 'should create empty azure mash' do
+      expect(@plugin[:azure]).to be_empty
+    end
+  end
+
+  describe "without azure hint file but with agent on windows" do
+    before(:each) do
+      allow(File).to receive(:exist?).with('/etc/chef/ohai/hints/azure.json').and_return(false)
+      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(false)
+      allow(File).to receive(:exist?).with('/usr/sbin/waagent').and_return(false)
+      allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(true)
+      @plugin.run
+    end
+
+    it 'should create empty azure mash' do
+      puts "The dir exists?:" + "#{Dir.exist?('C:\WindowsAzure')}"
+      expect(@plugin[:azure]).to be_empty
+    end
+  end
+
+  describe "without azure hint or agent but with dhcp option" do
+    before(:each) do
+      allow(File).to receive(:exist?).with('/etc/chef/ohai/hints/azure.json').and_return(false)
+      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(false)
+      allow(File).to receive(:exist?).with('/usr/sbin/waagent').and_return(false)
+      allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
+      allow(File).to receive(:exist?).with('/var/lib/dhcp/dhclient.eth0.leases').and_return(true)
+      @double_file = double("/var/lib/dhcp/dhclient.eth0.leases")
+      allow(@double_file).to receive(:each).
+      and_yield('lease {').
+      and_yield('  interface "eth0";').
+      and_yield('  fixed-address 10.1.0.5;').
+      and_yield('  server-name "RD24BE05C6F140";').
+      and_yield('  option subnet-mask 255.255.255.0;').
+      and_yield('  option dhcp-lease-time 4294967295;').
+      and_yield('  option routers 10.1.0.1;').
+      and_yield('  option dhcp-message-type 5;').
+      and_yield('  option dhcp-server-identifier 168.63.129.16;').
+      and_yield('  option domain-name-servers 168.63.129.16;').
+      and_yield('  option dhcp-renewal-time 4294967295;').
+      and_yield('  option rfc3442-classless-static-routes 0,10,1,0,1,32,168,63,129,16,10,1,0,1;').
+      and_yield('  option unknown-245 a8:3f:81:10;').
+      and_yield('  option dhcp-rebinding-time 4294967295;').
+      and_yield('  option domain-name "v4wvfurds4relghweduc4zqjmd.dx.internal.cloudapp.net";').
+      and_yield('  renew 5 2152/03/10 09:03:39;').
+      and_yield('  rebind 5 2152/03/10 09:03:39;').
+      and_yield('  expire 5 2152/03/10 09:03:39;').
+      and_yield('}')
+      allow(File).to receive(:open).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(@double_file)
+      @plugin.run
+    end
+
+    it 'should create empty azure mash' do
+      puts "The dir exists?:" + "#{Dir.exist?('C:\WindowsAzure')}"
+      expect(@plugin[:azure]).to be_empty
     end
   end
 


### PR DESCRIPTION
Azure has no metadata endpoint and we pass in everything we stick in the mash via the hint, but there's still value in detecting azure when we didn't knife bootstrap. Users still want to do different things on their cloud hosts and this gives them that ability.

1) Detect hosts as being on azure when the waagent is present (windows and linux)
2) Detect hosts as being on azure when we find unknown-245 dhcp option which is used by Azure (linux only)
3) Fix the specs for the lack of hint file or presence of rackspace hint file so they actually run.  This confused me for a while until I realized they were expecting nil and not running the plugin so they got nil. Ouch.

And a bonus commit: switch the order or MS virtualization detection since 99.9% of the time it's hyper-v. No point in checking for VirtualPC first only to skip it 99.9% of the time.