### PR TITLE
Update GCE metadata API version and fail better

### DIFF
--- a/lib/ohai/mixin/gce_metadata.rb
+++ b/lib/ohai/mixin/gce_metadata.rb
@@ -61,7 +61,7 @@ module Ohai
       def http_get(uri)
         conn = Net::HTTP.start(GCE_METADATA_ADDR)
         conn.read_timeout = 6
-        conn.get(uri, initheader = { 'Metadata-Flavor' => 'Google' })
+        conn.get(uri, initheader = { "Metadata-Flavor" => "Google" })
       end
 
       def fetch_metadata(id = "")

--- a/lib/ohai/mixin/gce_metadata.rb
+++ b/lib/ohai/mixin/gce_metadata.rb
@@ -23,11 +23,17 @@ module Ohai
 
       # Trailing dot to host is added to avoid DNS search path
       GCE_METADATA_ADDR = "metadata.google.internal." unless defined?(GCE_METADATA_ADDR)
-      GCE_METADATA_URL = "/computeMetadata/v1beta1/?recursive=true" unless defined?(GCE_METADATA_URL)
+      GCE_METADATA_URL = "/computeMetadata/v1/?recursive=true" unless defined?(GCE_METADATA_URL)
 
       def can_metadata_connect?(addr, port, timeout = 2)
         t = Socket.new(Socket::Constants::AF_INET, Socket::Constants::SOCK_STREAM, 0)
-        saddr = Socket.pack_sockaddr_in(port, addr)
+        begin
+          saddr = Socket.pack_sockaddr_in(port, addr)
+        rescue SocketError => e # occurs when non-GCE systems try to resolve metadata.google.internal
+          Ohai::Log.debug("gce mixin: can_metadata_connect? failed setting up socket: #{e}")
+          return false
+        end
+
         connected = false
 
         begin
@@ -47,24 +53,26 @@ module Ohai
           end
         rescue SystemCallError
         end
-        Ohai::Log.debug("can_metadata_connect? == #{connected}")
+        Ohai::Log.debug("gce mixin: can_metadata_connect? == #{connected}")
         connected
       end
 
-      def http_client
-        Net::HTTP.start(GCE_METADATA_ADDR).tap { |h| h.read_timeout = 6 }
+      # fetch the meta content with a timeout and the required header
+      def http_get(uri)
+        conn = Net::HTTP.start(GCE_METADATA_ADDR)
+        conn.read_timeout = 6
+        conn.get(uri, initheader = { 'Metadata-Flavor' => 'Google' })
       end
 
       def fetch_metadata(id = "")
-        uri = "#{GCE_METADATA_URL}/#{id}"
-        response = http_client.get(uri)
+        response = http_get("#{GCE_METADATA_URL}/#{id}")
         return nil unless response.code == "200"
 
         if json?(response.body)
           data = StringIO.new(response.body)
           parser = FFI_Yajl::Parser.new
           parser.parse(data)
-        elsif has_trailing_slash?(id) or (id == "")
+        elsif has_trailing_slash?(id) || (id == "")
           temp = {}
           response.body.split("\n").each do |sub_attr|
             temp[sanitize_key(sub_attr)] = fetch_metadata("#{id}#{sub_attr}")


### PR DESCRIPTION
Use the non-beta metadata URL. This requires setting the header on all requests so there's a bit of changes to how the http connection is initialized
Fail better if the google internal DNS name can't be resolved