### PR TITLE
Improve KVM host and guest detection

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -64,14 +64,10 @@ Ohai.plugin(:Virtualization) do
     # - Additional edge cases likely should not change the above assumptions
     #   but rather be additive - btm
 
-    # Detect from kernel module
+    # Detect Virtualbox from kernel module
     if File.exist?("/proc/modules")
       modules = File.read("/proc/modules")
-      if modules =~ /^kvm/
-        virtualization[:system] = "kvm"
-        virtualization[:role] = "host"
-        virtualization[:systems][:kvm] = "host"
-      elsif modules =~ /^vboxdrv/
+      if modules =~ /^vboxdrv/
         virtualization[:system] = "vbox"
         virtualization[:role] = "host"
         virtualization[:systems][:vbox] = "host"
@@ -93,6 +89,13 @@ Ohai.plugin(:Virtualization) do
         virtualization[:role] = "guest"
         virtualization[:systems][:kvm] = "guest"
       end
+    end
+
+    # Detect KVM guests via /sys/ data
+    if File.exist?("/sys/devices/virtual/misc/kvm")
+      virtualization[:system] = "kvm"
+      virtualization[:role] = "guest"
+      virtualization[:systems][:kvm] = "guest"
     end
 
     # Detect OpenVZ / Virtuozzo.

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -37,9 +37,6 @@ Ohai.plugin(:Virtualization) do
     virtualization Mash.new unless virtualization
     virtualization[:systems] = Mash.new unless virtualization[:systems]
 
-    # if it is possible to detect paravirt vs hardware virt, it should be put in
-    # virtualization[:mechanism]
-
     ## Xen
     # /proc/xen is an empty dir for EL6 + Linode Guests + Paravirt EC2 instances
     if File.exist?("/proc/xen")
@@ -60,7 +57,6 @@ Ohai.plugin(:Virtualization) do
     # Xen Notes:
     # - cpuid of guests, if we could get it, would also be a clue
     # - may be able to determine if under paravirt from /dev/xen/evtchn (See OHAI-253)
-    # - EL6 guests carry a 'hypervisor' cpu flag
     # - Additional edge cases likely should not change the above assumptions
     #   but rather be additive - btm
 
@@ -78,11 +74,7 @@ Ohai.plugin(:Virtualization) do
       end
     end
 
-    # Detect KVM/QEMU from cpuinfo, report as KVM
-    # We could pick KVM from 'Booting paravirtualized kernel on KVM' in dmesg
-    # 2.6.27-9-server (intrepid) has this / 2.6.18-6-amd64 (etch) does not
-    # It would be great if we could read pv_info in the kernel
-    # Wait for reply to: http://article.gmane.org/gmane.comp.emulators.kvm.devel/27885
+    # Detect paravirt KVM/QEMU from cpuinfo, report as KVM
     if File.exist?("/proc/cpuinfo")
       if File.read("/proc/cpuinfo") =~ /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/
         virtualization[:system] = "kvm"

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -83,11 +83,17 @@ Ohai.plugin(:Virtualization) do
       end
     end
 
-    # Detect KVM guests via /sys/ data
+    # Detect KVM systems via /sys
+    # guests will have the hypervisor cpu feature that hosts don't have
     if File.exist?("/sys/devices/virtual/misc/kvm")
       virtualization[:system] = "kvm"
-      virtualization[:role] = "guest"
-      virtualization[:systems][:kvm] = "guest"
+      if File.read("/proc/cpuinfo") =~ /hypervisor/
+        virtualization[:role] = "guest"
+        virtualization[:systems][:kvm] = "guest"
+      else
+        virtualization[:role] = "host"
+        virtualization[:systems][:kvm] = "host"
+      end
     end
 
     # Detect OpenVZ / Virtuozzo.

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -77,13 +77,12 @@ describe Ohai::System, "Linux virtualization platform" do
   end
 
   describe "when we are checking for kvm" do
-    it "sets kvm host if /proc/modules contains kvm" do
-      expect(File).to receive(:exist?).with("/proc/modules").and_return(true)
-      allow(File).to receive(:read).with("/proc/modules").and_return("kvm 165872  1 kvm_intel")
+    it "sets kvm guest if /sys/devices/virtual/misc/kvm exists" do
+      expect(File).to receive(:exist?).with("/sys/devices/virtual/misc/kvm").and_return(true)
       plugin.run
       expect(plugin[:virtualization][:system]).to eq("kvm")
-      expect(plugin[:virtualization][:role]).to eq("host")
-      expect(plugin[:virtualization][:systems][:kvm]).to eq("host")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+      expect(plugin[:virtualization][:systems][:kvm]).to eq("guest")
     end
 
     it "sets kvm guest if /proc/cpuinfo contains QEMU Virtual CPU" do

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -37,6 +37,7 @@ describe Ohai::System, "Linux virtualization platform" do
     allow(File).to receive(:exist?).with("/.dockerenv").and_return(false)
     allow(File).to receive(:exist?).with("/.dockerinit").and_return(false)
     allow(File).to receive(:exist?).with("/proc/bus/pci/devices").and_return(false)
+    allow(File).to receive(:exist?).with("/sys/devices/virtual/misc/kvm").and_return(false)
   end
 
   describe "when we are checking for xen" do
@@ -78,7 +79,7 @@ describe Ohai::System, "Linux virtualization platform" do
 
   describe "when we are checking for kvm" do
     it "sets kvm guest if /sys/devices/virtual/misc/kvm exists" do
-      expect(File).to receive(:exist?).with("/sys/devices/virtual/misc/kvm").and_return(true)
+      allow(File).to receive(:exist?).with("/sys/devices/virtual/misc/kvm").and_return(true)
       plugin.run
       expect(plugin[:virtualization][:system]).to eq("kvm")
       expect(plugin[:virtualization][:role]).to eq("guest")

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -78,12 +78,22 @@ describe Ohai::System, "Linux virtualization platform" do
   end
 
   describe "when we are checking for kvm" do
-    it "sets kvm guest if /sys/devices/virtual/misc/kvm exists" do
+    it "sets kvm guest if /sys/devices/virtual/misc/kvm exists & hypervisor cpu feature is present" do
       allow(File).to receive(:exist?).with("/sys/devices/virtual/misc/kvm").and_return(true)
+      allow(File).to receive(:read).with("/proc/cpuinfo").and_return("fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx rdtscp lm constant_tsc arch_perfmon rep_good nopl pni vmx ssse3 cx16 sse4_1 sse4_2 x2apic popcnt hypervisor lahf_lm vnmi ept tsc_adjust")
       plugin.run
       expect(plugin[:virtualization][:system]).to eq("kvm")
       expect(plugin[:virtualization][:role]).to eq("guest")
       expect(plugin[:virtualization][:systems][:kvm]).to eq("guest")
+    end
+
+    it "sets kvm host if /sys/devices/virtual/misc/kvm exists & hypervisor cpu feature is not present" do
+      allow(File).to receive(:exist?).with("/sys/devices/virtual/misc/kvm").and_return(true)
+      allow(File).to receive(:read).with("/proc/cpuinfo").and_return("fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm dca sse4_1 sse4_2 popcnt lahf_lm ida dtherm tpr_shadow vnmi flexpriority ept vpid")
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("kvm")
+      expect(plugin[:virtualization][:role]).to eq("host")
+      expect(plugin[:virtualization][:systems][:kvm]).to eq("host")
     end
 
     it "sets kvm guest if /proc/cpuinfo contains QEMU Virtual CPU" do


### PR DESCRIPTION
Before we detected KVM hosts via kvm modules, which are actually loaded for both guests and hosts.  Instead use /sys/devices/virtual/misc/kvm to determine if the system is KVM in anyway.  From there look for a hypervisor cpu feature flag to determine if we're a guest.  If that isn't there we're on a host.