### PR TITLE
Add support for opensuse leap

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -125,7 +125,7 @@ Ohai.plugin(:Platform) do
       suse_version = suse_release[/VERSION = ([\d\.]{2,})/, 1] if suse_version == ""
       platform_version suse_version
       if suse_release =~ /^openSUSE/
-        platform "opensuse"
+        platform "opensuse" && platform_version.to_i < 42
       else
         platform "suse"
       end

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -124,8 +124,8 @@ Ohai.plugin(:Platform) do
       suse_version = suse_release.scan(/VERSION = (\d+)\nPATCHLEVEL = (\d+)/).flatten.join(".")
       suse_version = suse_release[/VERSION = ([\d\.]{2,})/, 1] if suse_version == ""
       platform_version suse_version
-      if suse_release =~ /^openSUSE/
-        platform "opensuse" && platform_version.to_i < 42
+      if suse_release =~ /^openSUSE/ && platform_version.to_i < 42
+        platform "opensuse"
       else
         platform "suse"
       end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -665,6 +665,13 @@ CISCO_RELEASE
         expect(@plugin[:platform]).to eq("opensuse")
         expect(@plugin[:platform_family]).to eq("suse")
       end
+      
+      it "should read the platform as suse on openSUSE Leap" do
+        expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 42.1 (x86_64)\nVERSION = 42.1\nCODENAME = Malachite\n")
+        @plugin.run
+        expect(@plugin[:platform]).to eq("suse")
+        expect(@plugin[:platform_family]).to eq("suse")
+      end
     end
   end
 

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -665,7 +665,7 @@ CISCO_RELEASE
         expect(@plugin[:platform]).to eq("opensuse")
         expect(@plugin[:platform_family]).to eq("suse")
       end
-      
+
       it "should read the platform as suse on openSUSE Leap" do
         expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 42.1 (x86_64)\nVERSION = 42.1\nCODENAME = Malachite\n")
         @plugin.run


### PR DESCRIPTION
This fix address install failures of latest version chef server, chef reporting, chef manage and likely other products.