### PR TITLE
Improve Linux EC2 detection, fix false detection, and add Windows detection

### DIFF
--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -43,6 +43,9 @@ Ohai.plugin(:EC2) do
       if dmi[:bios][:all_records][0][:Version] =~ /amazon/
         Ohai::Log.debug("ec2 plugin: has_ec2_dmi? == true")
         true
+      else
+        Ohai::Log.debug("ec2 plugin: has_ec2_dmi? == false")
+        false
       end
     rescue NoMethodError
       Ohai::Log.debug("ec2 plugin: has_ec2_dmi? == false")
@@ -72,6 +75,9 @@ Ohai.plugin(:EC2) do
       if kernel[:os_info][:organization] =~ /Amazon/
         Ohai::Log.debug("ec2 plugin: has_amazon_org? == true")
         true
+      else
+        Ohai::Log.debug("ec2 plugin: has_amazon_org? == false")
+        false
       end
     rescue NoMethodError
       Ohai::Log.debug("ec2 plugin: has_amazon_org? == false")

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -42,15 +42,13 @@ Ohai.plugin(:EC2) do
       # detect a version of '4.2.amazon'
       if dmi[:bios][:all_records][0][:Version] =~ /amazon/
         Ohai::Log.debug("ec2 plugin: has_ec2_dmi? == true")
-        true
-      else
-        Ohai::Log.debug("ec2 plugin: has_ec2_dmi? == false")
-        false
+        return true
       end
     rescue NoMethodError
-      Ohai::Log.debug("ec2 plugin: has_ec2_dmi? == false")
-      false
+      # dmi[:bios][:all_records][0][:Version] may not exist
     end
+    Ohai::Log.debug("ec2 plugin: has_ec2_dmi? == false")
+    return false
   end
 
   # looks for a xen UUID that starts with ec2
@@ -61,10 +59,9 @@ Ohai.plugin(:EC2) do
         Ohai::Log.debug("ec2 plugin: has_ec2_xen_uuid? == true")
         return true
       end
-    else
-      Ohai::Log.debug("ec2 plugin: has_ec2_xen_uuid? == false")
-      return false
     end
+    Ohai::Log.debug("ec2 plugin: has_ec2_xen_uuid? == false")
+    return false
   end
 
   # looks for the Amazon.com Organization in Windows Kernel data
@@ -74,15 +71,13 @@ Ohai.plugin(:EC2) do
       # detect an Organization of 'Amazon.com'
       if kernel[:os_info][:organization] =~ /Amazon/
         Ohai::Log.debug("ec2 plugin: has_amazon_org? == true")
-        true
-      else
-        Ohai::Log.debug("ec2 plugin: has_amazon_org? == false")
-        false
+        return true
       end
     rescue NoMethodError
-      Ohai::Log.debug("ec2 plugin: has_amazon_org? == false")
-      false
+      # kernel[:os_info][:organization] may not exist
     end
+    Ohai::Log.debug("ec2 plugin: has_amazon_org? == false")
+    return false
   end
 
   def looks_like_ec2?

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -22,7 +22,6 @@
 # 1. Ohai ec2 hint exists. This always works
 # 2. DMI data mentions amazon. This catches HVM instances in a VPC
 # 3. Kernel data mentioned Amazon. This catches Windows instances
-# 4. Has a xen MAC + can connect to metadata. This catches paravirt instances not in a VPC
 
 require "ohai/mixin/ec2_metadata"
 require "base64"
@@ -32,30 +31,8 @@ Ohai.plugin(:EC2) do
 
   provides "ec2"
 
-  depends "network/interfaces"
   depends "dmi"
   depends "kernel"
-
-  # look for xen arp address
-  # this gets us detection of paravirt instances that are NOT within a VPC
-  def has_xen_mac?
-    network[:interfaces].values.each do |iface|
-      unless iface[:arp].nil?
-        if iface[:arp].value?("fe:ff:ff:ff:ff:ff")
-          # using MAC addresses from ARP is unreliable because they could time-out from the table
-          # fe:ff:ff:ff:ff:ff is actually a sign of Xen, not specifically EC2
-          deprecation_message <<-EOM
-ec2 plugin: Detected EC2 by the presence of fe:ff:ff:ff:ff:ff in the ARP table. This method is unreliable and will be removed in a future version of ohai. Bootstrap using knife-ec2 or create "/etc/chef/ohai/hints/ec2.json" instead.
-EOM
-          Ohai::Log.warn(deprecation_message)
-          Ohai::Log.debug("ec2 plugin: has_xen_mac? == true")
-          return true
-        end
-      end
-    end
-    Ohai::Log.debug("ec2 plugin: has_xen_mac? == false")
-    false
-  end
 
   # look for amazon string in dmi bios data
   # this gets us detection of HVM instances that are within a VPC
@@ -91,7 +68,7 @@ EOM
     return true if hint?("ec2")
 
     # Even if it looks like EC2 try to connect first
-    if has_ec2_dmi? || has_amazon_org? || has_xen_mac?
+    if has_ec2_dmi? || has_amazon_org?
       return true if can_metadata_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
     end
   end

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -2,6 +2,7 @@
 # Author:: Tim Dysinger (<tim@dysinger.net>)
 # Author:: Benjamin Black (<bb@chef.io>)
 # Author:: Christopher Brown (<cb@chef.io>)
+# Author:: Tim Smith (<tsmith@chef.io>)
 # Copyright:: Copyright (c) 2009-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
@@ -20,7 +21,8 @@
 # How we detect EC2 from easiest to hardest & least reliable
 # 1. Ohai ec2 hint exists. This always works
 # 2. DMI data mentions amazon. This catches HVM instances in a VPC
-# 3. Has a xen MAC + can connect to metadata. This catches paravirt instances not in a VPC
+# 3. Kernel data mentioned Amazon. This catches Windows instances
+# 4. Has a xen MAC + can connect to metadata. This catches paravirt instances not in a VPC
 
 require "ohai/mixin/ec2_metadata"
 require "base64"
@@ -32,6 +34,7 @@ Ohai.plugin(:EC2) do
 
   depends "network/interfaces"
   depends "dmi"
+  depends "kernel"
 
   # look for xen arp address
   # this gets us detection of paravirt instances that are NOT within a VPC
@@ -69,11 +72,26 @@ EOM
     end
   end
 
+  # looks for the Amazon.com Organization in Windows Kernel data
+  # this gets us detection of Windows systems
+  def has_amazon_org?
+    begin
+      # detect an Organization of 'Amazon.com'
+      if kernel[:os_info][:organization] =~ /Amazon/
+        Ohai::Log.debug("ec2 plugin: has_amazon_org? == true")
+        true
+      end
+    rescue NoMethodError
+      Ohai::Log.debug("ec2 plugin: has_amazon_org? == false")
+      false
+    end
+  end
+
   def looks_like_ec2?
     return true if hint?("ec2")
 
     # Even if it looks like EC2 try to connect first
-    if has_ec2_dmi? || has_xen_mac?
+    if has_ec2_dmi? || has_amazon_org? || has_xen_mac?
       return true if can_metadata_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
     end
   end

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -53,8 +53,8 @@ Ohai.plugin(:EC2) do
   # looks for a xen UUID that starts with ec2
   # this gets us detection of Linux HVM and Paravirt hosts
   def has_ec2_xen_uuid?
-    if ::File.exist?('/sys/hypervisor/uuid')
-      if ::File.read('/sys/hypervisor/uuid') =~ /^ec2/
+    if ::File.exist?("/sys/hypervisor/uuid")
+      if ::File.read("/sys/hypervisor/uuid") =~ /^ec2/
         Ohai::Log.debug("ec2 plugin: has_ec2_xen_uuid? == true")
         return true
       end

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -21,8 +21,8 @@
 # How we detect EC2 from easiest to hardest & least reliable
 # 1. Ohai ec2 hint exists. This always works
 # 2. Xen hypervisor UUID starts with 'ec2'. This catches Linux HVM & paravirt instances
-# 2. DMI data mentions amazon. This catches HVM instances in a VPC
-# 3. Kernel data mentioned Amazon. This catches Windows HVM & paravirt instances
+# 3. DMI data mentions amazon. This catches HVM instances in a VPC
+# 4. Kernel data mentioned Amazon. This catches Windows HVM & paravirt instances
 
 require "ohai/mixin/ec2_metadata"
 require "base64"

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -276,6 +276,14 @@ describe Ohai::System, "plugin ec2" do
     end
   end
 
+  describe "with amazon kernel data" do
+    it_should_behave_like "ec2"
+
+    before(:each) do
+      @plugin[:kernel] = { :os_info => { :organization => "Amazon.com" } }
+    end
+  end
+
   describe "with ec2 hint file" do
     it_should_behave_like "ec2"
 

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -259,7 +259,7 @@ describe Ohai::System, "plugin ec2" do
   end # shared examples for ec2
 
   describe "with ec2 dmi data" do
-    it_should_behave_like "ec2"
+    it_behaves_like "ec2"
 
     before(:each) do
       plugin[:dmi] = { :bios => { :all_records => [ { :Version => "4.2.amazon" } ] } }
@@ -267,7 +267,7 @@ describe Ohai::System, "plugin ec2" do
   end
 
   describe "with amazon kernel data" do
-    it_should_behave_like "ec2"
+    it_behaves_like "ec2"
 
     before(:each) do
       plugin[:kernel] = { :os_info => { :organization => "Amazon.com" } }
@@ -275,7 +275,7 @@ describe Ohai::System, "plugin ec2" do
   end
 
   describe "with EC2 Xen UUID" do
-    it_should_behave_like "ec2"
+    it_behaves_like "ec2"
 
     before(:each) do
       allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(true)
@@ -284,7 +284,7 @@ describe Ohai::System, "plugin ec2" do
   end
 
   describe "with non-EC2 Xen UUID" do
-    it_should_behave_like "!ec2"
+    it_behaves_like "!ec2"
 
     before(:each) do
       allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(true)
@@ -293,7 +293,7 @@ describe Ohai::System, "plugin ec2" do
   end
 
   describe "with ec2 hint file" do
-    it_should_behave_like "ec2"
+    it_behaves_like "ec2"
 
     before(:each) do
       if windows?
@@ -307,7 +307,7 @@ describe Ohai::System, "plugin ec2" do
   end
 
   describe "with rackspace hint file" do
-    it_should_behave_like "!ec2"
+    it_behaves_like "!ec2"
 
     before(:each) do
       allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/rackspace.json").and_return(true)
@@ -318,7 +318,7 @@ describe Ohai::System, "plugin ec2" do
   end
 
   describe "without any hints that it is an ec2 system" do
-    it_should_behave_like "!ec2"
+    it_behaves_like "!ec2"
 
     before(:each) do
       allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(false)

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -24,7 +24,6 @@ require "base64"
 describe Ohai::System, "plugin ec2" do
   before(:each) do
     @plugin = get_plugin("ec2")
-    @plugin[:network] = { :interfaces => { :eth0 => {} } }
     allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(false)
     allow(File).to receive(:exist?).with('C:\chef\ohai\hints/ec2.json').and_return(false)
   end
@@ -254,20 +253,6 @@ describe Ohai::System, "plugin ec2" do
     end
   end # shared examples for ec2
 
-  describe "without dmi data, kernel organization, with xen mac, and metadata address connected" do
-    before(:each) do
-      allow(IO).to receive(:select).and_return([[], [1], []])
-      @plugin[:network][:interfaces][:eth0][:arp] = { "169.254.1.0" => "fe:ff:ff:ff:ff:ff" }
-    end
-
-    it_should_behave_like "ec2"
-
-    it "warns that the arp table method is deprecated" do
-      expect(Ohai::Log).to receive(:warn).with(/will be removed/)
-      @plugin.has_xen_mac?
-    end
-  end
-
   describe "with ec2 dmi data" do
     it_should_behave_like "ec2"
 
@@ -316,7 +301,6 @@ describe Ohai::System, "plugin ec2" do
       allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(false)
       allow(File).to receive(:exist?).with('C:\chef\ohai\hints/ec2.json').and_return(false)
       @plugin[:dmi] = nil
-      @plugin[:network][:interfaces][:eth0][:arp] = { "169.254.1.0" => "00:50:56:c0:00:08" }
     end
   end
 

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -22,24 +22,29 @@ require "open-uri"
 require "base64"
 
 describe Ohai::System, "plugin ec2" do
+
   before(:each) do
-    @plugin = get_plugin("ec2")
     allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(false)
     allow(File).to receive(:exist?).with('C:\chef\ohai\hints/ec2.json').and_return(false)
+    allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(false)
   end
 
   shared_examples_for "!ec2" do
-    it "should NOT attempt to fetch the ec2 metadata or set ec2 attribute" do
-      expect(@plugin).not_to receive(:http_client)
-      expect(@plugin[:ec2]).to be_nil
-      @plugin.run
+    let(:plugin) { get_plugin("ec2") }
+
+    it "DOESN'T attempt to fetch the ec2 metadata or set ec2 attribute" do
+      expect(plugin).not_to receive(:http_client)
+      expect(plugin[:ec2]).to be_nil
+      plugin.run
     end
   end
 
   shared_examples_for "ec2" do
+    let(:plugin) { get_plugin("ec2") }
+
     before(:each) do
       @http_client = double("Net::HTTP client")
-      allow(@plugin).to receive(:http_client).and_return(@http_client)
+      allow(plugin).to receive(:http_client).and_return(@http_client)
       allow(IO).to receive(:select).and_return([[], [1], []])
       t = double("connection")
       allow(t).to receive(:connect_nonblock).and_raise(Errno::EINPROGRESS)
@@ -68,12 +73,12 @@ describe Ohai::System, "plugin ec2" do
           with("/2012-01-12/user-data/").
           and_return(double("Net::HTTP Response", :body => "By the pricking of my thumb...", :code => "200"))
 
-        @plugin.run
+        plugin.run
 
-        expect(@plugin[:ec2]).not_to be_nil
-        expect(@plugin[:ec2]["instance_type"]).to eq("c1.medium")
-        expect(@plugin[:ec2]["ami_id"]).to eq("ami-5d2dc934")
-        expect(@plugin[:ec2]["security_groups"]).to eql %w{group1 group2}
+        expect(plugin[:ec2]).not_to be_nil
+        expect(plugin[:ec2]["instance_type"]).to eq("c1.medium")
+        expect(plugin[:ec2]["ami_id"]).to eq("ami-5d2dc934")
+        expect(plugin[:ec2]["security_groups"]).to eql %w{group1 group2}
       end
 
       it "fetches binary userdata opaquely" do
@@ -86,17 +91,17 @@ describe Ohai::System, "plugin ec2" do
           with("/2012-01-12/user-data/").
           and_return(double("Net::HTTP Response", :body => "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", :code => "200"))
 
-        @plugin.run
+        plugin.run
 
-        expect(@plugin[:ec2]).not_to be_nil
-        expect(@plugin[:ec2]["instance_type"]).to eq("c1.medium")
-        expect(@plugin[:ec2]["ami_id"]).to eq("ami-5d2dc934")
-        expect(@plugin[:ec2]["security_groups"]).to eql %w{group1 group2}
-        expect(@plugin[:ec2]["userdata"]).to eq(Base64.decode64("Xl88OEI+XkheSDxDNz5VXkBeQ3NvbWV0aGluZ15AS1Q8Qzg+PEM5PiwpPEM5\nPklVKEktLkk8Q0I+PENDPkk8RTU+XkJeQF5RejxCRj48QjA+XlJeQF5AXkA="))
+        expect(plugin[:ec2]).not_to be_nil
+        expect(plugin[:ec2]["instance_type"]).to eq("c1.medium")
+        expect(plugin[:ec2]["ami_id"]).to eq("ami-5d2dc934")
+        expect(plugin[:ec2]["security_groups"]).to eql %w{group1 group2}
+        expect(plugin[:ec2]["userdata"]).to eq(Base64.decode64("Xl88OEI+XkheSDxDNz5VXkBeQ3NvbWV0aGluZ15AS1Q8Qzg+PEM5PiwpPEM5\nPklVKEktLkk8Q0I+PENDPkk8RTU+XkJeQF5RejxCRj48QjA+XlJeQF5AXkA="))
       end
     end
 
-    it "should parse ec2 network/ directory as a multi-level hash" do
+    it "parses ec2 network/ directory as a multi-level hash" do
       expect(@http_client).to receive(:get).
         with("/2012-01-12/meta-data/").
         and_return(double("Net::HTTP Response", :body => "network/", :code => "200"))
@@ -119,10 +124,10 @@ describe Ohai::System, "plugin ec2" do
         with("/2012-01-12/user-data/").
         and_return(double("Net::HTTP Response", :body => "By the pricking of my thumb...", :code => "200"))
 
-      @plugin.run
+      plugin.run
 
-      expect(@plugin[:ec2]).not_to be_nil
-      expect(@plugin[:ec2]["network_interfaces_macs"]["12:34:56:78:9a:bc"]["public_hostname"]).to eql("server17.opscode.com")
+      expect(plugin[:ec2]).not_to be_nil
+      expect(plugin[:ec2]["network_interfaces_macs"]["12:34:56:78:9a:bc"]["public_hostname"]).to eql("server17.opscode.com")
     end # context with common metadata paths
 
     context "with ec2_iam hint file" do
@@ -136,7 +141,7 @@ describe Ohai::System, "plugin ec2" do
         end
       end
 
-      it "should parse ec2 iam/ directory and collect iam/security-credentials/" do
+      it "parses ec2 iam/ directory and collect iam/security-credentials/" do
         expect(@http_client).to receive(:get).
           with("/2012-01-12/meta-data/").
           and_return(double("Net::HTTP Response", :body => "iam/", :code => "200"))
@@ -153,11 +158,11 @@ describe Ohai::System, "plugin ec2" do
           with("/2012-01-12/user-data/").
           and_return(double("Net::HTTP Response", :body => "By the pricking of my thumb...", :code => "200"))
 
-        @plugin.run
+        plugin.run
 
-        expect(@plugin[:ec2]).not_to be_nil
-        expect(@plugin[:ec2]["iam"]["security-credentials"]["MyRole"]["Code"]).to eql "Success"
-        expect(@plugin[:ec2]["iam"]["security-credentials"]["MyRole"]["Token"]).to eql "12345678"
+        expect(plugin[:ec2]).not_to be_nil
+        expect(plugin[:ec2]["iam"]["security-credentials"]["MyRole"]["Code"]).to eql "Success"
+        expect(plugin[:ec2]["iam"]["security-credentials"]["MyRole"]["Token"]).to eql "12345678"
       end
     end
 
@@ -170,7 +175,7 @@ describe Ohai::System, "plugin ec2" do
         end
       end
 
-      it "should parse ec2 iam/ directory and NOT collect iam/security-credentials/" do
+      it "parses ec2 iam/ directory and NOT collect iam/security-credentials/" do
         expect(@http_client).to receive(:get).
           with("/2012-01-12/meta-data/").
           and_return(double("Net::HTTP Response", :body => "iam/", :code => "200"))
@@ -187,14 +192,14 @@ describe Ohai::System, "plugin ec2" do
           with("/2012-01-12/user-data/").
           and_return(double("Net::HTTP Response", :body => "By the pricking of my thumb...", :code => "200"))
 
-        @plugin.run
+        plugin.run
 
-        expect(@plugin[:ec2]).not_to be_nil
-        expect(@plugin[:ec2]["iam"]).to be_nil
+        expect(plugin[:ec2]).not_to be_nil
+        expect(plugin[:ec2]["iam"]).to be_nil
       end
     end
 
-    it "should ignore \"./\" and \"../\" on ec2 metadata paths to avoid infinity loops" do
+    it "ignores \"./\" and \"../\" on ec2 metadata paths to avoid infinity loops" do
       expect(@http_client).to receive(:get).
         with("/2012-01-12/meta-data/").
         and_return(double("Net::HTTP Response", :body => ".\n./\n..\n../\npath1/.\npath2/./\npath3/..\npath4/../", :code => "200"))
@@ -226,12 +231,12 @@ describe Ohai::System, "plugin ec2" do
         with("/2012-01-12/user-data/").
         and_return(double("Net::HTTP Response", :body => "By the pricking of my thumb...", :code => "200"))
 
-      @plugin.run
+      plugin.run
 
-      expect(@plugin[:ec2]).not_to be_nil
+      expect(plugin[:ec2]).not_to be_nil
     end
 
-    it "should complete the run despite unavailable metadata" do
+    it "completes the run despite unavailable metadata" do
       expect(@http_client).to receive(:get).
         with("/2012-01-12/meta-data/").
         and_return(double("Net::HTTP Response", :body => "metrics/", :code => "200"))
@@ -245,11 +250,11 @@ describe Ohai::System, "plugin ec2" do
         with("/2012-01-12/user-data/").
         and_return(double("Net::HTTP Response", :body => "By the pricking of my thumb...", :code => "200"))
 
-      @plugin.run
+      plugin.run
 
-      expect(@plugin[:ec2]).not_to be_nil
-      expect(@plugin[:ec2]["metrics"]).to be_nil
-      expect(@plugin[:ec2]["metrics_vhostmd"]).to be_nil
+      expect(plugin[:ec2]).not_to be_nil
+      expect(plugin[:ec2]["metrics"]).to be_nil
+      expect(plugin[:ec2]["metrics_vhostmd"]).to be_nil
     end
   end # shared examples for ec2
 
@@ -257,7 +262,7 @@ describe Ohai::System, "plugin ec2" do
     it_should_behave_like "ec2"
 
     before(:each) do
-      @plugin[:dmi] = { :bios => { :all_records => [ { :Version => "4.2.amazon" } ] } }
+      plugin[:dmi] = { :bios => { :all_records => [ { :Version => "4.2.amazon" } ] } }
     end
   end
 
@@ -265,7 +270,25 @@ describe Ohai::System, "plugin ec2" do
     it_should_behave_like "ec2"
 
     before(:each) do
-      @plugin[:kernel] = { :os_info => { :organization => "Amazon.com" } }
+      plugin[:kernel] = { :os_info => { :organization => "Amazon.com" } }
+    end
+  end
+
+  describe "with EC2 Xen UUID" do
+    it_should_behave_like "ec2"
+
+    before(:each) do
+      allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(true)
+      allow(File).to receive(:read).with("/sys/hypervisor/uuid").and_return("ec2a0561-e4d6-8e15-d9c8-2e0e03adcde8")
+    end
+  end
+
+  describe "with non-EC2 Xen UUID" do
+    it_should_behave_like "!ec2"
+
+    before(:each) do
+      allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(true)
+      allow(File).to receive(:read).with("/sys/hypervisor/uuid").and_return("123a0561-e4d6-8e15-d9c8-2e0e03adcde8")
     end
   end
 
@@ -300,7 +323,7 @@ describe Ohai::System, "plugin ec2" do
     before(:each) do
       allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(false)
       allow(File).to receive(:exist?).with('C:\chef\ohai\hints/ec2.json').and_return(false)
-      @plugin[:dmi] = nil
+      plugin[:dmi] = nil
     end
   end
 


### PR DESCRIPTION
Remove the Xen MAC address detection method, which we previously deprecated
Detect Windows hosts based on Kernel owner information
Detect Linux hosts based on the Xen UUID starting with ec2