### PR TITLE
Cleanup to the lang plugins and additional debug information

### DIFF
--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,6 +30,7 @@ Ohai.plugin(:C) do
     begin
       so = shell_out("gcc -v")
       if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran gcc -v")
         description = so.stderr.split($/).last
         output = description.split
         if output.length >= 3
@@ -62,6 +63,7 @@ Ohai.plugin(:C) do
     begin
       so = shell_out("cl /?")
       if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran cl /?")
         description = so.stderr.lines.first.chomp
         if description =~ /Compiler Version ([\d\.]+)/
           c[:cl] = Mash.new

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -40,6 +40,7 @@ Ohai.plugin(:C) do
         end
       end
     rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run gcc -v: Errno::ENOENT")
     end
 
     #glibc
@@ -72,12 +73,14 @@ Ohai.plugin(:C) do
         end
       end
     rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run cl /?: Errno::ENOENT")
     end
 
     #ms vs
     begin
       so = shell_out("devenv.com /?")
       if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran devenv.com /?")
         lines = so.stdout.split($/)
         description = lines[0].length == 0 ? lines[1] : lines[0]
         if description =~ /Visual Studio Version ([\d\.]+)/
@@ -87,12 +90,14 @@ Ohai.plugin(:C) do
         end
       end
     rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run devenv.com /?: Errno::ENOENT")
     end
 
     #ibm xlc
     begin
       so = shell_out("xlc -qversion")
       if so.exitstatus == 0 or (so.exitstatus >> 8) == 249
+        Ohai::Log.debug("Successfully ran xlc -qversion")
         description = so.stdout.split($/).first
         if description =~ /V(\d+\.\d+)/
           c[:xlc] = Mash.new
@@ -101,12 +106,14 @@ Ohai.plugin(:C) do
         end
       end
     rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run xlc -qversion: Errno::ENOENT")
     end
 
     #sun pro
     begin
       so = shell_out("cc -V -flags")
       if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran cc -V -flags")
         output = so.stderr.split
         if so.stderr =~ /^cc: Sun C/ && output.size >= 4
           c[:sunpro] = Mash.new
@@ -115,12 +122,14 @@ Ohai.plugin(:C) do
         end
       end
     rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run cc -V -flags: Errno::ENOENT")
     end
 
     #hpux cc
     begin
       so = shell_out("what /opt/ansic/bin/cc")
       if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran what /opt/ansic/bin/cc")
         description = so.stdout.split($/).select { |line| line =~ /HP C Compiler/ }.first
         if description
           output = description.split
@@ -130,8 +139,9 @@ Ohai.plugin(:C) do
         end
       end
     rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run what /opt/ansic/bin/cc: Errno::ENOENT")
     end
 
-    languages[:c] = c if c.keys.length > 0
+    languages[:c] = c unless c.empty?
   end
 end

--- a/lib/ohai/plugins/elixir.rb
+++ b/lib/ohai/plugins/elixir.rb
@@ -19,14 +19,18 @@ Ohai.plugin(:Elixir) do
   depends "languages"
 
   collect_data do
-    so = shell_out("elixir -v")
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran elixir -v")
-      elixir = Mash.new
-      output = nil
-      output = so.stdout.split
-      elixir[:version] = output[1]
-      languages[:elixir] = elixir unless elixir.empty?
+    begin
+      so = shell_out("elixir -v")
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran elixir -v")
+        elixir = Mash.new
+        output = nil
+        output = so.stdout.split
+        elixir[:version] = output[1]
+        languages[:elixir] = elixir unless elixir.empty?
+      end
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run elixir -v: Errno::ENOENT")
     end
   end
 end

--- a/lib/ohai/plugins/elixir.rb
+++ b/lib/ohai/plugins/elixir.rb
@@ -19,14 +19,14 @@ Ohai.plugin(:Elixir) do
   depends "languages"
 
   collect_data do
-    output = nil
-
-    elixir = Mash.new
     so = shell_out("elixir -v")
     if so.exitstatus == 0
-      output =  so.stdout.split
+      Ohai::Log.debug("Successfully ran elixir -v")
+      elixir = Mash.new
+      output = nil
+      output = so.stdout.split
       elixir[:version] = output[1]
-      languages[:elixir] = elixir if elixir[:version]
+      languages[:elixir] = elixir unless elixir.empty?
     end
   end
 end

--- a/lib/ohai/plugins/erlang.rb
+++ b/lib/ohai/plugins/erlang.rb
@@ -22,11 +22,11 @@ Ohai.plugin(:Erlang) do
   depends "languages"
 
   collect_data do
-    output = nil
-
-    erlang = Mash.new
     so = shell_out("erl +V")
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran erl +V")
+      erlang = Mash.new
+      output = nil
       output = so.stderr.split
       if output.length >= 6
         options = output[1]
@@ -34,9 +34,7 @@ Ohai.plugin(:Erlang) do
         erlang[:version] = output[5]
         erlang[:options] = options.split(',')
         erlang[:emulator] = output[2].gsub!(/(\(|\))/, '')
-        if erlang[:version] and erlang[:options] and erlang[:emulator]
-          languages[:erlang] = erlang
-        end
+        languages[:erlang] = erlang unless erlang.empty?
       end
     end
   end

--- a/lib/ohai/plugins/erlang.rb
+++ b/lib/ohai/plugins/erlang.rb
@@ -22,20 +22,24 @@ Ohai.plugin(:Erlang) do
   depends "languages"
 
   collect_data do
-    so = shell_out("erl +V")
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran erl +V")
-      erlang = Mash.new
-      output = nil
-      output = so.stderr.split
-      if output.length >= 6
-        options = output[1]
-        options.gsub!(/(\(|\))/, '')
-        erlang[:version] = output[5]
-        erlang[:options] = options.split(',')
-        erlang[:emulator] = output[2].gsub!(/(\(|\))/, '')
-        languages[:erlang] = erlang unless erlang.empty?
+    begin
+      so = shell_out("erl +V")
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran erl +V")
+        erlang = Mash.new
+        output = nil
+        output = so.stderr.split
+        if output.length >= 6
+          options = output[1]
+          options.gsub!(/(\(|\))/, '')
+          erlang[:version] = output[5]
+          erlang[:options] = options.split(',')
+          erlang[:emulator] = output[2].gsub!(/(\(|\))/, '')
+          languages[:erlang] = erlang unless erlang.empty?
+        end
       end
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run erl +V: Errno::ENOENT")
     end
   end
 end

--- a/lib/ohai/plugins/go.rb
+++ b/lib/ohai/plugins/go.rb
@@ -18,14 +18,18 @@ Ohai.plugin(:Go) do
   depends "languages"
 
   collect_data do
-    so = shell_out("go version")
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran go version")
-      go = Mash.new
-      output = nil
-      output = so.stdout.split
-      go[:version] = output[2].slice!(2..16)
-      languages[:go] = go unless go.empty?
+    begin
+      so = shell_out("go version")
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran go version")
+        go = Mash.new
+        output = nil
+        output = so.stdout.split
+        go[:version] = output[2].slice!(2..16)
+        languages[:go] = go unless go.empty?
+      end
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run go version: Errno::ENOENT")
     end
   end
 end

--- a/lib/ohai/plugins/go.rb
+++ b/lib/ohai/plugins/go.rb
@@ -18,13 +18,14 @@ Ohai.plugin(:Go) do
   depends "languages"
 
   collect_data do
-    output = nil
-    go = Mash.new
     so = shell_out("go version")
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran go version")
+      go = Mash.new
+      output = nil
       output = so.stdout.split
       go[:version] = output[2].slice!(2..16)
-      languages[:go] = go if go[:version]
+      languages[:go] = go unless go.empty?
     end
   end
 end

--- a/lib/ohai/plugins/groovy.rb
+++ b/lib/ohai/plugins/groovy.rb
@@ -22,16 +22,20 @@ Ohai.plugin(:Groovy) do
   depends "languages"
 
   collect_data do
-    so = shell_out("groovy -v")
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran groovy -v")
-      groovy = Mash.new
-      output = nil
-      output = so.stdout.split
-      if output.length >= 2
-        groovy[:version] = output[2]
+    begin
+      so = shell_out("groovy -v")
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran groovy -v")
+        groovy = Mash.new
+        output = nil
+        output = so.stdout.split
+        if output.length >= 2
+          groovy[:version] = output[2]
+        end
+        languages[:groovy] = groovy unless groovy.empty?
       end
-      languages[:groovy] = groovy unless groovy.empty?
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run groovy -v: Errno::ENOENT")
     end
   end
 end

--- a/lib/ohai/plugins/groovy.rb
+++ b/lib/ohai/plugins/groovy.rb
@@ -22,17 +22,16 @@ Ohai.plugin(:Groovy) do
   depends "languages"
 
   collect_data do
-    output = nil
-
-    groovy = Mash.new
-
     so = shell_out("groovy -v")
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran groovy -v")
+      groovy = Mash.new
+      output = nil
       output = so.stdout.split
       if output.length >= 2
         groovy[:version] = output[2]
       end
-      languages[:groovy] = groovy if groovy[:version]
+      languages[:groovy] = groovy unless groovy.empty?
     end
   end
 end

--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -21,9 +21,10 @@ Ohai.plugin(:Java) do
   depends "languages"
 
   def get_java_info
-    java = Mash.new
     so = shell_out("java -mx64m -version")
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran java -mx64m -version")
+      java = Mash.new
       so.stderr.split(/\r?\n/).each do |line|
         case line
         when /java version \"([0-9\.\_]+)\"/
@@ -35,7 +36,7 @@ Ohai.plugin(:Java) do
         end
       end
 
-      languages[:java] = java if java[:version]
+      languages[:java] = java unless java.empty?
     end
   end
 

--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -21,22 +21,26 @@ Ohai.plugin(:Java) do
   depends "languages"
 
   def get_java_info
-    so = shell_out("java -mx64m -version")
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran java -mx64m -version")
-      java = Mash.new
-      so.stderr.split(/\r?\n/).each do |line|
-        case line
-        when /java version \"([0-9\.\_]+)\"/
-          java[:version] = $1
-        when /^(.+Runtime Environment.*) \((build)\s*(.+)\)$/
-          java[:runtime] = { "name" => $1, "build" => $3 }
-        when /^(.+ (Client|Server) VM) \(build\s*(.+)\)$/
-          java[:hotspot] = { "name" => $1, "build" => $3 }
+    begin
+      so = shell_out("java -mx64m -version")
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran java -mx64m -version")
+        java = Mash.new
+        so.stderr.split(/\r?\n/).each do |line|
+          case line
+          when /java version \"([0-9\.\_]+)\"/
+            java[:version] = $1
+          when /^(.+Runtime Environment.*) \((build)\s*(.+)\)$/
+            java[:runtime] = { "name" => $1, "build" => $3 }
+          when /^(.+ (Client|Server) VM) \(build\s*(.+)\)$/
+            java[:hotspot] = { "name" => $1, "build" => $3 }
+          end
         end
-      end
 
-      languages[:java] = java unless java.empty?
+        languages[:java] = java unless java.empty?
+      end
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run java -mx64m -version: Errno::ENOENT")
     end
   end
 

--- a/lib/ohai/plugins/lua.rb
+++ b/lib/ohai/plugins/lua.rb
@@ -22,17 +22,16 @@ Ohai.plugin(:Lua) do
   depends "languages"
 
   collect_data do
-    output = nil
-
-    lua = Mash.new
-
     so = shell_out("lua -v")
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran lua -v")
+      lua = Mash.new
+      output = nil
       output = so.stderr.split
       if output.length >= 1
         lua[:version] = output[1]
       end
-      languages[:lua] = lua if lua[:version]
+      languages[:lua] = lua unless lua.empty?
     end
   end
 end

--- a/lib/ohai/plugins/lua.rb
+++ b/lib/ohai/plugins/lua.rb
@@ -22,16 +22,20 @@ Ohai.plugin(:Lua) do
   depends "languages"
 
   collect_data do
-    so = shell_out("lua -v")
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran lua -v")
-      lua = Mash.new
-      output = nil
-      output = so.stderr.split
-      if output.length >= 1
-        lua[:version] = output[1]
+    begin
+      so = shell_out("lua -v")
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran lua -v")
+        lua = Mash.new
+        output = nil
+        output = so.stderr.split
+        if output.length >= 1
+          lua[:version] = output[1]
+        end
+        languages[:lua] = lua unless lua.empty?
       end
-      languages[:lua] = lua unless lua.empty?
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run lua -v: Errno::ENOENT")
     end
   end
 end

--- a/lib/ohai/plugins/mono.rb
+++ b/lib/ohai/plugins/mono.rb
@@ -22,12 +22,11 @@ Ohai.plugin(:Mono) do
   depends "languages"
 
   collect_data do
-    output = nil
-
-    mono = Mash.new
-
     so = shell_out("mono -V")
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran mono -V")
+      mono = Mash.new
+      output = nil
       output = so.stdout.split
       if output.length >= 4
         mono[:version] = output[4]
@@ -35,7 +34,7 @@ Ohai.plugin(:Mono) do
       if output.length >= 11
         mono[:builddate] = "%s %s %s %s" % [output[6],output[7],output[8],output[11].gsub!(/\)/,'')]
       end
-      languages[:mono] = mono if mono[:version]
+      languages[:mono] = mono unless mono.empty?
     end
   end
 end

--- a/lib/ohai/plugins/mono.rb
+++ b/lib/ohai/plugins/mono.rb
@@ -22,19 +22,23 @@ Ohai.plugin(:Mono) do
   depends "languages"
 
   collect_data do
-    so = shell_out("mono -V")
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran mono -V")
-      mono = Mash.new
-      output = nil
-      output = so.stdout.split
-      if output.length >= 4
-        mono[:version] = output[4]
+    begin
+      so = shell_out("mono -V")
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran mono -V")
+        mono = Mash.new
+        output = nil
+        output = so.stdout.split
+        if output.length >= 4
+          mono[:version] = output[4]
+        end
+        if output.length >= 11
+          mono[:builddate] = "%s %s %s %s" % [output[6],output[7],output[8],output[11].gsub!(/\)/,'')]
+        end
+        languages[:mono] = mono unless mono.empty?
       end
-      if output.length >= 11
-        mono[:builddate] = "%s %s %s %s" % [output[6],output[7],output[8],output[11].gsub!(/\)/,'')]
-      end
-      languages[:mono] = mono unless mono.empty?
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run mono -V: Errno::ENOENT")
     end
   end
 end

--- a/lib/ohai/plugins/nodejs.rb
+++ b/lib/ohai/plugins/nodejs.rb
@@ -22,16 +22,20 @@ Ohai.plugin(:Nodejs) do
   depends "languages"
 
   collect_data do
-    so = shell_out("node -v")
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran node -v")
-      nodejs = Mash.new
-      output = nil
-      output = so.stdout.split
-      if output.length >= 1
-        nodejs[:version] = output[0][1..output[0].length]
+    begin
+      so = shell_out("node -v")
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran node -v")
+        nodejs = Mash.new
+        output = nil
+        output = so.stdout.split
+        if output.length >= 1
+          nodejs[:version] = output[0][1..output[0].length]
+        end
+        languages[:nodejs] = nodejs unless nodejs.empty?
       end
-      languages[:nodejs] = nodejs unless nodejs.empty?
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run node -v: Errno::ENOENT")
     end
   end
 end

--- a/lib/ohai/plugins/nodejs.rb
+++ b/lib/ohai/plugins/nodejs.rb
@@ -22,17 +22,16 @@ Ohai.plugin(:Nodejs) do
   depends "languages"
 
   collect_data do
-    output = nil
-
-    nodejs = Mash.new
-
     so = shell_out("node -v")
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran node -v")
+      nodejs = Mash.new
+      output = nil
       output = so.stdout.split
       if output.length >= 1
         nodejs[:version] = output[0][1..output[0].length]
       end
-      languages[:nodejs] = nodejs if nodejs[:version]
+      languages[:nodejs] = nodejs unless nodejs.empty?
     end
   end
 end

--- a/lib/ohai/plugins/perl.rb
+++ b/lib/ohai/plugins/perl.rb
@@ -22,11 +22,10 @@ Ohai.plugin(:Perl) do
   depends "languages"
 
   collect_data do
-    output = nil
-
-    perl = Mash.new
     so = shell_out("perl -V:version -V:archname")
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran perl -V:version -V:archname")
+      perl = Mash.new
       so.stdout.split(/\r?\n/).each do |line|
         case line
         when /^version=\'(.+)\';$/
@@ -35,7 +34,7 @@ Ohai.plugin(:Perl) do
           perl[:archname] = $1
         end
       end
-      languages[:perl] = perl
+      languages[:perl] = perl unless perl.empty?
     end
 
   end

--- a/lib/ohai/plugins/perl.rb
+++ b/lib/ohai/plugins/perl.rb
@@ -22,20 +22,23 @@ Ohai.plugin(:Perl) do
   depends "languages"
 
   collect_data do
-    so = shell_out("perl -V:version -V:archname")
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran perl -V:version -V:archname")
-      perl = Mash.new
-      so.stdout.split(/\r?\n/).each do |line|
-        case line
-        when /^version=\'(.+)\';$/
-          perl[:version] = $1
-        when /^archname=\'(.+)\';$/
-          perl[:archname] = $1
+    begin
+      so = shell_out("perl -V:version -V:archname")
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran perl -V:version -V:archname")
+        perl = Mash.new
+        so.stdout.split(/\r?\n/).each do |line|
+          case line
+          when /^version=\'(.+)\';$/
+            perl[:version] = $1
+          when /^archname=\'(.+)\';$/
+            perl[:archname] = $1
+          end
         end
+        languages[:perl] = perl unless perl.empty?
       end
-      languages[:perl] = perl unless perl.empty?
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run perl -V:version -V:archname: Errno::ENOENT")
     end
-
   end
 end

--- a/lib/ohai/plugins/php.rb
+++ b/lib/ohai/plugins/php.rb
@@ -24,10 +24,10 @@ Ohai.plugin(:PHP) do
   depends "languages"
 
   collect_data do
-    php = Mash.new
-
     so = shell_out("php -v")
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran php -v")
+      php = Mash.new
       so.stdout.each_line do |line|
         case line
         when /PHP (\S+).+built: ([^)]+)/
@@ -40,7 +40,7 @@ Ohai.plugin(:PHP) do
         end
       end
 
-      languages[:php] = php if php[:version]
+      languages[:php] = php unless php.empty?
     end
   end
 end

--- a/lib/ohai/plugins/php.rb
+++ b/lib/ohai/plugins/php.rb
@@ -24,23 +24,27 @@ Ohai.plugin(:PHP) do
   depends "languages"
 
   collect_data do
-    so = shell_out("php -v")
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran php -v")
-      php = Mash.new
-      so.stdout.each_line do |line|
-        case line
-        when /PHP (\S+).+built: ([^)]+)/
-          php[:version] = $1
-          php[:builddate] = $2
-        when /Zend Engine v([^\s]+),/
-          php[:zend_engine_version] = $1
-        when /Zend OPcache v([^\s]+),/
-          php[:zend_opcache_version] = $1
+    begin
+      so = shell_out("php -v")
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran php -v")
+        php = Mash.new
+        so.stdout.each_line do |line|
+          case line
+          when /PHP (\S+).+built: ([^)]+)/
+            php[:version] = $1
+            php[:builddate] = $2
+          when /Zend Engine v([^\s]+),/
+            php[:zend_engine_version] = $1
+          when /Zend OPcache v([^\s]+),/
+            php[:zend_opcache_version] = $1
+          end
         end
-      end
 
-      languages[:php] = php unless php.empty?
+        languages[:php] = php unless php.empty?
+      end
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run php -v: Errno::ENOENT")
     end
   end
 end

--- a/lib/ohai/plugins/powershell.rb
+++ b/lib/ohai/plugins/powershell.rb
@@ -20,7 +20,6 @@ Ohai.plugin(:Powershell) do
   depends "languages"
 
   collect_data(:windows) do
-    powershell = Mash.new
     so = shell_out("powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable")
     # Sample output:
     #
@@ -35,6 +34,8 @@ Ohai.plugin(:Powershell) do
     # PSRemotingProtocolVersion      2.2
 
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable")
+      powershell = Mash.new
       version_info = {}
       so.stdout.strip.each_line do |line|
         kv = line.strip.split(/\s+/, 2)
@@ -47,7 +48,7 @@ Ohai.plugin(:Powershell) do
       powershell[:build_version] = version_info['BuildVersion']
       powershell[:compatible_versions] = parse_compatible_versions(version_info['PSCompatibleVersions'])
       powershell[:remoting_protocol_version] = version_info['PSRemotingProtocolVersion']
-      languages[:powershell] = powershell if powershell[:version]
+      languages[:powershell] = powershell unless powershell.empty?
     end
   end
 

--- a/lib/ohai/plugins/powershell.rb
+++ b/lib/ohai/plugins/powershell.rb
@@ -20,35 +20,39 @@ Ohai.plugin(:Powershell) do
   depends "languages"
 
   collect_data(:windows) do
-    so = shell_out("powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable")
-    # Sample output:
-    #
-    # Name                           Value
-    # ----                           -----
-    # PSVersion                      4.0
-    # WSManStackVersion              3.0
-    # SerializationVersion           1.1.0.1
-    # CLRVersion                     4.0.30319.34014
-    # BuildVersion                   6.3.9600.16394
-    # PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0}
-    # PSRemotingProtocolVersion      2.2
+    begin
+      so = shell_out("powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable")
+      # Sample output:
+      #
+      # Name                           Value
+      # ----                           -----
+      # PSVersion                      4.0
+      # WSManStackVersion              3.0
+      # SerializationVersion           1.1.0.1
+      # CLRVersion                     4.0.30319.34014
+      # BuildVersion                   6.3.9600.16394
+      # PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0}
+      # PSRemotingProtocolVersion      2.2
 
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable")
-      powershell = Mash.new
-      version_info = {}
-      so.stdout.strip.each_line do |line|
-        kv = line.strip.split(/\s+/, 2)
-        version_info[kv[0]] = kv[1] if kv.length == 2
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable")
+        powershell = Mash.new
+        version_info = {}
+        so.stdout.strip.each_line do |line|
+          kv = line.strip.split(/\s+/, 2)
+          version_info[kv[0]] = kv[1] if kv.length == 2
+        end
+        powershell[:version] = version_info['PSVersion']
+        powershell[:ws_man_stack_version] = version_info['WSManStackVersion']
+        powershell[:serialization_version] = version_info['SerializationVersion']
+        powershell[:clr_version] = version_info['CLRVersion']
+        powershell[:build_version] = version_info['BuildVersion']
+        powershell[:compatible_versions] = parse_compatible_versions(version_info['PSCompatibleVersions'])
+        powershell[:remoting_protocol_version] = version_info['PSRemotingProtocolVersion']
+        languages[:powershell] = powershell unless powershell.empty?
       end
-      powershell[:version] = version_info['PSVersion']
-      powershell[:ws_man_stack_version] = version_info['WSManStackVersion']
-      powershell[:serialization_version] = version_info['SerializationVersion']
-      powershell[:clr_version] = version_info['CLRVersion']
-      powershell[:build_version] = version_info['BuildVersion']
-      powershell[:compatible_versions] = parse_compatible_versions(version_info['PSCompatibleVersions'])
-      powershell[:remoting_protocol_version] = version_info['PSRemotingProtocolVersion']
-      languages[:powershell] = powershell unless powershell.empty?
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable: Errno::ENOENT")
     end
   end
 

--- a/lib/ohai/plugins/python.rb
+++ b/lib/ohai/plugins/python.rb
@@ -22,20 +22,19 @@ Ohai.plugin(:Python) do
   depends "languages"
 
   collect_data do
-    output = nil
-
-    python = Mash.new
-
     so = shell_out("python -c \"import sys; print (sys.version)\"")
 
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran python -c \"import sys; print (sys.version)\"")
+      output = nil
+      python = Mash.new
       output = so.stdout.split
       python[:version] = output[0]
       if output.length >= 6
         python[:builddate] = "%s %s %s %s" % [output[2],output[3],output[4],output[5].gsub!(/\)/,'')]
       end
 
-      languages[:python] = python if python[:version] and python[:builddate]
+      languages[:python] = python unless python.empty?
     end
   end
 end

--- a/lib/ohai/plugins/python.rb
+++ b/lib/ohai/plugins/python.rb
@@ -22,19 +22,23 @@ Ohai.plugin(:Python) do
   depends "languages"
 
   collect_data do
-    so = shell_out("python -c \"import sys; print (sys.version)\"")
+    begin
+      so = shell_out("python -c \"import sys; print (sys.version)\"")
 
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran python -c \"import sys; print (sys.version)\"")
-      output = nil
-      python = Mash.new
-      output = so.stdout.split
-      python[:version] = output[0]
-      if output.length >= 6
-        python[:builddate] = "%s %s %s %s" % [output[2],output[3],output[4],output[5].gsub!(/\)/,'')]
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran python -c \"import sys; print (sys.version)\"")
+        python = Mash.new
+        output = nil
+        output = so.stdout.split
+        python[:version] = output[0]
+        if output.length >= 6
+          python[:builddate] = "%s %s %s %s" % [output[2],output[3],output[4],output[5].gsub!(/\)/,'')]
+        end
+
+        languages[:python] = python unless python.empty?
       end
-
-      languages[:python] = python unless python.empty?
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run python -c \"import sys; print (sys.version)\": Errno::ENOENT")
     end
   end
 end

--- a/lib/ohai/plugins/rust.rb
+++ b/lib/ohai/plugins/rust.rb
@@ -19,15 +19,19 @@ Ohai.plugin(:Rust) do
   depends "languages"
 
   collect_data do
-    so = shell_out("rustc --version")
+    begin
+      so = shell_out("rustc --version")
 
-    if so.exitstatus == 0
-      Ohai::Log.debug("Successfully ran rustc --version")
-      output = nil
-      rust = Mash.new
-      output =  so.stdout.split
-      rust[:version] = output[1]
-      languages[:rust] = rust unless rust.empty?
+      if so.exitstatus == 0
+        Ohai::Log.debug("Successfully ran rustc --version")
+        output = nil
+        rust = Mash.new
+        output =  so.stdout.split
+        rust[:version] = output[1]
+        languages[:rust] = rust unless rust.empty?
+      end
+    rescue Errno::ENOENT
+      Ohai::Log.debug("Could not run rustc --version: Errno::ENOENT")
     end
   end
 end

--- a/lib/ohai/plugins/rust.rb
+++ b/lib/ohai/plugins/rust.rb
@@ -19,14 +19,15 @@ Ohai.plugin(:Rust) do
   depends "languages"
 
   collect_data do
-    output = nil
-
-    rust = Mash.new
     so = shell_out("rustc --version")
+
     if so.exitstatus == 0
+      Ohai::Log.debug("Successfully ran rustc --version")
+      output = nil
+      rust = Mash.new
       output =  so.stdout.split
       rust[:version] = output[1]
-      languages[:rust] = rust if rust[:version]
+      languages[:rust] = rust unless rust.empty?
     end
   end
 end


### PR DESCRIPTION
Avoid creating the mashes before we've successfully shelled out.  Most of the time we'll fail and then we wasted our time initializing the mash.

Be smarter about when we save the data we found.  Some of these plugins collect 1/2 dozen attributes, but only use them if a 'version' attribute was found. Seems to be a lot of cargo culting since this is almost all the same code. We should save if we get back anything.

Finally add debugging information. Debug what we successfully shelled out with, which is helpful when you don't want to dig into the code to figure out what we're doing to get information. Also rescue the failure exceptions on the shell out and print simple messages.  This avoids pages of output.