### PR TITLE
Improve virtualization detection on Solaris

### DIFF
--- a/lib/ohai/mixin/dmi_decode.rb
+++ b/lib/ohai/mixin/dmi_decode.rb
@@ -21,7 +21,7 @@ module ::Ohai::Mixin::DmiDecode
     dmi_data.each_line do |line|
       case line
       when /Manufacturer: Microsoft/
-        if dmi_data =~ /Product Name: Virtual Machine/
+        if dmi_data =~ /Product.*: Virtual Machine/
           if dmi_data =~ /Version: (7.0|Hyper-V)/
             return "hyperv"
           elsif dmi_data =~ /Version: (VS2005R2|6.0)/

--- a/lib/ohai/mixin/dmi_decode.rb
+++ b/lib/ohai/mixin/dmi_decode.rb
@@ -34,9 +34,9 @@ module ::Ohai::Mixin::DmiDecode
         return "vmware"
       when /Manufacturer: Xen/
         return "xen"
-      when /Product Name: VirtualBox/
+      when /Product.*: VirtualBox/
         return "vbox"
-      when /Product Name: OpenStack/
+      when /Product.*: OpenStack/
         return "openstack"
       when /Manufacturer: QEMU|Product Name: (KVM|RHEV)/
         return "kvm"

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -41,6 +41,7 @@ Ohai.plugin(:Virtualization) do
       if so.stdout =~ /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/
         virtualization[:system] = "kvm"
         virtualization[:role] = "guest"
+        virtualization[:systems][:kvm] = "guest"
       end
     end
 
@@ -73,15 +74,17 @@ Ohai.plugin(:Virtualization) do
 
       if zones.length == 1
         first_zone = zones.keys[0]
-        unless( first_zone == "global")
+        unless first_zone == "global"
           virtualization[:system] = "zone"
           virtualization[:role] = "guest"
+          virtualization[:systems][:zone] = "guest"
           virtualization[:guest_uuid] = zones[first_zone]["uuid"]
           virtualization[:guest_id] = collect_solaris_guestid
         end
       elsif zones.length > 1
         virtualization[:system] = "zone"
         virtualization[:role] = "host"
+        virtualization[:systems][:zone] = "host"
         virtualization[:guests] = zones
       end
     end

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -30,11 +30,11 @@ Ohai.plugin(:Virtualization) do
   collect_data(:solaris2) do
     virtualization Mash.new
 
-    # Detect KVM/QEMU from cpuinfo, report as KVM
+    # Detect paravirt KVM/QEMU from cpuinfo, report as KVM
     psrinfo_path = Ohai.abs_path( "/usr/sbin/psrinfo" )
-    if File.exists?(psrinfo_path)
+    if File.exist?(psrinfo_path)
       so = shell_out("#{psrinfo_path} -pv")
-      if so.stdout =~ /QEMU Virtual CPU/
+      if so.stdout =~ /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/
         virtualization[:system] = "kvm"
         virtualization[:role] = "guest"
       end

--- a/spec/unit/plugins/solaris2/virtualization_spec.rb
+++ b/spec/unit/plugins/solaris2/virtualization_spec.rb
@@ -30,16 +30,16 @@ PSRINFO_PV
     allow(@plugin).to receive(:collect_os).and_return(:solaris2)
 
     # default to all requested Files not existing
-    allow(File).to receive(:exists?).with("/usr/sbin/psrinfo").and_return(false)
-    allow(File).to receive(:exists?).with("/usr/sbin/smbios").and_return(false)
-    allow(File).to receive(:exists?).with("/usr/sbin/zoneadm").and_return(false)
+    allow(File).to receive(:exist?).with("/usr/sbin/psrinfo").and_return(false)
+    allow(File).to receive(:exist?).with("/usr/sbin/smbios").and_return(false)
+    allow(File).to receive(:exist?).with("/usr/sbin/zoneadm").and_return(false)
     allow(@plugin).to receive(:shell_out).with("/usr/sbin/smbios").and_return(mock_shell_out(0, "", ""))
     allow(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, "", ""))
   end
 
   describe "when we are checking for kvm" do
     before(:each) do
-      expect(File).to receive(:exists?).with("/usr/sbin/psrinfo").and_return(true)
+      expect(File).to receive(:exist?).with("/usr/sbin/psrinfo").and_return(true)
     end
 
     it "should run psrinfo -pv" do
@@ -52,18 +52,19 @@ PSRINFO_PV
       @plugin.run
       expect(@plugin[:virtualization][:system]).to eq("kvm")
       expect(@plugin[:virtualization][:role]).to eq("guest")
+      expect(@plugin[:virtualization][:systems][:kvm]).to eq("guest")
     end
 
     it "should not set virtualization if kvm isn't there" do
       expect(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, @psrinfo_pv, ""))
       @plugin.run
-      expect(@plugin[:virtualization]).to eq({})
+      expect(@plugin[:virtualization][:systems]).to eq({})
     end
   end
 
   describe "when we are parsing smbios" do
     before(:each) do
-      expect(File).to receive(:exists?).with("/usr/sbin/smbios").and_return(true)
+      expect(File).to receive(:exist?).with("/usr/sbin/smbios").and_return(true)
     end
 
     it "should run smbios" do
@@ -107,17 +108,18 @@ VMWARE
       @plugin.run
       expect(@plugin[:virtualization][:system]).to eq("vmware")
       expect(@plugin[:virtualization][:role]).to eq("guest")
+      expect(@plugin[:virtualization][:systems][:vmware]).to eq("guest")
     end
 
     it "should run smbios and not set virtualization if nothing is detected" do
       expect(@plugin).to receive(:shell_out).with("/usr/sbin/smbios")
       @plugin.run
-      expect(@plugin[:virtualization]).to eq({})
+      expect(@plugin[:virtualization][:systems]).to eq({})
     end
   end
 
   it "should not set virtualization if no tests match" do
     @plugin.run
-    expect(@plugin[:virtualization]).to eq({})
+    expect(@plugin[:virtualization][:systems]).to eq({})
   end
 end


### PR DESCRIPTION
Detect additional paravirt KVM CPU strings:
- Common KVM processor
- Common 32-bit KVM processor

Use the same node[:virtualization][:systems] multiple virtualization system attribute structure we use on other systems

Use our shared DMI Decode library for detection virtualization systems. This adds detection for Solaris running on the following systems:
- VirtualBox
- OpenStack
- Hyper-V
- KVM
- Xen
- VirtualServer