### PR TITLE
Make pnp plugin opt-in via config

### DIFF
--- a/lib/ohai/plugins/windows/drivers.rb
+++ b/lib/ohai/plugins/windows/drivers.rb
@@ -20,12 +20,13 @@ Ohai.plugin(:Drivers) do
   depends "kernel"
 
   collect_data(:windows) do
-    require 'wmi-lite/wmi'
-
-    kext = Mash.new
-    pnp_drivers = Mash.new
-
     if configuration(:enabled)
+
+      require 'wmi-lite/wmi'
+
+      kext = Mash.new
+      pnp_drivers = Mash.new
+
       wmi = WmiLite::Wmi.new
 
       drivers = wmi.instances_of('Win32_PnPSignedDriver')
@@ -40,10 +41,11 @@ Ohai.plugin(:Drivers) do
           kext[driver['devicename']][:date] = pnp_drivers[driver['deviceid']][:driver_date] ? pnp_drivers[driver['deviceid']][:driver_date].to_s[0..7] : nil
         end
       end
+
+      kernel[:pnp_drivers] = pnp_drivers
+      kernel[:modules] = kext
+
     end
-
-    kernel[:pnp_drivers] = pnp_drivers
-    kernel[:modules] = kext
-
   end
+
 end

--- a/lib/ohai/plugins/windows/drivers.rb
+++ b/lib/ohai/plugins/windows/drivers.rb
@@ -22,21 +22,23 @@ Ohai.plugin(:Drivers) do
   collect_data(:windows) do
     require 'wmi-lite/wmi'
 
-    wmi = WmiLite::Wmi.new
-
     kext = Mash.new
     pnp_drivers = Mash.new
 
-    drivers = wmi.instances_of('Win32_PnPSignedDriver')
-    drivers.each do |driver|
-      pnp_drivers[driver['deviceid']] = Mash.new
-      driver.wmi_ole_object.properties_.each do |p|
-        pnp_drivers[driver['deviceid']][p.name.wmi_underscore.to_sym] = driver[p.name.downcase]
-      end
-      if driver['devicename']
-        kext[driver['devicename']] = pnp_drivers[driver['deviceid']]
-        kext[driver['devicename']][:version] = pnp_drivers[driver['deviceid']][:driver_version]
-        kext[driver['devicename']][:date] = pnp_drivers[driver['deviceid']][:driver_date] ? pnp_drivers[driver['deviceid']][:driver_date].to_s[0..7] : nil
+    if configuration(:enabled)
+      wmi = WmiLite::Wmi.new
+
+      drivers = wmi.instances_of('Win32_PnPSignedDriver')
+      drivers.each do |driver|
+        pnp_drivers[driver['deviceid']] = Mash.new
+        driver.wmi_ole_object.properties_.each do |p|
+          pnp_drivers[driver['deviceid']][p.name.wmi_underscore.to_sym] = driver[p.name.downcase]
+        end
+        if driver['devicename']
+          kext[driver['devicename']] = pnp_drivers[driver['deviceid']]
+          kext[driver['devicename']][:version] = pnp_drivers[driver['deviceid']][:driver_version]
+          kext[driver['devicename']][:date] = pnp_drivers[driver['deviceid']][:driver_date] ? pnp_drivers[driver['deviceid']][:driver_date].to_s[0..7] : nil
+        end
       end
     end
 


### PR DESCRIPTION
Makes the windows `Drivers` plugin opt-in via a config setting, similar to the packages plugin (see: https://github.com/chef/ohai/pull/717 ). This is technically a breaking change, but we decided in this case that the plugin was delivering too much negative value so it's worth it. The plugin can be re-enabled by setting `ohai.plugins[:drivers][:enabled] = true` in the Chef config file.