### PR TITLE
Don't execute .so libs for Windows

### DIFF
--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -53,7 +53,7 @@ Ohai.plugin(:C) do
           c[:glibc][:version] = $1
           c[:glibc][:description] = description
         end
-      end unless c[:glibc]
+      end unless c[:glibc] || ::RbConfig::CONFIG["host_os"] =~ /mswin|mingw32|windows/
     end
 
     #ms cl

--- a/spec/unit/plugins/c_spec.rb
+++ b/spec/unit/plugins/c_spec.rb
@@ -153,17 +153,17 @@ describe Ohai::System, "plugin c" do
   end
 
   #glibc
-  it "gets the glibc x.x.x version from running /lib/libc.so.6" do
+  it "gets the glibc x.x.x version from running /lib/libc.so.6", :unix_only do
     expect(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(0, C_GLIBC_2_3_4, ""))
     plugin.run
   end
 
-  it "sets languages[:c][:glibc][:version]" do
+  it "sets languages[:c][:glibc][:version]", :unix_only do
     plugin.run
     expect(plugin.languages[:c][:glibc][:version]).to eql("2.3.4")
   end
 
-  it "sets languages[:c][:glibc][:description]" do
+  it "sets languages[:c][:glibc][:description]", :unix_only do
     plugin.run
     expect(plugin.languages[:c][:glibc][:description]).to eql(C_GLIBC_2_3_4.split($/).first)
   end
@@ -183,7 +183,7 @@ describe Ohai::System, "plugin c" do
     expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
   end
 
-  it "gets the glibc x.x version from running /lib/libc.so.6" do
+  it "gets the glibc x.x version from running /lib/libc.so.6", :unix_only do
     allow(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(0, C_GLIBC_2_5, ""))
     expect(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(0, C_GLIBC_2_5, ""))
     plugin.run


### PR DESCRIPTION
This fixes an issue where evaluating the C plug-in causes Windows to issue spurious DNS calls because the file path can get evaluated as a UNC in some cases.  We should not be trying to shell out and execute .so files in a non-Unix environment.

@chef/client-core 