### PR TITLE
Use escape_glob_dir instead of escape_glob

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ platform:
 environment:
   matrix:
     - ruby_version: "200"
+    - ruby_version: "21"
 
 clone_folder: c:\projects\ohai
 clone_depth: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
   matrix:
     - ruby_version: "200"
     - ruby_version: "21"
+    - ruby_version: "22"
 
 clone_folder: c:\projects\ohai
 clone_depth: 1

--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -39,7 +39,7 @@ module Ohai
 
       # Finds all the *.rb files under the configured paths in :plugin_path
       def self.find_all_in(plugin_dir)
-        Dir[File.join(ChefConfig::PathHelper.escape_glob(plugin_dir), "**", "*.rb")].map do |file|
+        Dir[File.join(ChefConfig::PathHelper.escape_glob_dir(plugin_dir), "**", "*.rb")].map do |file|
           new(file, plugin_dir)
         end
       end


### PR DESCRIPTION
For ruby >= 2.2, Dir.glob behaves differently than ruby 2.0
and breaks in more places when backslashes are used when globbing.
This means that Windows is sad and will not load any plugins with
Ruby >= 2.2 in a lot of cases. This is the safest thing to do
because it will use forward slashes.