### PR TITLE
Fix digital ocean ip address detection

### DIFF
--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -28,7 +28,7 @@ Ohai.plugin(:DigitalOcean) do
     addresses = Mash.new({ "v4" => [], "v6" => [] })
     network[:interfaces].each_value do |iface|
       iface[:addresses].each do |address, details|
-        next if loopback?(address) || details[:family] == "lladdr"
+        next if details[:family] == "lladdr" || loopback?(address)
 
         ip = IPAddress(address)
         type = digital_ocean_address_type(ip)

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -42,6 +42,9 @@ describe Ohai::System, "plugin digital_ocean" do
       "interfaces" => {
         "eth0" => {
           "addresses" => {
+            "00:D3:AD:B3:3F:00" => {
+              "family": "lladdr"
+            },
             "1.2.3.4" => {
               "netmask" => "255.255.255.0"
             },

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -43,7 +43,7 @@ describe Ohai::System, "plugin digital_ocean" do
         "eth0" => {
           "addresses" => {
             "00:D3:AD:B3:3F:00" => {
-              "family": "lladdr"
+              "family" => "lladdr"
             },
             "1.2.3.4" => {
               "netmask" => "255.255.255.0"


### PR DESCRIPTION
IpHelper's loopback? method fails when you pass it a MAC address, so we
should check for this first