### PR TITLE
Detect paravirt amazon instances without hint files

### DIFF
--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -50,7 +50,7 @@ Ohai.plugin(:EC2) do
 ec2 plugin: Detected EC2 by the presence of fe:ff:ff:ff:ff:ff in the ARP table. This method is unreliable and will be removed in a future version of ohai. Bootstrap using knife-ec2 or create "/etc/chef/ohai/hints/ec2.json" instead.
 EOM
           Ohai::Log.warn(deprecation_message)
-          Ohai::Log.debug("ec2 plugin: has_ec2_mac? == true")
+          Ohai::Log.debug("ec2 plugin: has_xen_mac? == true")
           return true
         end
       end

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -265,7 +265,7 @@ describe Ohai::System, "plugin ec2" do
 
     it "warns that the arp table method is deprecated" do
       expect(Ohai::Log).to receive(:warn).with(/will be removed/)
-      @plugin.has_ec2_mac?
+      @plugin.has_xen_mac?
     end
   end
 


### PR DESCRIPTION
Official AMIs ship with the ec2metadata binary which we can look for. With this change we should be detecting the majority of scenarios without a hint file.

has_ec2_mac has been renamed has_xen_mac since we're actually looking for a xen mac.  Due to that the attempt to connect to the metadata only needs to happen when we only find the mac address since that can be either AWS or Xen.  If we find dmi data, a hint, or the metadata binary we can safely assume the metadata endpoint will respond.

 I also consolidated the "no hints or signs of AWS" scenario into a single spec since it seems to make more sense that way.