### PR TITLE
Log sigar gem load failures

### DIFF
--- a/lib/ohai/plugins/sigar/network_route.rb
+++ b/lib/ohai/plugins/sigar/network_route.rb
@@ -19,41 +19,46 @@
 require "ohai/mixin/network_constants"
 
 Ohai.plugin(:NetworkRoutes) do
-  include Ohai::Mixin::NetworkConstants
-
-  provides "network/interfaces/adapters/route"
-  depends "network/interfaces"
-
-  def flags(flags)
-    f = ""
-    if (flags & Sigar::RTF_UP) != 0
-      f += "U"
-    end
-    if (flags & Sigar::RTF_GATEWAY) != 0
-      f += "G"
-    end
-    if (flags & Sigar::RTF_HOST) != 0
-      f += "H"
-    end
-    f
-  end
-
-  collect_data(:default) do
+  begin
     require "sigar"
-    sigar = Sigar.new
 
-    sigar.net_route_list.each do |route|
-      next unless network[:interfaces][route.ifname] # this should never happen
-      network[:interfaces][route.ifname][:route] = Mash.new unless network[:interfaces][route.ifname][:route]
-      route_data = {}
-      Ohai::Mixin::NetworkConstants::SIGAR_ROUTE_METHODS.each do |m|
-        if(m == :flags)
-          route_data[m] = flags(route.send(m))
-        else
-          route_data[m] = route.send(m)
-        end
+    include Ohai::Mixin::NetworkConstants
+
+    provides "network/interfaces/adapters/route"
+    depends "network/interfaces"
+
+    def flags(flags)
+      f = ""
+      if (flags & Sigar::RTF_UP) != 0
+        f += "U"
       end
-      network[:interfaces][route.ifname][:route][route.destination] = route_data
+      if (flags & Sigar::RTF_GATEWAY) != 0
+        f += "G"
+      end
+      if (flags & Sigar::RTF_HOST) != 0
+        f += "H"
+      end
+      f
     end
+
+    collect_data(:default) do
+      sigar = Sigar.new
+
+      sigar.net_route_list.each do |route|
+        next unless network[:interfaces][route.ifname] # this should never happen
+        network[:interfaces][route.ifname][:route] = Mash.new unless network[:interfaces][route.ifname][:route]
+        route_data = {}
+        Ohai::Mixin::NetworkConstants::SIGAR_ROUTE_METHODS.each do |m|
+          if(m == :flags)
+            route_data[m] = flags(route.send(m))
+          else
+            route_data[m] = route.send(m)
+          end
+        end
+        network[:interfaces][route.ifname][:route][route.destination] = route_data
+      end
+    end
+  rescue LoadError
+    Ohai::Log.debug('Could not load sigar gem. Skipping NetworkRoutes plugin')
   end
 end


### PR DESCRIPTION
These two plugins run on every system and spam debug logs. There are other plugins that use sigar, but they're confined to HPUX where you need sigar for ohai to operate.