### PR TITLE
Don't pull chef from master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  gem "chef", github: "chef/chef", branch: "master"
-
   gem "sigar", :platform => "ruby"
 
   gem "chefstyle", "= 0.3.0"


### PR DESCRIPTION
When ohai is `bundle installed` without the development group, bundler
doesn't install the development gems but it still includes them in the
gemfile solution. When chef-client is on an unreleased version, this
results in the unreleased version of chef-client ending up in the
Gemfile.lock. Because chef-client has an exact equality pin on
chef-config, which ohai also uses, this results in ohai's Gemfile.lock
pinning ohai to the unreleased version of chef-config. When the ohai
executable is created by appbundler, this results in a broken executable
that tries to load a version of chef-config that doesn't exist.