### PR TITLE
Rake is a dev dep

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   # Chef 13 starts, otherwise builds will break.
   s.add_dependency "chef-config", ">= 12.5.0.alpha.1", "< 13"
 
-  s.add_dependency "rake", "~> 10.1"
+  s.add_dependency "rake", ">= 10.1.0", "< 12.0.0"
   s.add_development_dependency "rspec-core", "~> 3.0"
   s.add_development_dependency "rspec-expectations", "~> 3.0"
   s.add_development_dependency "rspec-mocks", "~> 3.0"

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   # Chef 13 starts, otherwise builds will break.
   s.add_dependency "chef-config", ">= 12.5.0.alpha.1", "< 13"
 
-  s.add_dependency "rake", ">= 10.1.0", "< 12.0.0"
+  s.add_development_dependency "rake", ">= 10.1.0", "< 12.0.0"
   s.add_development_dependency "rspec-core", "~> 3.0"
   s.add_development_dependency "rspec-expectations", "~> 3.0"
   s.add_development_dependency "rspec-mocks", "~> 3.0"


### PR DESCRIPTION
# 1. Allow rake 11.x.

Something in our Rakefile is using a deprecated API, but it doesn't seem to be breaking anything:

```
bundle exec rake -T
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
rake build               # Build ohai-8.12.0.gem into the pkg directory
rake changelog           # Generate a Change log from GitHub
rake clean               # Remove any temporary products
rake clobber             # Remove any generated files
rake install             # Build and install ohai-8.12.0.gem into system gems
rake install:local       # Build and install ohai-8.12.0.gem into system gems without network access
rake release[remote]     # Create tag v8.12.0 and build and push ohai-8.12.0.gem to Rubygems
rake spec                # Run RSpec code examples
rake style               # Run RuboCop
rake style:auto_correct  # Auto-correct RuboCop offenses
```

# 2. Make rake a dev dependency. 

Running `git grep -i rake -- lib` gives zero results, so we probably just overlooked making rake a dev dep in the past.