### PR TITLE
Detect openSUSE Leap as platform opensuseleap

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -125,7 +125,12 @@ Ohai.plugin(:Platform) do
       suse_version = suse_release[/VERSION = ([\d\.]{2,})/, 1] if suse_version == ""
       platform_version suse_version
       if suse_release =~ /^openSUSE/
-        platform "opensuse"
+        # opensuse releases >= 42 are openSUSE Leap
+        if platform_version.to_i < 42
+          platform "opensuse"
+        else
+          platform "opensuseleap"
+        end
       else
         platform "suse"
       end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -665,6 +665,13 @@ CISCO_RELEASE
         expect(@plugin[:platform]).to eq("opensuse")
         expect(@plugin[:platform_family]).to eq("suse")
       end
+
+      it "should read the platform as opensuseleap on openSUSE Leap" do
+        expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 42.1 (x86_64)\nVERSION = 42.1\nCODENAME = Malachite\n")
+        @plugin.run
+        expect(@plugin[:platform]).to eq("opensuseleap")
+        expect(@plugin[:platform_family]).to eq("suse")
+      end
     end
   end
 


### PR DESCRIPTION
It's different then opensuse or suse.  Platform family is still suse.

This is a modified version of #745 based on the discussion in the PR