### PR TITLE
Fix the scala plugin

### DIFF
--- a/lib/ohai/plugins/scala.rb
+++ b/lib/ohai/plugins/scala.rb
@@ -20,24 +20,31 @@ Ohai.plugin(:Scala) do
   depends "languages"
 
   collect_data(:default) do
-    # Check for scala
-    output = nil
-
     scala = Mash.new
-    so = shell_out("scala -version")
-    if so.exitstatus == 0
-      output = so.stdout.split
-      scala[:version] = output[4]
-      languages[:scala] = scala if scala[:version]
+
+    # Check for scala
+    begin
+      # Scala code runner version 2.11.8 -- Copyright 2002-2016, LAMP/EPFL
+      so = shell_out("scala -version")
+      if so.exitstatus == 0
+        scala[:version] = so.stderr.split[4]
+      end
+    rescue Ohai::Exceptions::Exec
+      # ignore shell_out failures
     end
 
     # Check for sbt
-    output = nil
-
-    so = shell_out("sbt --version")
-    if so.exitstatus == 0
-      output = so.stdout.split
-      scala[:sbt] = output[3] if scala[:version]
+    begin
+      # sbt launcher version 0.13.7
+      so = shell_out("sbt --version")
+      if so.exitstatus == 0
+        scala[:sbt] = Mash.new
+        scala[:sbt][:version] = so.stdout.split[3]
+      end
+    rescue Ohai::Exceptions::Exec
+      # ignore shell_out failures
     end
+
+    languages[:scala] = scala unless scala.empty?
   end
 end


### PR DESCRIPTION
There were several problems with the scala plugin:

1) scala -version is returned on stderr not stdout so we were never setting this and thus the plugin never ran

2) If sbt or scala weren't installed it threw exceptions

3) we were storing shell outs return in the output value for no real reason

4) if scala failed for some reason, but sbt succeeded we weren't setting the sbt values since were relied on scala[:version] being set

5) the specs incorrectly mocked scala output to stdout

6) the specs that checked to make sure values weren't set didn't actually run the plugin so they would always no find scala's key

While I was here I moved the version key for sbt into it's own key.  This would allow us to add other sbt values in the future if we found them. If we make version to top level value we lose that ability forever.