### PR TITLE
Add debug logging to hints and improve cloud specs

### DIFF
--- a/lib/ohai/hints.rb
+++ b/lib/ohai/hints.rb
@@ -26,15 +26,13 @@ module Ohai
     end
 
     def self.parse_hint_file(filename)
-      begin
-        json_parser = FFI_Yajl::Parser.new
-        hash = json_parser.parse(File.read(filename))
-        hash || {} # hint
-        # should exist because the file did, even if it didn't
-        # contain anything
-      rescue FFI_Yajl::ParseError => e
-        Ohai::Log.error("Could not parse hint file at #{filename}: #{e.message}")
-      end
+      json_parser = FFI_Yajl::Parser.new
+      hash = json_parser.parse(File.read(filename))
+      hash || {} # hint
+      # should exist because the file did, even if it didn't
+      # contain anything
+    rescue FFI_Yajl::ParseError => e
+      Ohai::Log.error("Could not parse hint file at #{filename}: #{e.message}")
     end
 
     def self.hint?(name)

--- a/lib/ohai/hints.rb
+++ b/lib/ohai/hints.rb
@@ -45,7 +45,7 @@ module Ohai
         @hints[name] = parse_hint_file(filename)
       end
 
-      Ohai::Log.debug("Did not find hint #{name}.json in the hint path(s): #{Ohai.config[:hints_path].join(',')} ") unless @hints.key?(name)
+      Ohai::Log.debug("Did not find hint #{name}.json in the hint path(s): #{Ohai.config[:hints_path].join(', ')} ") unless @hints.key?(name)
       @hints[name]
     end
   end

--- a/lib/ohai/hints.rb
+++ b/lib/ohai/hints.rb
@@ -22,28 +22,32 @@ require "ffi_yajl"
 module Ohai
   module Hints
     def self.refresh_hints
-      @hints = Hash.new
+      @hints = {}
+    end
+
+    def self.parse_hint_file(filename)
+      begin
+        json_parser = FFI_Yajl::Parser.new
+        hash = json_parser.parse(File.read(filename))
+        hash || {} # hint
+        # should exist because the file did, even if it didn't
+        # contain anything
+      rescue FFI_Yajl::ParseError => e
+        Ohai::Log.error("Plugin #{self.name}: Could not parse hint file at #{filename}: #{e.message}")
+      end
     end
 
     def self.hint?(name)
-      @hints ||= Hash.new
+      @hints ||= {}
       return @hints[name] if @hints[name]
-
       Ohai.config[:hints_path].each do |path|
         filename = File.join(path, "#{name}.json")
-        if File.exist?(filename)
-          begin
-            json_parser = FFI_Yajl::Parser.new
-            hash = json_parser.parse(File.read(filename))
-            @hints[name] = hash || Hash.new # hint
-            # should exist because the file did, even if it didn't
-            # contain anything
-          rescue FFI_Yajl::ParseError => e
-            Ohai::Log.error("Could not parse hint file at #{filename}: #{e.message}")
-          end
-        end
+        next unless File.exist?(filename)
+        Ohai::Log.debug("Found hint #{name}.json at #{filename}")
+        @hints[name] = parse_hint_file(filename)
       end
 
+      Ohai::Log.debug("Did not find hint #{name}.json in the hint path(s): #{Ohai.config[:hints_path].join(',')} ") unless @hints.key?(name)
       @hints[name]
     end
   end

--- a/lib/ohai/hints.rb
+++ b/lib/ohai/hints.rb
@@ -33,7 +33,7 @@ module Ohai
         # should exist because the file did, even if it didn't
         # contain anything
       rescue FFI_Yajl::ParseError => e
-        Ohai::Log.error("Plugin #{self.name}: Could not parse hint file at #{filename}: #{e.message}")
+        Ohai::Log.error("Could not parse hint file at #{filename}: #{e.message}")
       end
     end
 

--- a/spec/unit/plugins/azure_spec.rb
+++ b/spec/unit/plugins/azure_spec.rb
@@ -20,34 +20,50 @@ require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
 require "open-uri"
 
 describe Ohai::System, "plugin azure" do
-  before(:each) do
-    @plugin = get_plugin("azure")
+  let(:plugin) { get_plugin("azure") }
+  let(:hint) {
+    {
+      "public_ip" => "137.135.46.202",
+      "vm_name" => "test-vm",
+      "public_fqdn" => "service.cloudapp.net",
+      "public_ssh_port" => "22",
+      "public_winrm_port" => "5985"
+    }
+  }
+
+  shared_examples_for "!azure" do
+    it "does not set the azure attribute" do
+      plugin.run
+      expect(plugin[:azure]).to be_nil
+    end
+  end
+
+  shared_examples_for "azure" do
+    it "sets the azure attribute" do
+      plugin.run
+      expect(plugin[:azure]).to be_truthy
+    end
   end
 
   describe "with azure hint file" do
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/azure.json").and_return(true)
-      allow(File).to receive(:read).with("/etc/chef/ohai/hints/azure.json").and_return('{"public_ip":"137.135.46.202","vm_name":"test-vm","public_fqdn":"service.cloudapp.net","public_ssh_port":"22", "public_winrm_port":"5985"}')
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(true)
-      allow(File).to receive(:read).with('C:\chef\ohai\hints/azure.json').and_return('{"public_ip":"137.135.46.202","vm_name":"test-vm","public_fqdn":"service.cloudapp.net","public_ssh_port":"22", "public_winrm_port":"5985"}')
-      @plugin.run
+      allow(plugin).to receive(:hint?).with("azure").and_return(hint)
     end
 
-    it "should set the azure cloud attributes" do
-      expect(@plugin[:azure]).not_to be_nil
-      expect(@plugin[:azure]["public_ip"]).to eq("137.135.46.202")
-      expect(@plugin[:azure]["vm_name"]).to eq("test-vm")
-      expect(@plugin[:azure]["public_fqdn"]).to eq("service.cloudapp.net")
-      expect(@plugin[:azure]["public_ssh_port"]).to eq("22")
-      expect(@plugin[:azure]["public_winrm_port"]).to eq("5985")
+    it "sets the azure cloud attributes" do
+      plugin.run
+      expect(plugin[:azure]["public_ip"]).to eq("137.135.46.202")
+      expect(plugin[:azure]["vm_name"]).to eq("test-vm")
+      expect(plugin[:azure]["public_fqdn"]).to eq("service.cloudapp.net")
+      expect(plugin[:azure]["public_ssh_port"]).to eq("22")
+      expect(plugin[:azure]["public_winrm_port"]).to eq("5985")
     end
 
   end
 
   describe "without azure hint file or agent or dhcp options" do
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/azure.json").and_return(false)
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(false)
+      allow(plugin).to receive(:hint?).with("azure").and_return(false)
       allow(File).to receive(:exist?).with("/usr/sbin/waagent").and_return(false)
       allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
       allow(File).to receive(:exist?).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(true)
@@ -73,66 +89,46 @@ describe Ohai::System, "plugin azure" do
         and_yield("  expire 2 2016/03/01 16:40:56;").
         and_yield("}")
       allow(File).to receive(:open).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(@double_file)
-      @plugin.run
     end
 
-    it "should not behave like azure" do
-      expect(@plugin[:azure]).to be_nil
-    end
+    it_behaves_like "!azure"
   end
 
-  describe "with rackspace hint file no agent and no dhcp lease" do
+  describe "with rackspace hint file, no agent, and no dhcp lease" do
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/rackspace.json").and_return(true)
-      allow(File).to receive(:read).with("/etc/chef/ohai/hints/rackspace.json").and_return("")
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/rackspace.json').and_return(true)
-      allow(File).to receive(:read).with('C:\chef\ohai\hints/rackspace.json').and_return("")
+      allow(plugin).to receive(:hint?).with("rackspace").and_return(true)
+      allow(plugin).to receive(:hint?).with("azure").and_return(false)
       allow(File).to receive(:exist?).with("/usr/sbin/waagent").and_return(false)
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/azure.json").and_return(false)
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(false)
       allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
       allow(File).to receive(:exist?).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(false)
-      @plugin.run
     end
 
-    it "should not behave like azure" do
-      expect(@plugin[:azure]).to be_nil
-    end
+    it_behaves_like "!azure"
   end
 
   describe "without azure hint file but with agent on linux" do
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/azure.json").and_return(false)
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(false)
+      allow(plugin).to receive(:hint?).with("azure").and_return(false)
       allow(File).to receive(:exist?).with("/usr/sbin/waagent").and_return(true)
       allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
-      @plugin.run
     end
 
-    it "should create empty azure mash" do
-      expect(@plugin[:azure]).to be_empty
-    end
+    it_behaves_like "azure"
   end
 
   describe "without azure hint file but with agent on windows" do
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/azure.json").and_return(false)
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(false)
+      allow(plugin).to receive(:hint?).with("azure").and_return(false)
       allow(File).to receive(:exist?).with("/usr/sbin/waagent").and_return(false)
       allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(true)
-      @plugin.run
     end
 
-    it "should create empty azure mash" do
-      puts "The dir exists?:" + "#{Dir.exist?('C:\WindowsAzure')}"
-      expect(@plugin[:azure]).to be_empty
-    end
+    it_behaves_like "azure"
   end
 
   describe "without azure hint or agent but with dhcp option" do
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/azure.json").and_return(false)
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/azure.json').and_return(false)
+      allow(plugin).to receive(:hint?).with("azure").and_return(false)
       allow(File).to receive(:exist?).with("/usr/sbin/waagent").and_return(false)
       allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
       allow(File).to receive(:exist?).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(true)
@@ -158,13 +154,9 @@ describe Ohai::System, "plugin azure" do
         and_yield("  expire 5 2152/03/10 09:03:39;").
         and_yield("}")
       allow(File).to receive(:open).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(@double_file)
-      @plugin.run
     end
 
-    it "should create empty azure mash" do
-      puts "The dir exists?:" + "#{Dir.exist?('C:\WindowsAzure')}"
-      expect(@plugin[:azure]).to be_empty
-    end
+    it_behaves_like "azure"
   end
 
 end

--- a/spec/unit/plugins/azure_spec.rb
+++ b/spec/unit/plugins/azure_spec.rb
@@ -27,7 +27,7 @@ describe Ohai::System, "plugin azure" do
       "vm_name" => "test-vm",
       "public_fqdn" => "service.cloudapp.net",
       "public_ssh_port" => "22",
-      "public_winrm_port" => "5985"
+      "public_winrm_port" => "5985",
     }
   }
 

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -30,8 +30,8 @@ describe Ohai::System, "plugin digital_ocean" do
       "region_id" => 4,
       "ip_addresses" => {
         "public" => "1.2.3.4",
-        "private" => "5.6.7.8"
-      }
+        "private" => "5.6.7.8",
+      },
     }
   }
 
@@ -72,11 +72,11 @@ describe Ohai::System, "plugin digital_ocean" do
 
     it "pulls ip addresses from the network interfaces" do
       expect(plugin[:digital_ocean][:networks][:v4]).to eq([{ "ip_address" => "1.2.3.4",
-                                                               "type" => "public",
-                                                               "netmask" => "255.255.255.0" }])
+                                                              "type" => "public",
+                                                              "netmask" => "255.255.255.0" }])
       expect(plugin[:digital_ocean][:networks][:v6]).to eq([{ "ip_address" => "2400:6180:0000:00d0:0000:0000:0009:7001",
-                                                               "type" => "public",
-                                                               "cidr" => 128 }])
+                                                              "type" => "public",
+                                                              "cidr" => 128 }])
     end
   end
 
@@ -137,14 +137,14 @@ describe Ohai::System, "plugin digital_ocean" do
 
       it "extracts the private networking ips" do
         expect(plugin[:digital_ocean][:networks][:v4]).to eq([{ "ip_address" => "1.2.3.4",
-                                                                 "type" => "public",
-                                                                 "netmask" => "255.255.255.0" },
+                                                                "type" => "public",
+                                                                "netmask" => "255.255.255.0" },
                                                             { "ip_address" => "10.128.142.89",
                                                               "type" => "private",
                                                               "netmask" => "255.255.255.0" }])
         expect(plugin[:digital_ocean][:networks][:v6]).to eq([{ "ip_address" => "2400:6180:0000:00d0:0000:0000:0009:7001",
-                                                                 "type" => "public",
-                                                                 "cidr" => 128 },
+                                                                "type" => "public",
+                                                                "cidr" => 128 },
                                                            { "ip_address" => "fdf8:f53b:82e4:0000:0000:0000:0000:0053",
                                                              "type" => "private",
                                                              "cidr" => 128 }])

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -172,26 +172,4 @@ describe Ohai::System, "plugin digital_ocean" do
       it_should_behave_like "!digital_ocean"
     end
   end
-
-  context "with ec2 hint file" do
-    before do
-      allow(plugin).to receive(:hint?).with("ec2").and_return({})
-      allow(plugin).to receive(:hint?).with("digital_ocean").and_return(false)
-    end
-
-    describe "with the /etc/digitalocean file" do
-      before do
-        allow(File).to receive(:exist?).with(digitalocean_path).and_return(true)
-        plugin.run
-      end
-      it_should_behave_like "digital_ocean_networking"
-    end
-
-    describe "without the /etc/digitalocean file" do
-      before do
-        allow(File).to receive(:exist?).with(digitalocean_path).and_return(false)
-      end
-      it_should_behave_like "!digital_ocean"
-    end
-  end
 end

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -19,26 +19,24 @@ require "ipaddress"
 require "spec_helper"
 
 describe Ohai::System, "plugin digital_ocean" do
-  let(:hint_path_nix) { "/etc/chef/ohai/hints/digital_ocean.json" }
-  let(:hint_path_win) { 'C:\chef\ohai\hints/digital_ocean.json' }
+  let(:plugin) { get_plugin("digital_ocean") }
   let(:digitalocean_path) { "/etc/digitalocean" }
   let(:hint) {
-    '{
-      "droplet_id": 12345678,
-      "name": "example.com",
-      "image_id": 3240036,
-      "size_id": 66,
-      "region_id": 4,
-      "ip_addresses": {
-        "public": "1.2.3.4",
-        "private": "5.6.7.8"
+    {
+      "droplet_id" => 12345678,
+      "name" => "example.com",
+      "image_id" => 3240036,
+      "size_id" => 66,
+      "region_id" => 4,
+      "ip_addresses" => {
+        "public" => "1.2.3.4",
+        "private" => "5.6.7.8"
       }
-    }'
+    }
   }
 
   before do
-    @plugin = get_plugin("digital_ocean")
-    @plugin[:network] = {
+    plugin[:network] = {
       "interfaces" => {
         "eth0" => {
           "addresses" => {
@@ -54,32 +52,29 @@ describe Ohai::System, "plugin digital_ocean" do
       },
     }
 
-    allow(File).to receive(:exist?).with(hint_path_nix).and_return(true)
-    allow(File).to receive(:read).with(hint_path_nix).and_return(hint)
-    allow(File).to receive(:exist?).with(hint_path_win).and_return(true)
-    allow(File).to receive(:read).with(hint_path_win).and_return(hint)
+    allow(plugin).to receive(:hint?).with("digital_ocean").and_return(hint)
   end
 
   shared_examples_for "!digital_ocean" do
     before(:each) do
-      @plugin.run
+      plugin.run
     end
 
     it "does not create the digital_ocean mash" do
-      expect(@plugin[:digital_ocean]).to be_nil
+      expect(plugin[:digital_ocean]).to be_nil
     end
   end
 
   shared_examples_for "digital_ocean_networking" do
     it "creates the networks attribute" do
-      expect(@plugin[:digital_ocean][:networks]).not_to be_nil
+      expect(plugin[:digital_ocean][:networks]).not_to be_nil
     end
 
     it "pulls ip addresses from the network interfaces" do
-      expect(@plugin[:digital_ocean][:networks][:v4]).to eq([{ "ip_address" => "1.2.3.4",
+      expect(plugin[:digital_ocean][:networks][:v4]).to eq([{ "ip_address" => "1.2.3.4",
                                                                "type" => "public",
                                                                "netmask" => "255.255.255.0" }])
-      expect(@plugin[:digital_ocean][:networks][:v6]).to eq([{ "ip_address" => "2400:6180:0000:00d0:0000:0000:0009:7001",
+      expect(plugin[:digital_ocean][:networks][:v6]).to eq([{ "ip_address" => "2400:6180:0000:00d0:0000:0000:0009:7001",
                                                                "type" => "public",
                                                                "cidr" => 128 }])
     end
@@ -87,31 +82,31 @@ describe Ohai::System, "plugin digital_ocean" do
 
   shared_examples_for "digital_ocean" do
     before(:each) do
-      @plugin.run
+      plugin.run
     end
 
     it "creates a digital_ocean mash" do
-      expect(@plugin[:digital_ocean]).not_to be_nil
+      expect(plugin[:digital_ocean]).not_to be_nil
     end
 
     it "has all hint attributes" do
-      expect(@plugin[:digital_ocean][:droplet_id]).not_to be_nil
-      expect(@plugin[:digital_ocean][:name]).not_to be_nil
-      expect(@plugin[:digital_ocean][:image_id]).not_to be_nil
-      expect(@plugin[:digital_ocean][:size_id]).not_to be_nil
-      expect(@plugin[:digital_ocean][:region_id]).not_to be_nil
+      expect(plugin[:digital_ocean][:droplet_id]).not_to be_nil
+      expect(plugin[:digital_ocean][:name]).not_to be_nil
+      expect(plugin[:digital_ocean][:image_id]).not_to be_nil
+      expect(plugin[:digital_ocean][:size_id]).not_to be_nil
+      expect(plugin[:digital_ocean][:region_id]).not_to be_nil
     end
 
     it "skips the ip_addresses hint attribute" do
-      expect(@plugin[:digital_ocean][:ip_addresses]).to be_nil
+      expect(plugin[:digital_ocean][:ip_addresses]).to be_nil
     end
 
     it "has correct values for all hint attributes" do
-      expect(@plugin[:digital_ocean][:droplet_id]).to eq(12345678)
-      expect(@plugin[:digital_ocean][:name]).to eq("example.com")
-      expect(@plugin[:digital_ocean][:image_id]).to eq(3240036)
-      expect(@plugin[:digital_ocean][:size_id]).to eq(66)
-      expect(@plugin[:digital_ocean][:region_id]).to eq(4)
+      expect(plugin[:digital_ocean][:droplet_id]).to eq(12345678)
+      expect(plugin[:digital_ocean][:name]).to eq("example.com")
+      expect(plugin[:digital_ocean][:image_id]).to eq(3240036)
+      expect(plugin[:digital_ocean][:size_id]).to eq(66)
+      expect(plugin[:digital_ocean][:region_id]).to eq(4)
     end
 
     include_examples "digital_ocean_networking"
@@ -119,8 +114,7 @@ describe Ohai::System, "plugin digital_ocean" do
 
   describe "with digital_ocean hint file" do
     before do
-      allow(File).to receive(:exist?).with(hint_path_nix).and_return(true)
-      allow(File).to receive(:exist?).with(hint_path_win).and_return(true)
+      allow(plugin).to receive(:hint?).with("digital_ocean").and_return(hint)
     end
 
     context "without private networking enabled" do
@@ -129,7 +123,7 @@ describe Ohai::System, "plugin digital_ocean" do
 
     context "with private networking enabled" do
       before do
-        @plugin[:network][:interfaces][:eth1] = {
+        plugin[:network][:interfaces][:eth1] = {
           "addresses" => {
             "10.128.142.89" => {
               "netmask" => "255.255.255.0",
@@ -138,17 +132,17 @@ describe Ohai::System, "plugin digital_ocean" do
           },
         }
 
-        @plugin.run
+        plugin.run
       end
 
-      it "should extract the private networking ips" do
-        expect(@plugin[:digital_ocean][:networks][:v4]).to eq([{ "ip_address" => "1.2.3.4",
+      it "extracts the private networking ips" do
+        expect(plugin[:digital_ocean][:networks][:v4]).to eq([{ "ip_address" => "1.2.3.4",
                                                                  "type" => "public",
                                                                  "netmask" => "255.255.255.0" },
                                                             { "ip_address" => "10.128.142.89",
                                                               "type" => "private",
                                                               "netmask" => "255.255.255.0" }])
-        expect(@plugin[:digital_ocean][:networks][:v6]).to eq([{ "ip_address" => "2400:6180:0000:00d0:0000:0000:0009:7001",
+        expect(plugin[:digital_ocean][:networks][:v6]).to eq([{ "ip_address" => "2400:6180:0000:00d0:0000:0000:0009:7001",
                                                                  "type" => "public",
                                                                  "cidr" => 128 },
                                                            { "ip_address" => "fdf8:f53b:82e4:0000:0000:0000:0000:0053",
@@ -160,14 +154,13 @@ describe Ohai::System, "plugin digital_ocean" do
 
   describe "without digital_ocean hint file" do
     before do
-      allow(File).to receive(:exist?).with(hint_path_nix).and_return(false)
-      allow(File).to receive(:exist?).with(hint_path_win).and_return(false)
+      allow(plugin).to receive(:hint?).with("digital_ocean").and_return(false)
     end
 
     describe "with the /etc/digitalocean file" do
       before do
         allow(File).to receive(:exist?).with(digitalocean_path).and_return(true)
-        @plugin.run
+        plugin.run
       end
       it_should_behave_like "digital_ocean_networking"
     end
@@ -181,23 +174,15 @@ describe Ohai::System, "plugin digital_ocean" do
   end
 
   context "with ec2 hint file" do
-    let(:ec2_hint_path_nix) { "/etc/chef/ohai/hints/ec2.json" }
-    let(:ec2_hint_path_win) { 'C:\chef\ohai\hints/ec2.json' }
-
     before do
-      allow(File).to receive(:exist?).with(hint_path_nix).and_return(false)
-      allow(File).to receive(:exist?).with(hint_path_win).and_return(false)
-
-      allow(File).to receive(:exist?).with(ec2_hint_path_nix).and_return(true)
-      allow(File).to receive(:read).with(ec2_hint_path_nix).and_return("")
-      allow(File).to receive(:exist?).with(ec2_hint_path_win).and_return(true)
-      allow(File).to receive(:read).with(ec2_hint_path_win).and_return("")
+      allow(plugin).to receive(:hint?).with("ec2").and_return({})
+      allow(plugin).to receive(:hint?).with("digital_ocean").and_return(false)
     end
 
     describe "with the /etc/digitalocean file" do
       before do
         allow(File).to receive(:exist?).with(digitalocean_path).and_return(true)
-        @plugin.run
+        plugin.run
       end
       it_should_behave_like "digital_ocean_networking"
     end

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -118,7 +118,7 @@ describe Ohai::System, "plugin digital_ocean" do
     end
 
     context "without private networking enabled" do
-      it_should_behave_like "digital_ocean"
+      it_behaves_like "digital_ocean"
     end
 
     context "with private networking enabled" do
@@ -162,14 +162,14 @@ describe Ohai::System, "plugin digital_ocean" do
         allow(File).to receive(:exist?).with(digitalocean_path).and_return(true)
         plugin.run
       end
-      it_should_behave_like "digital_ocean_networking"
+      it_behaves_like "digital_ocean_networking"
     end
 
     describe "without the /etc/digitalocean file" do
       before do
         allow(File).to receive(:exist?).with(digitalocean_path).and_return(false)
       end
-      it_should_behave_like "!digital_ocean"
+      it_behaves_like "!digital_ocean"
     end
   end
 end

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -24,8 +24,7 @@ require "base64"
 describe Ohai::System, "plugin ec2" do
 
   before(:each) do
-    allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(false)
-    allow(File).to receive(:exist?).with('C:\chef\ohai\hints/ec2.json').and_return(false)
+    allow(plugin).to receive(:hint?).with("ec2").and_return(false)
     allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(false)
   end
 
@@ -132,13 +131,7 @@ describe Ohai::System, "plugin ec2" do
 
     context "with ec2_iam hint file" do
       before do
-        if windows?
-          allow(File).to receive(:exist?).with('C:\chef\ohai\hints/iam.json').and_return(true)
-          allow(File).to receive(:read).with('C:\chef\ohai\hints/iam.json').and_return("")
-        else
-          allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/iam.json").and_return(true)
-          allow(File).to receive(:read).with("/etc/chef/ohai/hints/iam.json").and_return("")
-        end
+        allow(plugin).to receive(:hint?).with("iam").and_return(true)
       end
 
       it "parses ec2 iam/ directory and collect iam/security-credentials/" do
@@ -168,11 +161,7 @@ describe Ohai::System, "plugin ec2" do
 
     context "without ec2_iam hint file" do
       before do
-        if windows?
-          allow(File).to receive(:exist?).with('C:\chef\ohai\hints/iam.json').and_return(false)
-        else
-          allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/iam.json").and_return(false)
-        end
+        allow(plugin).to receive(:hint?).with("iam").and_return(false)
       end
 
       it "parses ec2 iam/ directory and NOT collect iam/security-credentials/" do
@@ -296,13 +285,7 @@ describe Ohai::System, "plugin ec2" do
     it_behaves_like "ec2"
 
     before(:each) do
-      if windows?
-        expect(File).to receive(:exist?).with('C:\chef\ohai\hints/ec2.json').and_return(true)
-        allow(File).to receive(:read).with('C:\chef\ohai\hints/ec2.json').and_return("")
-      else
-        expect(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(true)
-        allow(File).to receive(:read).with("/etc/chef/ohai/hints/ec2.json").and_return("")
-      end
+      allow(plugin).to receive(:hint?).with("ec2").and_return({})
     end
   end
 
@@ -310,10 +293,7 @@ describe Ohai::System, "plugin ec2" do
     it_behaves_like "!ec2"
 
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/rackspace.json").and_return(true)
-      allow(File).to receive(:read).with("/etc/chef/ohai/hints/rackspace.json").and_return("")
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/rackspace.json').and_return(true)
-      allow(File).to receive(:read).with('C:\chef\ohai\hints/rackspace.json').and_return("")
+      allow(plugin).to receive(:hint?).with("rackspace").and_return(true)
     end
   end
 
@@ -321,8 +301,7 @@ describe Ohai::System, "plugin ec2" do
     it_behaves_like "!ec2"
 
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(false)
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/ec2.json').and_return(false)
+      allow(plugin).to receive(:hint?).with("ec2").and_return(false)
       plugin[:dmi] = nil
     end
   end

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -288,15 +288,6 @@ describe Ohai::System, "plugin ec2" do
       allow(plugin).to receive(:hint?).with("ec2").and_return({})
     end
   end
-
-  describe "with rackspace hint file" do
-    it_behaves_like "!ec2"
-
-    before(:each) do
-      allow(plugin).to receive(:hint?).with("rackspace").and_return(true)
-    end
-  end
-
   describe "without any hints that it is an ec2 system" do
     it_behaves_like "!ec2"
 

--- a/spec/unit/plugins/eucalyptus_spec.rb
+++ b/spec/unit/plugins/eucalyptus_spec.rb
@@ -102,15 +102,4 @@ describe Ohai::System, "plugin eucalyptus" do
     end
   end
 
-  describe "with ec2 hint file" do
-    it_behaves_like "!eucalyptus"
-
-    before(:each) do
-      plugin[:network] = { :interfaces => {} }
-
-      allow(plugin).to receive(:hint?).with("eucalyptus").and_return(false)
-      allow(plugin).to receive(:hint?).with("ec2").and_return({})
-    end
-  end
-
 end

--- a/spec/unit/plugins/gce_spec.rb
+++ b/spec/unit/plugins/gce_spec.rb
@@ -19,26 +19,24 @@ require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
 require "open-uri"
 
 describe Ohai::System, "plugin gce" do
-  before(:each) do
-    @plugin = get_plugin("gce")
-  end
+  let(:plugin) { get_plugin("gce") }
 
   shared_examples_for "!gce" do
-    it "should NOT attempt to fetch the gce metadata" do
-      expect(@plugin).not_to receive(:http_get)
-      @plugin.run
+    it "does NOT attempt to fetch the gce metadata" do
+      expect(plugin).not_to receive(:http_get)
+      plugin.run
     end
 
-    it "should NOT set gce attributes" do
-      expect(@plugin[:gce]).to be_nil
-      @plugin.run
+    it "does NOT set gce attributes" do
+      expect(plugin[:gce]).to be_nil
+      plugin.run
     end
   end
 
   shared_examples_for "gce" do
     before(:each) do
       @http_get = double("Net::HTTP client")
-      allow(@plugin).to receive(:http_get).and_return(double("Net::HTTP Response", :body => '{"instance":{"hostname":"test-host"}}', :code => "200"))
+      allow(plugin).to receive(:http_get).and_return(double("Net::HTTP Response", :body => '{"instance":{"hostname":"test-host"}}', :code => "200"))
       allow(IO).to receive(:select).and_return([[], [1], []])
       t = double("connection")
       allow(t).to receive(:connect_nonblock).and_raise(Errno::EINPROGRESS)
@@ -46,11 +44,11 @@ describe Ohai::System, "plugin gce" do
       allow(Socket).to receive(:pack_sockaddr_in).and_return(nil)
     end
 
-    it "should recursively fetch and properly parse json metadata" do
-      @plugin.run
+    it "recursively fetches and properly parses json metadata" do
+      plugin.run
 
-      expect(@plugin[:gce]).not_to be_nil
-      expect(@plugin[:gce]["instance"]).to eq("hostname" => "test-host")
+      expect(plugin[:gce]).not_to be_nil
+      expect(plugin[:gce]["instance"]).to eq("hostname" => "test-host")
     end
 
   end
@@ -59,10 +57,7 @@ describe Ohai::System, "plugin gce" do
     it_should_behave_like "gce"
 
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/gce.json").and_return(true)
-      allow(File).to receive(:read).with("/etc/chef/ohai/hints/gce.json").and_return("")
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/gce.json').and_return(true)
-      allow(File).to receive(:read).with('C:\chef\ohai\hints/gce.json').and_return("")
+      allow(plugin).to receive(:hint?).with("gce").and_return({})
     end
   end
 
@@ -70,8 +65,7 @@ describe Ohai::System, "plugin gce" do
     it_should_behave_like "!gce"
 
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/gce.json").and_return(false)
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/gce.json').and_return(false)
+      allow(plugin).to receive(:hint?).with("gce").and_return(false)
 
       # Raise Errno::ENOENT to simulate the scenario in which metadata server
       # can not be connected

--- a/spec/unit/plugins/gce_spec.rb
+++ b/spec/unit/plugins/gce_spec.rb
@@ -54,7 +54,7 @@ describe Ohai::System, "plugin gce" do
   end
 
   describe "with hint file and with metadata connection" do
-    it_should_behave_like "gce"
+    it_behaves_like "gce"
 
     before(:each) do
       allow(plugin).to receive(:hint?).with("gce").and_return({})
@@ -62,7 +62,7 @@ describe Ohai::System, "plugin gce" do
   end
 
   describe "without hint file and without metadata connection" do
-    it_should_behave_like "!gce"
+    it_behaves_like "!gce"
 
     before(:each) do
       allow(plugin).to receive(:hint?).with("gce").and_return(false)

--- a/spec/unit/plugins/linode_spec.rb
+++ b/spec/unit/plugins/linode_spec.rb
@@ -132,13 +132,4 @@ describe Ohai::System, "plugin linode" do
     it_behaves_like "!linode"
   end
 
-  context "with ec2 hint file" do
-    before do
-      allow(plugin).to receive(:hint?).with("linode").and_return(false)
-      allow(plugin).to receive(:hint?).with("ec2").and_return({})
-    end
-
-    it_behaves_like "!linode"
-  end
-
 end

--- a/spec/unit/plugins/linode_spec.rb
+++ b/spec/unit/plugins/linode_spec.rb
@@ -18,12 +18,10 @@
 require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
 
 describe Ohai::System, "plugin linode" do
-  let(:hint_path_nix) { "/etc/chef/ohai/hints/linode.json" }
-  let(:hint_path_win) { 'C:\chef\ohai\hints/linode.json' }
+  let(:plugin) { get_plugin("linode") }
 
   before do
-    @plugin = get_plugin("linode")
-    @plugin[:network] = {
+    plugin[:network] = {
       "interfaces" => {
         "eth0" => {
           "addresses" => {
@@ -48,49 +46,49 @@ describe Ohai::System, "plugin linode" do
 
   shared_examples_for "!linode" do
     it "does not create the linode mash" do
-      @plugin.run
-      expect(@plugin[:linode]).to be_nil
+      plugin.run
+      expect(plugin[:linode]).to be_nil
     end
   end
 
   shared_examples_for "linode" do
-    it "creates a linode mash" do
-      @plugin.run
-      expect(@plugin[:linode]).not_to be_nil
+    it "creates the linode mash" do
+      plugin.run
+      expect(plugin[:linode]).not_to be_nil
     end
 
-    it "has all required attributes" do
-      @plugin.run
-      expect(@plugin[:linode][:public_ip]).not_to be_nil
+    it "has public_ip attribute" do
+      plugin.run
+      expect(plugin[:linode][:public_ip]).not_to be_nil
     end
 
-    it "has correct values for all attributes" do
-      @plugin.run
-      expect(@plugin[:linode][:public_ip]).to eq("1.2.3.4")
+    it "has correct value for public_ip attribute" do
+      plugin.run
+      expect(plugin[:linode][:public_ip]).to eq("1.2.3.4")
     end
 
   end
 
   context "without linode kernel" do
     before do
-      @plugin[:kernel] = { "release" => "3.5.2-x86_64" }
+      plugin[:kernel] = { "release" => "3.5.2-x86_64" }
     end
 
-    it_should_behave_like "!linode"
+    it_behaves_like "!linode"
   end
 
   context "with linode kernel" do
     before do
-      @plugin[:kernel] = { "release" => "3.5.2-x86_64-linode24" }
+      plugin[:kernel] = { "release" => "3.5.2-x86_64-linode24" }
     end
 
-    it_should_behave_like "linode"
+    it_behaves_like "linode"
 
     # This test is an interface created according to this guide by Linode
     # http://library.linode.com/networking/configuring-static-ip-interfaces
     context "with configured private ip address as suggested by linode" do
       before do
-        @plugin[:network][:interfaces]["eth0:1"] = {
+        plugin[:network][:interfaces]["eth0:1"] = {
           "addresses" => {
             "5.6.7.8" => {
               "broadcast" => "10.176.191.255",
@@ -110,49 +108,37 @@ describe Ohai::System, "plugin linode" do
       end
 
       it "detects and sets the private ip" do
-        @plugin.run
-        expect(@plugin[:linode][:private_ip]).not_to be_nil
-        expect(@plugin[:linode][:private_ip]).to eq("5.6.7.8")
+        plugin.run
+        expect(plugin[:linode][:private_ip]).not_to be_nil
+        expect(plugin[:linode][:private_ip]).to eq("5.6.7.8")
       end
     end
 
   end
 
-  describe "with linode cloud file" do
+  describe "with linode hint file" do
     before do
-      allow(File).to receive(:exist?).with(hint_path_nix).and_return(true)
-      allow(File).to receive(:read).with(hint_path_nix).and_return("")
-      allow(File).to receive(:exist?).with(hint_path_win).and_return(true)
-      allow(File).to receive(:read).with(hint_path_win).and_return("")
+      allow(plugin).to receive(:hint?).with("linode").and_return({})
     end
 
-    it_should_behave_like "linode"
+    it_behaves_like "linode"
   end
 
-  describe "without cloud file" do
+  describe "without hint file" do
     before do
-      allow(File).to receive(:exist?).with(hint_path_nix).and_return(false)
-      allow(File).to receive(:exist?).with(hint_path_win).and_return(false)
+      allow(plugin).to receive(:hint?).with("linode").and_return(false)
     end
 
-    it_should_behave_like "!linode"
+    it_behaves_like "!linode"
   end
 
-  context "with ec2 cloud file" do
-    let(:ec2_hint_path_nix) { "/etc/chef/ohai/hints/ec2.json" }
-    let(:ec2_hint_path_win) { 'C:\chef\ohai\hints/ec2.json' }
-
+  context "with ec2 hint file" do
     before do
-      allow(File).to receive(:exist?).with(hint_path_nix).and_return(false)
-      allow(File).to receive(:exist?).with(hint_path_win).and_return(false)
-
-      allow(File).to receive(:exist?).with(ec2_hint_path_nix).and_return(true)
-      allow(File).to receive(:read).with(ec2_hint_path_nix).and_return("")
-      allow(File).to receive(:exist?).with(ec2_hint_path_win).and_return(true)
-      allow(File).to receive(:read).with(ec2_hint_path_win).and_return("")
+      allow(plugin).to receive(:hint?).with("linode").and_return(false)
+      allow(plugin).to receive(:hint?).with("ec2").and_return({})
     end
 
-    it_should_behave_like "!linode"
+    it_behaves_like "!linode"
   end
 
 end

--- a/spec/unit/plugins/rackspace_spec.rb
+++ b/spec/unit/plugins/rackspace_spec.rb
@@ -224,15 +224,6 @@ OUT
     end
   end
 
-  describe "with ec2 hint file and no rackspace hint file" do
-    it_behaves_like "!rackspace"
-
-    before(:each) do
-      allow(plugin).to receive(:hint?).with("ec2").and_return({})
-      allow(plugin).to receive(:hint?).with("rackspace").and_return(false)
-    end
-  end
-
   describe "xenstore provider returns rackspace" do
     it_behaves_like "rackspace"
 

--- a/spec/unit/plugins/rackspace_spec.rb
+++ b/spec/unit/plugins/rackspace_spec.rb
@@ -220,7 +220,7 @@ OUT
     it_behaves_like "!rackspace"
 
     before(:each) do
-      allow(plugin).to receive(:hint?).with('rackspace').and_return(false)
+      allow(plugin).to receive(:hint?).with("rackspace").and_return(false)
     end
   end
 

--- a/spec/unit/plugins/rackspace_spec.rb
+++ b/spec/unit/plugins/rackspace_spec.rb
@@ -82,19 +82,19 @@ describe Ohai::System, "plugin rackspace" do
   end
 
   shared_examples_for "!rackspace" do
-    it "does not create rackspace" do
+    it "does not create rackspace attribute" do
       plugin.run
       expect(plugin[:rackspace]).to be_nil
     end
   end
 
   shared_examples_for "rackspace" do
-    it "creates rackspace" do
+    it "has rackspace attribute" do
       plugin.run
       expect(plugin[:rackspace]).not_to be_nil
     end
 
-    it "has all required attributes" do
+    it "has expected rackspace ip/hostname attributes" do
       plugin.run
       expect(plugin[:rackspace][:public_ip]).not_to be_nil
       expect(plugin[:rackspace][:private_ip]).not_to be_nil
@@ -184,17 +184,14 @@ OUT
     end
   end
 
-  describe "with rackspace cloud file" do
+  describe "with rackspace hint file" do
     it_behaves_like "rackspace"
 
     before(:each) do
       allow(Resolv).to receive(:getname).and_raise(Resolv::ResolvError)
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/rackspace.json").and_return(true)
-      allow(File).to receive(:read).with("/etc/chef/ohai/hints/rackspace.json").and_return("")
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/rackspace.json').and_return(true)
-      allow(File).to receive(:read).with('C:\chef\ohai\hints/rackspace.json').and_return("")
       allow(File).to receive(:exist?).with("/etc/resolv.conf").and_return(true)
       allow(File).to receive(:read).with("/etc/resolv.conf").and_return("")
+      allow(plugin).to receive(:hint?).with("rackspace").and_return(true)
     end
 
     describe "with no public interfaces (empty eth0)" do
@@ -203,7 +200,7 @@ OUT
         plugin[:network][:interfaces][:eth0]["addresses"] = {}
       end
 
-      it "has all required attributes" do
+      it "has correct rackspace attributes" do
         plugin.run
         # expliticly nil
         expect(plugin[:rackspace][:public_ip]).to be_nil
@@ -211,14 +208,7 @@ OUT
         expect(plugin[:rackspace][:public_ipv6]).to be_nil
         expect(plugin[:rackspace][:public_hostname]).to be_nil
         # per normal
-        expect(plugin[:rackspace][:private_ip]).not_to be_nil
-        expect(plugin[:rackspace][:local_ipv4]).not_to be_nil
         expect(plugin[:rackspace][:local_ipv6]).to be_nil
-        expect(plugin[:rackspace][:local_hostname]).not_to be_nil
-      end
-
-      it "has correct values for all attributes" do
-        plugin.run
         expect(plugin[:rackspace][:private_ip]).to eq("5.6.7.8")
         expect(plugin[:rackspace][:local_ipv4]).to eq("5.6.7.8")
         expect(plugin[:rackspace][:local_hostname]).to eq("katie")
@@ -226,26 +216,20 @@ OUT
     end
   end
 
-  describe "without cloud file" do
+  describe "without hint file" do
     it_behaves_like "!rackspace"
 
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/rackspace.json").and_return(false)
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/rackspace.json').and_return(false)
+      allow(plugin).to receive(:hint?).with('rackspace').and_return(false)
     end
   end
 
-  describe "with ec2 cloud file" do
+  describe "with ec2 hint file and no rackspace hint file" do
     it_behaves_like "!rackspace"
 
     before(:each) do
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/ec2.json").and_return(true)
-      allow(File).to receive(:read).with("/etc/chef/ohai/hints/ec2.json").and_return("")
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/ec2.json').and_return(true)
-      allow(File).to receive(:read).with('C:\chef\ohai\hints/ec2.json').and_return("")
-
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/rackspace.json").and_return(false)
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/rackspace.json').and_return(false)
+      allow(plugin).to receive(:hint?).with("ec2").and_return({})
+      allow(plugin).to receive(:hint?).with("rackspace").and_return(false)
     end
   end
 
@@ -254,6 +238,7 @@ OUT
 
     before(:each) do
       stdout = "Rackspace\n"
+      allow(plugin).to receive(:hint?).with("rackspace").and_return(false)
       allow(plugin).to receive(:shell_out).with("xenstore-read vm-data/provider_data/provider").and_return(mock_shell_out(0, stdout, "" ))
     end
   end
@@ -262,6 +247,7 @@ OUT
     it_behaves_like "!rackspace"
 
     before(:each) do
+      allow(plugin).to receive(:hint?).with("rackspace").and_return(false)
       stdout = "cumulonimbus\n"
       allow(plugin).to receive(:shell_out).with("xenstore-read vm-data/provider_data/provider").and_return(mock_shell_out(0, stdout, "" ))
     end
@@ -271,6 +257,7 @@ OUT
     it_behaves_like "!rackspace"
 
     before(:each) do
+      allow(plugin).to receive(:hint?).with("rackspace").and_return(false)
       allow(plugin).
         to receive(:shell_out).
         with("xenstore-read vm-data/provider_data/provider").
@@ -301,14 +288,10 @@ OUT
   describe "does not have private networks" do
     before do
       stdout = 'BC764E20422B = "{"label": "public"}"\n'
+      allow(plugin).to receive(:hint?).with("rackspace").and_return(true)
       allow(plugin).to receive(:shell_out).with("xenstore-ls vm-data/networking").and_return(mock_shell_out(0, stdout, "" ))
       stdout = '{"label": "public", "broadcast": "9.10.11.255", "ips": [{"ip": "9.10.11.12", "netmask": "255.255.255.0", "enabled": "1", "gateway": null}], "mac": "BC:76:4E:20:42:2B", "dns": ["69.20.0.164", "69.20.0.196"], "gateway": null}'
       allow(plugin).to receive(:shell_out).with("xenstore-read vm-data/networking/BC764E20422B").and_return(mock_shell_out(0, stdout, "" ))
-
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/rackspace.json").and_return(true)
-      allow(File).to receive(:read).with("/etc/chef/ohai/hints/rackspace.json").and_return("")
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/rackspace.json').and_return(true)
-      allow(File).to receive(:read).with('C:\chef\ohai\hints/rackspace.json').and_return("")
     end
 
     it "does not have private_networks object" do
@@ -340,11 +323,7 @@ OUT
       allow(plugin).to receive(:shell_out).with("xenstore-ls vm-data/networking").and_return(mock_shell_out(0, stdout, "" ))
       stdout = '{"label": "private-network", "broadcast": "9.10.11.255", "ips": [{"ip": "9.10.11.12", "netmask": "255.255.255.0", "enabled": "1", "gateway": null}], "mac": "BC:76:4E:20:42:2B", "dns": ["69.20.0.164", "69.20.0.196"], "gateway": null}'
       allow(plugin).to receive(:shell_out).with("xenstore-read vm-data/networking/BC764E20422B").and_return(mock_shell_out(0, stdout, "" ))
-
-      allow(File).to receive(:exist?).with("/etc/chef/ohai/hints/rackspace.json").and_return(true)
-      allow(File).to receive(:read).with("/etc/chef/ohai/hints/rackspace.json").and_return("")
-      allow(File).to receive(:exist?).with('C:\chef\ohai\hints/rackspace.json').and_return(true)
-      allow(File).to receive(:read).with('C:\chef\ohai\hints/rackspace.json').and_return("")
+      allow(plugin).to receive(:hint?).with("rackspace").and_return(true)
     end
 
     it "has private_networks object" do
@@ -352,7 +331,7 @@ OUT
       expect(plugin[:rackspace][:private_networks]).not_to be_nil
     end
 
-    it "has correct values for all attributes" do
+    it "has correct values for all rackspace attributes" do
       plugin.run
       expect(plugin[:rackspace][:private_networks][0][:label]).to eq("private-network")
       expect(plugin[:rackspace][:private_networks][0][:broadcast]).to eq("9.10.11.255")

--- a/spec/unit/plugins/softlayer_spec.rb
+++ b/spec/unit/plugins/softlayer_spec.rb
@@ -23,7 +23,7 @@ describe Ohai::System, "plugin softlayer" do
   let(:plugin) { get_plugin("softlayer") }
 
   it "not create softlayer if hint file doesn't exists" do
-    allow(@plugin).to receive(:hint?).with("softlayer").and_return(false)
+    allow(plugin).to receive(:hint?).with("softlayer").and_return(false)
     plugin.run
     expect(plugin[:softlayer]).to be_nil
   end


### PR DESCRIPTION
Adds some basic logging to .hint? and breaks up a large method before making it even larger with debug logging.  Also cleanup how we test  use of hints.  We're already testing the Hint class in its own spec.  There's no need to mock out hint files on the filesystem and test it again in each cloud provider. Instead we should just mock the call to the hint? method itself and save some time. While I was in there I cleaned up the specs, improved some wording, and removed a bunch of specs that didn't actually work.