### PR TITLE
Add bhyve / xhyve support

### DIFF
--- a/lib/ohai/mixin/dmi_decode.rb
+++ b/lib/ohai/mixin/dmi_decode.rb
@@ -40,6 +40,8 @@ module ::Ohai::Mixin::DmiDecode
         return "openstack"
       when /Manufacturer: QEMU|Product Name: (KVM|RHEV)/
         return "kvm"
+      when /Product.*: BHYVE/
+        return "bhyve"
       end
     end
     return nil


### PR DESCRIPTION
Unfortunately xhyve reports as bhyve right now and I can't find a way to detect xhyve over bhyve, but I mostly care about it being detected as a guest.
```
# ohai virtualization
{
  "systems": {
    "bhyve": "guest"
  },
  "system": "bhyve",
  "role": "guest"
}
```