### PR TITLE
Refactor DigitalOcean plugin to use DigitalOcean Metadata API

### DIFF
--- a/lib/ohai/mixin/do_metadata.rb
+++ b/lib/ohai/mixin/do_metadata.rb
@@ -1,0 +1,73 @@
+
+# Author:: Dylan Page (<dpage@digitalocean.com>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'net/http'
+require 'socket'
+
+module Ohai
+  module Mixin
+    module DOMetadata
+
+      DO_METADATA_ADDR = "169.254.269.254" unless defined?(DO_METADATA_ADDR)
+      DO_METADATA_URL = "/metadata/v1.json" unless defined?(DO_METADATA_URL)
+
+      def can_metadata_connect?(addr, port, timeout=2)
+        t = Socket.new(Socket::Constants::AF_INET, Socket::Constants::SOCK_STREAM, 0)
+        saddr = Socket.pack_sockaddr_in(port, addr)
+        connected = false
+
+        begin
+          t.connect_nonblock(saddr)
+        rescue Errno::EINPROGRESS
+          r,w,e = IO::select(nil,[t],nil,timeout)
+          if !w.nil?
+            connected = true
+          else
+            begin
+              t.connect_nonblock(saddr)
+            rescue Errno::EISCONN
+              t.close
+              connected = true
+            rescue SystemCallError
+            end
+          end
+        rescue SystemCallError
+        end
+        Ohai::Log.debug("DOMetadata mixin: can_metadata_connect? == #{connected}")
+        connected
+      end
+
+      def http_client
+        Net::HTTP.start(DO_METADATA_ADDR).tap {|h| h.read_timeout = 6}
+      end
+
+      def fetch_metadata()
+        uri = "#{DO_METADATA_URL}"
+        response = http_client.get(uri)
+        case response.code
+        when "200"
+          response.body
+        when "404"
+          Ohai::Log.debug("Encountered 404 response retreiving Digital Ocean metadata: #{uri} ; continuing.")
+          Hash.new
+        else
+          raise "Encountered error retrieving Digital Ocean metadata (#{uri} returned #{response.code} response)"
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -30,9 +30,10 @@ Ohai.plugin(:DigitalOcean) do
   def has_do_init?
     if File.exist?(DO_CLOUD_INIT_FILE)
       datasource = YAML.load_file(DO_CLOUD_INIT_FILE)
-      puts datasource.inspect
-      Ohai::Log.debug("digital_ocean plugin: has_do_init? == true")
-      true
+      if datasource['datasource_list'].include?("DigitalOcean")
+        Ohai::Log.debug("digital_ocean plugin: has_do_init? == true")
+        true
+      end
     else
       Ohai::Log.debug("digital_ocean plugin: has_do_init? == false")
       false

--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -1,4 +1,5 @@
 #
+# Author:: Dylan Page (<dpage@digitalocean.com>)
 # Author:: Stafford Brunk (<stafford.brunk@gmail.com>)
 # License:: Apache License, Version 2.0
 #
@@ -14,65 +15,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "ohai/util/ip_helper"
+require 'ohai/mixin/do_metadata'
+require 'yaml'
 
 Ohai.plugin(:DigitalOcean) do
-  include Ohai::Util::IpHelper
+  include Ohai::Mixin::DOMetadata
 
-  DIGITALOCEAN_FILE = "/etc/digitalocean" unless defined?(DIGITALOCEAN_FILE)
+  DO_CLOUD_INIT_FILE = "/etc/cloud/cloud.cfg" unless defined?(DO_CLOUD_INIT_FILE)
 
   provides "digital_ocean"
+
   depends "network/interfaces"
 
-  def extract_droplet_ip_addresses
-    addresses = Mash.new({ "v4" => [], "v6" => [] })
-    network[:interfaces].each_value do |iface|
-      iface[:addresses].each do |address, details|
-        next if details[:family] == "lladdr" || loopback?(address)
-
-        ip = IPAddress(address)
-        type = digital_ocean_address_type(ip)
-        address_hash = build_address_hash(ip, details)
-        addresses[type] << address_hash
-      end
+  def has_do_init?
+    if File.exist?(DO_CLOUD_INIT_FILE)
+      datasource = YAML.load_file(DO_CLOUD_INIT_FILE)
+      puts datasource.inspect
+      Ohai::Log.debug("digital_ocean plugin: has_do_init? == true")
+      true
+    else
+      Ohai::Log.debug("digital_ocean plugin: has_do_init? == false")
+      false
     end
-    addresses
-  end
-
-  def build_address_hash(ip, details)
-    address_hash = Mash.new({
-      "ip_address" => ip.address,
-      "type" => private_address?(ip.address) ? "private" : "public",
-    },)
-
-    if ip.ipv4?
-      address_hash["netmask"] = details[:netmask]
-    elsif ip.ipv6?
-      address_hash["cidr"] = ip.prefix
-    end
-    address_hash
-  end
-
-  def digital_ocean_address_type(ip)
-    ip.ipv4? ? "v4" : "v6"
   end
 
   def looks_like_digital_ocean?
-    hint?("digital_ocean") || File.exist?(DIGITALOCEAN_FILE)
+    return true if hint?("digital_ocean")
+
+    if has_do_init?
+     return true if can_metadata_connect?(Ohai::Mixin::DOMetadata::DO_METADATA_ADDR,80)
+    end
   end
 
   collect_data do
     if looks_like_digital_ocean?
-      Ohai::Log.debug("digitalocean plugin: looks_like_digital_ocean? == true")
+      Ohai::Log.debug("looks_like_digital_ocean? == true")
       digital_ocean Mash.new
-      hint = hint?("digital_ocean") || {}
-      hint.each { |k, v| digital_ocean[k] = v unless k == "ip_addresses" }
-
-      # Extract actual ip addresses
-      # The networks sub-hash is structured similarly to how
-      # Digital Ocean's v2 API structures things:
-      # https://developers.digitalocean.com/#droplets
-      digital_ocean[:networks] = extract_droplet_ip_addresses
+      fetch_metadata.each do |k, v|
+        digital_ocean[k] = v
+      end
     else
       Ohai::Log.debug("digitalocean plugin: No hints present for and doesn't look like digitalocean")
       false

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -1,4 +1,5 @@
 #
+# Author:: Dylan Page (<dpage@digitalocean.com>)
 # Author:: Stafford Brunk (<stafford.brunk@gmail.com>)
 # License:: Apache License, Version 2.0
 #
@@ -15,198 +16,136 @@
 # limitations under the License.
 #
 
-require "ipaddress"
-require "spec_helper"
+require 'spec_helper'
 
 describe Ohai::System, "plugin digital_ocean" do
-  let(:hint_path_nix) { "/etc/chef/ohai/hints/digital_ocean.json" }
-  let(:hint_path_win) { 'C:\chef\ohai\hints/digital_ocean.json' }
-  let(:digitalocean_path) { "/etc/digitalocean" }
-  let(:hint) {
-    '{
-      "droplet_id": 12345678,
-      "name": "example.com",
-      "image_id": 3240036,
-      "size_id": 66,
-      "region_id": 4,
-      "ip_addresses": {
-        "public": "1.2.3.4",
-        "private": "5.6.7.8"
-      }
-    }'
-  }
-
-  before do
+  before(:each) do
     @plugin = get_plugin("digital_ocean")
-    @plugin[:network] = {
-      "interfaces" => {
-        "eth0" => {
-          "addresses" => {
-            "00:D3:AD:B3:3F:00" => {
-              "family" => "lladdr"
-            },
-            "1.2.3.4" => {
-              "netmask" => "255.255.255.0"
-            },
-            "2400:6180:0000:00d0:0000:0000:0009:7001" => {},
-          }
-        }
-      }
-    }
-
-    allow(File).to receive(:exist?).with(hint_path_nix).and_return(true)
-    allow(File).to receive(:read).with(hint_path_nix).and_return(hint)
-    allow(File).to receive(:exist?).with(hint_path_win).and_return(true)
-    allow(File).to receive(:read).with(hint_path_win).and_return(hint)
+    allow(File).to receive(:exist?).with('/etc/chef/ohai/hints/digital_ocean.json').and_return(false)
+    allow(File).to receive(:exist?).with('C:\chef\ohai\hints/digital_ocean.json').and_return(false)
+    allow(File).to receive(:exist?).with('/etc/cloud/cloud.cfg').and_return(false)
   end
 
   shared_examples_for "!digital_ocean" do
-    before(:each) do
-      @plugin.run
-    end
-
-    it "does not create the digital_ocean mash" do
+    it "should NOT attempt to fetch the digital_ocean metadata" do
+      expect(@plugin).not_to receive(:http_client)
       expect(@plugin[:digital_ocean]).to be_nil
-    end
-  end
-
-  shared_examples_for "digital_ocean_networking" do
-    it "creates the networks attribute" do
-      expect(@plugin[:digital_ocean][:networks]).not_to be_nil
-    end
-
-    it "pulls ip addresses from the network interfaces" do
-      expect(@plugin[:digital_ocean][:networks][:v4]).to eq([{ "ip_address" => "1.2.3.4",
-                                                               "type" => "public",
-                                                               "netmask" => "255.255.255.0" }])
-      expect(@plugin[:digital_ocean][:networks][:v6]).to eq([{ "ip_address" => "2400:6180:0000:00d0:0000:0000:0009:7001",
-                                                               "type" => "public",
-                                                               "cidr" => 128 }])
+      @plugin.run
     end
   end
 
   shared_examples_for "digital_ocean" do
     before(:each) do
+      @http_client = double("Net::HTTP client")
+      allow(@plugin).to receive(:http_client).and_return(@http_client)
+      allow(IO).to receive(:select).and_return([[],[1],[]])
+      t = double("connection")
+      allow(t).to receive(:connect_nonblock).and_raise(Errno::EINPROGRESS)
+      allow(Socket).to receive(:new).and_return(t)
+      allow(Socket).to receive(:pack_sockaddr_in).and_return(nil)
+    end
+
+    let(:body) do
+     {"droplet_id" => 2756924,
+      "hostname" => "sample-droplet",
+      "vendor_data" => "#cloud-config\ndisable_root: false\n",
+      "public_keys" => ["ssh-rsa pubey sammy@digitalocean.com"],
+      "region" => "nyc3",
+      "interfaces" => {
+        "private" => [
+          {
+            "ipv4" => {
+              "ip_address" => "10.132.255.113",
+              "netmask" => "255.255.0.0",
+              "gateway" => "10.132.0.1"
+            },
+            "mac" => "04:01:2a:0f:2a:02",
+            "type" => "private"
+          }
+        ],
+        "public" => [
+          {
+            "ipv4" => {
+              "ip_address" => "104.131.20.105",
+              "netmask" => "255.255.192.0",
+              "gateway" => "104.131.0.1"
+            },
+            "ipv6":{
+              "ip_address" => "2604:A880:0800:0010:0000:0000:017D:2001",
+              "cidr" => 64,
+              "gateway" => "2604:A880:0800:0010:0000:0000:0000:0001"
+            },
+            "mac" => "04:01:2a:0f:2a:01",
+            "type" => "public"}
+        ]
+      },
+      "floating_ip" => {
+        "ipv4" => {
+          "active" => false
+        }
+      },
+      "dns" => {
+        "nameservers" => [
+          "2001:4860:4860::8844",
+          "2001:4860:4860::8888",
+          "8.8.8.8"
+        ]
+      }
+     }
+    end
+
+    it "should fetch and properly parse json metadata" do
+      expect(@http_client).to receive(:get).
+        with("/metadata/v1.json").
+        and_return(double("Net::HTTP Response", :body => body, :code=>"200"))
+
       @plugin.run
-    end
 
-    it "creates a digital_ocean mash" do
       expect(@plugin[:digital_ocean]).not_to be_nil
+      expect(@plugin[:digital_ocean]['droplet_id']).to eq(2756924)
+      expect(@plugin[:digital_ocean]['hostname']).to eq("sample-droplet")
     end
 
-    it "has all hint attributes" do
-      expect(@plugin[:digital_ocean][:droplet_id]).not_to be_nil
-      expect(@plugin[:digital_ocean][:name]).not_to be_nil
-      expect(@plugin[:digital_ocean][:image_id]).not_to be_nil
-      expect(@plugin[:digital_ocean][:size_id]).not_to be_nil
-      expect(@plugin[:digital_ocean][:region_id]).not_to be_nil
-    end
+    it "should complete the run despite unavailable metadata" do
+      expect(@http_client).to receive(:get).
+        with("/metadata/v1.json").
+        and_return(double("Net::HTTP Response", :body => "", :code => "404"))
 
-    it "skips the ip_addresses hint attribute" do
-      expect(@plugin[:digital_ocean][:ip_addresses]).to be_nil
-    end
+      @plugin.run
 
-    it "has correct values for all hint attributes" do
-      expect(@plugin[:digital_ocean][:droplet_id]).to eq(12345678)
-      expect(@plugin[:digital_ocean][:name]).to eq("example.com")
-      expect(@plugin[:digital_ocean][:image_id]).to eq(3240036)
-      expect(@plugin[:digital_ocean][:size_id]).to eq(66)
-      expect(@plugin[:digital_ocean][:region_id]).to eq(4)
-    end
 
-    include_examples "digital_ocean_networking"
+      expect(@plugin[:digitalocean]).to be_nil
+    end
+  end
+
+  describe "with metadata address connected" do
+    it_should_behave_like "digital_ocean"
+  end
+
+  describe "without metadata address connected" do
+    it_should_behave_like "!digital_ocean"
   end
 
   describe "with digital_ocean hint file" do
-    before do
-      allow(File).to receive(:exist?).with(hint_path_nix).and_return(true)
-      allow(File).to receive(:exist?).with(hint_path_win).and_return(true)
-    end
+    it_should_behave_like "digital_ocean"
 
-    context "without private networking enabled" do
-      it_should_behave_like "digital_ocean"
-    end
-
-    context "with private networking enabled" do
-      before do
-        @plugin[:network][:interfaces][:eth1] = {
-          "addresses" => {
-            "10.128.142.89" => {
-              "netmask" => "255.255.255.0"
-            },
-            "fdf8:f53b:82e4:0000:0000:0000:0000:0053" => {},
-          }
-        }
-
-        @plugin.run
-      end
-
-      it "should extract the private networking ips" do
-        expect(@plugin[:digital_ocean][:networks][:v4]).to eq([{ "ip_address" => "1.2.3.4",
-                                                                 "type" => "public",
-                                                                 "netmask" => "255.255.255.0" },
-                                                            { "ip_address" => "10.128.142.89",
-                                                              "type" => "private",
-                                                              "netmask" => "255.255.255.0" }])
-        expect(@plugin[:digital_ocean][:networks][:v6]).to eq([{ "ip_address" => "2400:6180:0000:00d0:0000:0000:0009:7001",
-                                                                 "type" => "public",
-                                                                 "cidr" => 128 },
-                                                           { "ip_address" => "fdf8:f53b:82e4:0000:0000:0000:0000:0053",
-                                                             "type" => "private",
-                                                             "cidr" => 128 }])
+    before(:each) do
+      if windows?
+        expect(File).to receive(:exist?).with('C:\chef\ohai\hints/digital_ocean.json').and_return(true)
+        allow(File).to receive(:read).with('C:\chef\ohai\hints/digital_ocean.json').and_return("")
+      else
+        expect(File).to receive(:exist?).with("/etc/chef/ohai/hints/digital_ocean.json").and_return(true)
+        allow(File).to receive(:read).with("/etc/chef/ohai/hints/digital_ocean.json").and_return("")
       end
     end
   end
 
-  describe "without digital_ocean hint file" do
-    before do
-      allow(File).to receive(:exist?).with(hint_path_nix).and_return(false)
-      allow(File).to receive(:exist?).with(hint_path_win).and_return(false)
-    end
+  describe "with digital_ocean cloud-config file" do
+    it_should_behave_like "digital_ocean"
 
-    describe "with the /etc/digitalocean file" do
-      before do
-        allow(File).to receive(:exist?).with(digitalocean_path).and_return(true)
-        @plugin.run
-      end
-      it_should_behave_like "digital_ocean_networking"
-    end
-
-    describe "without the /etc/digitalocean file" do
-      before do
-        allow(File).to receive(:exist?).with(digitalocean_path).and_return(false)
-      end
-      it_should_behave_like "!digital_ocean"
-    end
-  end
-
-  context "with ec2 hint file" do
-    let(:ec2_hint_path_nix) { "/etc/chef/ohai/hints/ec2.json" }
-    let(:ec2_hint_path_win) { 'C:\chef\ohai\hints/ec2.json' }
-
-    before do
-      allow(File).to receive(:exist?).with(hint_path_nix).and_return(false)
-      allow(File).to receive(:exist?).with(hint_path_win).and_return(false)
-
-      allow(File).to receive(:exist?).with(ec2_hint_path_nix).and_return(true)
-      allow(File).to receive(:read).with(ec2_hint_path_nix).and_return("")
-      allow(File).to receive(:exist?).with(ec2_hint_path_win).and_return(true)
-      allow(File).to receive(:read).with(ec2_hint_path_win).and_return("")
-    end
-
-    describe "with the /etc/digitalocean file" do
-      before do
-        allow(File).to receive(:exist?).with(digitalocean_path).and_return(true)
-        @plugin.run
-      end
-      it_should_behave_like "digital_ocean_networking"
-    end
-
-    describe "without the /etc/digitalocean file" do
-      before do
-        allow(File).to receive(:exist?).with(digitalocean_path).and_return(false)
-      end
-      it_should_behave_like "!digital_ocean"
+    before(:each) do
+        expect(File).to receive(:exist?).with("/etc/cloud/cloud.cfg").and_return(true)
+        allow(File).to receive(:read).with("/etc/cloud/cloud.cfg").and_return("")
     end
   end
 end

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -143,9 +143,20 @@ describe Ohai::System, "plugin digital_ocean" do
   describe "with digital_ocean cloud-config file" do
     it_should_behave_like "digital_ocean"
 
+    yaml_example = <<-EOF
+    datasource_list: [ DigitalOcean, None ]
+    datasource:
+    DigitalOcean:
+     retries: 5
+     timeout: 10
+
+    vendor_data:
+     enabled: True
+    EOF
+
     before(:each) do
         expect(File).to receive(:exist?).with("/etc/cloud/cloud.cfg").and_return(true)
-        allow(File).to receive(:read).with("/etc/cloud/cloud.cfg").and_return("")
+        allow(File).to receive(:read).with("/etc/cloud/cloud.cfg").and_return(yaml_example)
     end
   end
 end


### PR DESCRIPTION
Here's my first iteration that I've done. I've ripped out the old network/interface code in place of the metadata information. About half of the tests are passing right now, still working on that. Please let me know if there is anything I am missing or something that stands out to anyone that should be done better/differently. :smile: 

This is a follow-up to #649 
