### PR TITLE
deprecate looking for EC2 by mac

### DIFF
--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -33,6 +33,12 @@ Ohai.plugin(:EC2) do
     network[:interfaces].values.each do |iface|
       unless iface[:arp].nil?
         if iface[:arp].value?("fe:ff:ff:ff:ff:ff")
+          # using MAC addresses from ARP is unreliable because they could time-out from the table
+          # fe:ff:ff:ff:ff:ff is actually a sign of Xen, not specifically EC2
+          deprecation_message <<-EOM
+Detected EC2 by the presence of fe:ff:ff:ff:ff:ff in the ARP table. This method is unreliable and will be removed in a future version of ohai. Use knife-ec2 or create "/etc/chef/ohai/hints/ec2.json" instead.
+EOM
+          Ohai::Log.warn(deprecation_message)
           Ohai::Log.debug("has_ec2_mac? == true")
           return true
         end


### PR DESCRIPTION
we should have enough other methods now, hints have been around for a while.
this detects xen, not ec2.

also cleans up some confusing whitespacing in the test.

we don't really need to do this, but my :neckbeard: is itching.