### PR TITLE
Improve FreeBSD guest virtualization detection

### DIFF
--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -36,7 +36,10 @@ Ohai.plugin(:Virtualization) do
       virtualization[:systems][:jail] = "guest"
     end
 
-    so = shell_out("jls -n")
+    # run jls to get a list of running jails
+    # -n: name=value 1 line per jail format
+    # -d: list the dying jails as well as active jails
+    so = shell_out("jls -nd")
     if (so.stdout || "").lines.count >= 1
       virtualization[:system] = "jail"
       virtualization[:role] = "host"

--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -57,13 +57,21 @@ Ohai.plugin(:Virtualization) do
         virtualization[:system] = "vbox"
         virtualization[:role] = "host"
         virtualization[:systems][:vbox] = "host"
-        Ohai::Log.debug('Virtualization plugin: Guest running on VirtualBox detected')
+        Ohai::Log.debug("Virtualization plugin: Guest running on VirtualBox detected")
       when /vboxguest/
         virtualization[:system] = "vbox"
         virtualization[:role] = "guest"
         virtualization[:systems][:vbox] = "guest"
-        Ohai::Log.debug('Virtualization plugin: Host running VirtualBox detected')
+        Ohai::Log.debug("Virtualization plugin: Host running VirtualBox detected")
       end
+    end
+
+    # Detect bhyve by presence of /dev/vmm
+    if File.exist?("/dev/vmm")
+      virtualization[:system] = "bhyve"
+      virtualization[:role] = "host"
+      virtualization[:systems][:bhyve] = "host"
+      Ohai::Log.debug("Virtualization plugin: Host running bhyve detected")
     end
 
     # Detect KVM/QEMU paravirt guests from cpu, report as KVM
@@ -73,7 +81,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "kvm"
       virtualization[:role] = "guest"
       virtualization[:systems][:kvm] = "guest"
-      Ohai::Log.debug('Virtualization plugin: Guest running on KVM detected')
+      Ohai::Log.debug("Virtualization plugin: Guest running on KVM detected")
     end
 
     # parse dmidecode to discover various virtualization guests

--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -84,6 +84,33 @@ Ohai.plugin(:Virtualization) do
       Ohai::Log.debug("Virtualization plugin: Guest running on KVM detected")
     end
 
+    # gather hypervisor of guests from sysctl kern.vm_guest
+    # there are a limited number of hypervisors detected here, BUT it doesn't
+    # require dmidecode to be installed and dmidecode isn't in freebsd out of the box
+    so = shell_out("sysctl -n kern.vm_guest")
+    case so.stdout
+    when /vmware/
+      virtualization[:system] = "vmware"
+      virtualization[:role] = "guest"
+      virtualization[:systems][:vmware] = "guest"
+      Ohai::Log.debug("Virtualization plugin: Guest running on VMware detected")
+    when /hv/
+      virtualization[:system] = "hyperv"
+      virtualization[:role] = "guest"
+      virtualization[:systems][:hyperv] = "guest"
+      Ohai::Log.debug("Virtualization plugin: Guest running on Hyper-V detected")
+    when /xen/
+      virtualization[:system] = "xen"
+      virtualization[:role] = "guest"
+      virtualization[:systems][:xen] = "guest"
+      Ohai::Log.debug("Virtualization plugin: Guest running on Xen detected")
+    when /bhyve/
+      virtualization[:system] = "bhyve"
+      virtualization[:role] = "guest"
+      virtualization[:systems][:bhyve] = "guest"
+      Ohai::Log.debug("Virtualization plugin: Guest running on bhyve detected")
+    end
+
     # parse dmidecode to discover various virtualization guests
     if File.exist?("/usr/local/sbin/dmidecode") || File.exist?("/usr/pkg/sbin/dmidecode")
       guest = guest_from_dmi(shell_out("dmidecode").stdout)

--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Bryan McLellan (btm@loftninjas.org)
 # Copyright:: Copyright (c) 2009 Bryan McLellan
+# Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +35,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "jail"
       virtualization[:role] = "guest"
       virtualization[:systems][:jail] = "guest"
+      Ohai::Log.debug("Virtualization plugin: Guest running in FreeBSD jail detected")
     end
 
     # run jls to get a list of running jails
@@ -44,6 +46,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "jail"
       virtualization[:role] = "host"
       virtualization[:systems][:jail] = "host"
+      Ohai::Log.debug("Virtualization plugin: Host running FreeBSD jails detected")
     end
 
     # detect from modules
@@ -54,20 +57,23 @@ Ohai.plugin(:Virtualization) do
         virtualization[:system] = "vbox"
         virtualization[:role] = "host"
         virtualization[:systems][:vbox] = "host"
+        Ohai::Log.debug('Virtualization plugin: Guest running on VirtualBox detected')
       when /vboxguest/
         virtualization[:system] = "vbox"
         virtualization[:role] = "guest"
         virtualization[:systems][:vbox] = "guest"
+        Ohai::Log.debug('Virtualization plugin: Host running VirtualBox detected')
       end
     end
 
-    # Detect KVM/QEMU from cpu, report as KVM
+    # Detect KVM/QEMU paravirt guests from cpu, report as KVM
     # hw.model: QEMU Virtual CPU version 0.9.1
     so = shell_out("sysctl -n hw.model")
     if so.stdout.split($/)[0] =~ /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/
       virtualization[:system] = "kvm"
       virtualization[:role] = "guest"
       virtualization[:systems][:kvm] = "guest"
+      Ohai::Log.debug('Virtualization plugin: Guest running on KVM detected')
     end
 
     # parse dmidecode to discover various virtualization guests
@@ -77,6 +83,7 @@ Ohai.plugin(:Virtualization) do
         virtualization[:system] = guest
         virtualization[:role] = "guest"
         virtualization[:systems][guest.to_sym] = "guest"
+        Ohai::Log.debug("Virtualization plugin: Guest running on #{guest} detected")
       end
     end
   end

--- a/spec/unit/plugins/bsd/virtualization_spec.rb
+++ b/spec/unit/plugins/bsd/virtualization_spec.rb
@@ -26,6 +26,17 @@ describe Ohai::System, "BSD virtualization plugin" do
     allow(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path( "/sbin/kldstat" )}").and_return(mock_shell_out(0, "", ""))
     allow(@plugin).to receive(:shell_out).with("jls -nd").and_return(mock_shell_out(0, "", ""))
     allow(@plugin).to receive(:shell_out).with("sysctl -n hw.model").and_return(mock_shell_out(0, "", ""))
+    allow(File).to receive(:exist?).and_return false
+  end
+
+  context "bhyve" do
+    it "detects we are running bhyve" do
+      allow(File).to receive(:exist?).with("/dev/vmm").and_return true
+      @plugin.run
+      expect(@plugin[:virtualization][:system]).to eq("bhyve")
+      expect(@plugin[:virtualization][:role]).to eq("host")
+      expect(@plugin[:virtualization][:systems][:bhyve]).to eq("host")
+    end
   end
 
   context "jails" do
@@ -40,7 +51,7 @@ describe Ohai::System, "BSD virtualization plugin" do
     it "detects we are hosting jails" do
       # from http://www.freebsd.org/doc/handbook/jails-application.html
       @jails = "JID  IP Address      Hostname                      Path\n     3  192.168.3.17    ns.example.org                /home/j/ns\n     2  192.168.3.18    mail.example.org              /home/j/mail\n     1  62.123.43.14    www.example.org               /home/j/www"
-      allow(@plugin).to receive(:shell_out).with("jls -n").and_return(mock_shell_out(0, @jails, ""))
+      allow(@plugin).to receive(:shell_out).with("jls -nd").and_return(mock_shell_out(0, @jails, ""))
       @plugin.run
       expect(@plugin[:virtualization][:system]).to eq("jail")
       expect(@plugin[:virtualization][:role]).to eq("host")

--- a/spec/unit/plugins/bsd/virtualization_spec.rb
+++ b/spec/unit/plugins/bsd/virtualization_spec.rb
@@ -24,7 +24,7 @@ describe Ohai::System, "BSD virtualization plugin" do
     allow(@plugin).to receive(:collect_os).and_return(:freebsd)
     allow(@plugin).to receive(:shell_out).with("sysctl -n security.jail.jailed").and_return(mock_shell_out(0, "0", ""))
     allow(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path( "/sbin/kldstat" )}").and_return(mock_shell_out(0, "", ""))
-    allow(@plugin).to receive(:shell_out).with("jls -n").and_return(mock_shell_out(0, "", ""))
+    allow(@plugin).to receive(:shell_out).with("jls -nd").and_return(mock_shell_out(0, "", ""))
     allow(@plugin).to receive(:shell_out).with("sysctl -n hw.model").and_return(mock_shell_out(0, "", ""))
   end
 


### PR DESCRIPTION
Add debug output for everything we detect
Detect bhyve hosts when /dev/vmm exists (vmm module)
Detect jail hosts with jails in the dying state. They still count
Detect guests with sysctl -n kern.vm_guest output. This detects vmware, xen, hyper-v, and bhyve guests even when dmidecode isn't present (it's not installed by default so big win here)