### PR TITLE
Avoid false detection of systems with the ec2 binary as ec2

### DIFF
--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -17,6 +17,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# How we detect EC2 from easiest to hardest & least reliable
+# 1. Ohai ec2 hint exists. This always works
+# 2. DMI data mentions amazon. This catches HVM instances in a VPC
+# 3. Has a xen MAC + can connect to metadata. This catches paravirt instances not in a VPC
+# 4. Has ec2metadata binary + can connect to metadata. This catches paravirt instances in a VPC
+
 require "ohai/mixin/ec2_metadata"
 require "base64"
 
@@ -28,18 +34,26 @@ Ohai.plugin(:EC2) do
   depends "network/interfaces"
   depends "dmi"
 
-  # look for ec2metadata which is included on paravirt / hvm AMIs
+  # look for ec2metadata and see if we get data back
+  # this gets us detection of paravirt instances that are within a VPC
   def has_ec2metadata_bin?
     if File.exist?("/usr/bin/ec2metadata")
-      Ohai::Log.debug("ec2 plugin: has_ec2metadata_bin? == true")
-      true
+      # make sure actual data is returned when we run it. Otherwise we might be on GCE or Rackspace
+      if shell_out("/usr/bin/ec2metadata").stdout =~ /id: ami-/
+        Ohai::Log.debug("ec2 plugin: has_ec2metadata_bin? == true")
+        return true
+      else
+        Ohai::Log.debug("ec2 plugin: has_ec2metadata_bin? found ec2metadata but no metadata returned. Not on EC2")
+        return false
+      end
     else
       Ohai::Log.debug("ec2 plugin: has_ec2metadata_bin? == false")
-      false
+      return false
     end
   end
 
-  # look for arp address that non-VPC hosts will have
+  # look for xen arp address
+  # this gets us detection of paravirt instances that are NOT within a VPC
   def has_xen_mac?
     network[:interfaces].values.each do |iface|
       unless iface[:arp].nil?
@@ -60,7 +74,7 @@ EOM
   end
 
   # look for amazon string in dmi bios data
-  # this only works on hvm instances as paravirt instances have no dmi data
+  # this gets us detection of HVM instances that are within a VPC
   def has_ec2_dmi?
     begin
       # detect a version of '4.2.amazon'
@@ -74,16 +88,11 @@ EOM
     end
   end
 
-  # rackspace systems look like ec2 so instead of timing out dig a bit deeper
-  def looks_like_rackspace?
-    return true if File.exist?("/usr/bin/rackspace-monitoring-agent")
-  end
-
   def looks_like_ec2?
     return true if hint?("ec2")
 
     # Even if it looks like EC2 try to connect first
-    if has_ec2_dmi? || has_xen_mac? || (has_ec2metadata_bin? && !looks_like_rackspace?)
+    if has_ec2_dmi? || has_xen_mac? || has_ec2metadata_bin?
       return true if can_metadata_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
     end
   end

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -28,7 +28,6 @@ describe Ohai::System, "plugin ec2" do
     allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(false)
     allow(File).to receive(:exist?).with('C:\chef\ohai\hints/ec2.json').and_return(false)
     allow(File).to receive(:exist?).with("/usr/bin/ec2metadata").and_return(false)
-    allow(File).to receive(:exist?).with("/usr/bin/rackspace-monitoring-agent").and_return(false)
   end
 
   shared_examples_for "!ec2" do
@@ -270,11 +269,72 @@ describe Ohai::System, "plugin ec2" do
     end
   end
 
-  describe "with ec2metadata binary" do
+  describe "with ec2metadata binary and on ec2" do
     it_should_behave_like "ec2"
+
+    ec2metadata_output = <<END
+ami-id: ami-5189a661
+ami-launch-index: 0
+ami-manifest-path: (unknown)
+ancestor-ami-ids: unavailable
+availability-zone: us-west-2a
+block-device-mapping: ami
+root
+instance-action: none
+instance-id: i-c6d78f04
+instance-type: t2.micro
+local-hostname: ip-172-31-42-15.us-west-2.compute.internal
+local-ipv4: 172.31.42.15
+kernel-id: unavailable
+mac: unavailable
+profile: default-hvm
+product-codes: unavailable
+public-hostname: ec2-52-88-253-145.us-west-2.compute.amazonaws.com
+public-ipv4: 52.88.253.145
+public-keys: ['ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCmvsxBSgSxK1pOCMEIx4LyVATfYA+ehoOpADJa+ZYx7Tq6Btp3yBnWZWjkTp9b0BFF7LxfJJsw62BfYPy2dJ/xy3HF0J7qY+W3LPcN9C9jyT9plbfsn1DdxgVZreekdPhjS7viyF0+g+PUdTocRPrG4H4dpe464wWTnn2OJQg4I/hiDYBouDUUVzYYpTxIia6RMDhjvC/9yeYTOVc4m5jTQLUpidUNkZ2azTKkYiL5hPMZj6QdFqeKctFhvYPhvTd9+La3gjdFfFpAUpNjBf5ry2MUkw8/Yp0n1m6/IAhRaQ3rracM7qpkJ35n6cYadSZ09N7GCbt1fE72VFYJXEMef tsmith']
+ramdisk-id: unavailable
+reserveration-id: unavailable
+security-groups: securesystem
+user-data: unavailable
+END
 
     before(:each) do
       allow(File).to receive(:exist?).with("/usr/bin/ec2metadata").and_return(true)
+      allow(@plugin).to receive(:shell_out).with(anything()).and_return(mock_shell_out(0, ec2metadata_output, ""))
+    end
+  end
+
+  describe "with ec2metadata binary and NOT on ec2" do
+    it_should_behave_like "!ec2"
+
+    ec2metadata_output = <<END
+ami-id: unavailable
+ami-launch-index: unavailable
+ami-manifest-path: unavailable
+ancestor-ami-ids: unavailable
+availability-zone: unavailable
+block-device-mapping: unavailable
+instance-action: unavailable
+instance-id: unavailable
+instance-type: unavailable
+local-hostname: unavailable
+local-ipv4: unavailable
+kernel-id: unavailable
+mac: unavailable
+profile: unavailable
+product-codes: unavailable
+public-hostname: unavailable
+public-ipv4: unavailable
+public-keys: unavailable
+ramdisk-id: unavailable
+reserveration-id: unavailable
+security-groups: unavailable
+user-data: unavailable
+END
+
+    before(:each) do
+      allow(File).to receive(:exist?).with("/usr/bin/ec2metadata").and_return(true)
+      allow(@plugin).to receive(:shell_out).with(anything()).and_return(mock_shell_out(0, ec2metadata_output, ""))
     end
   end
 
@@ -308,15 +368,6 @@ describe Ohai::System, "plugin ec2" do
       allow(File).to receive(:read).with("/etc/chef/ohai/hints/rackspace.json").and_return("")
       allow(File).to receive(:exist?).with('C:\chef\ohai\hints/rackspace.json').and_return(true)
       allow(File).to receive(:read).with('C:\chef\ohai\hints/rackspace.json').and_return("")
-    end
-  end
-
-  describe "with ec2metadata, but with rackspace-monitoring-agent" do
-    it_should_behave_like "!ec2"
-
-    before(:each) do
-      allow(File).to receive(:exist?).with("/usr/bin/ec2metadata").and_return(true)
-      allow(File).to receive(:exist?).with("/usr/bin/rackspace-monitoring-agent").and_return(true)
     end
   end
 


### PR DESCRIPTION
Ensure the ec2metadata bin actually returns data. Otherwise we're probably not on ec2