### PR TITLE
Handle mis-identifying Rackspace as EC2 better

### DIFF
--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -99,7 +99,7 @@ module Ohai
       end
 
       def http_client
-        Net::HTTP.start(EC2_METADATA_ADDR).tap { |h| h.read_timeout = 600 }
+        Net::HTTP.start(EC2_METADATA_ADDR).tap { |h| h.read_timeout = 30 }
       end
 
       # Get metadata for a given path and API version

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -74,12 +74,18 @@ EOM
     end
   end
 
+  # rackspace systems look like ec2 so instead of timing out dig a bit deeper
+  def looks_like_rackspace?
+    return true if File.exist?("/usr/bin/rackspace-monitoring-agent")
+  end
+
   def looks_like_ec2?
     return true if hint?("ec2")
 
-    # if has ec2 mac try non-blocking connect so we don't "block" if
-    # the Xen environment is *not* EC2
-    return true if (has_ec2metadata_bin? || has_ec2_dmi?) || (has_xen_mac? && can_metadata_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80))
+    # Even if it looks like EC2 try to connect first
+    if has_ec2_dmi? || has_xen_mac? || (has_ec2metadata_bin? && !looks_like_rackspace?)
+      return true if can_metadata_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
+    end
   end
 
   collect_data do

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -28,6 +28,7 @@ describe Ohai::System, "plugin ec2" do
     allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(false)
     allow(File).to receive(:exist?).with('C:\chef\ohai\hints/ec2.json').and_return(false)
     allow(File).to receive(:exist?).with("/usr/bin/ec2metadata").and_return(false)
+    allow(File).to receive(:exist?).with("/usr/bin/rackspace-monitoring-agent").and_return(false)
   end
 
   shared_examples_for "!ec2" do
@@ -310,7 +311,16 @@ describe Ohai::System, "plugin ec2" do
     end
   end
 
-  describe "without hint file, mac address, dmi data, or ec2metadata binary" do
+  describe "with ec2metadata, but with rackspace-monitoring-agent" do
+    it_should_behave_like "!ec2"
+
+    before(:each) do
+      allow(File).to receive(:exist?).with("/usr/bin/ec2metadata").and_return(true)
+      allow(File).to receive(:exist?).with("/usr/bin/rackspace-monitoring-agent").and_return(true)
+    end
+  end
+
+  describe "without any hints that it is an ec2 system" do
     it_should_behave_like "!ec2"
 
     before(:each) do


### PR DESCRIPTION
Be extra sure we're on EC2 in the first place
Timeout querying the metadata quicker. Without this Ohai runs on Rackspace will take 2 minutes