### PR TITLE
Update bundler in travis to fix broken builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ branches:
     - 7.4-stable
 
 before_install:
+  - gem update --system
+  - gem install bundler
   - bundle --version
   - gem --version
 rvm:


### PR DESCRIPTION
Without this ohai can't handle Chef's need for a newer bundler than
Travis has