### PR TITLE
Fix mono builddate capture and add debug logging

### DIFF
--- a/lib/ohai/plugins/mono.rb
+++ b/lib/ohai/plugins/mono.rb
@@ -37,14 +37,14 @@ Ohai.plugin(:Mono) do
       if so.exitstatus == 0
         mono = Mash.new
         output = so.stdout.split
-        mono[:version] = output[4] if output.length >= 4
-        if output.length >= 11
+        mono[:version] = output[4] unless output[4].nil?
+        if output.length >= 12
           mono[:builddate] = "%s %s %s %s %s %s" % [output[7], output[8], output[9], output[10], output[11], output[12].delete!(")")]
         end
         languages[:mono] = mono unless mono.empty?
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Mono plugin: Could not shell_out "mono -v". Skipping plugin')
+      Ohai::Log.debug('Mono plugin: Could not shell_out "mono -V". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/mono.rb
+++ b/lib/ohai/plugins/mono.rb
@@ -18,24 +18,29 @@
 
 Ohai.plugin(:Mono) do
   provides "languages/mono"
-
   depends "languages"
 
   collect_data do
-    output = nil
-
-    mono = Mash.new
-
+    # Mono JIT compiler version 4.2.3 (Stable 4.2.3.4/832de4b Wed Mar 30 13:57:48 PDT 2016)
+    # Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
+    # 	TLS:           normal
+    # 	SIGSEGV:       altstack
+    # 	Notification:  kqueue
+    # 	Architecture:  amd64
+    # 	Disabled:      none
+    # 	Misc:          softdebug
+    # 	LLVM:          supported, not enabled.
+    # 	GC:            sgen
     so = shell_out("mono -V")
     if so.exitstatus == 0
+      output = nil
+      mono = Mash.new
       output = so.stdout.split
-      if output.length >= 4
-        mono[:version] = output[4]
-      end
+      mono[:version] = output[4] if output.length >= 4
       if output.length >= 11
-        mono[:builddate] = "%s %s %s %s" % [output[6], output[7], output[8], output[11].delete!(")")]
+        mono[:builddate] = "%s %s %s %s %s %s" % [output[7], output[8], output[9], output[10], output[11], output[12].delete!(")")]
       end
-      languages[:mono] = mono if mono[:version]
+      languages[:mono] = mono unless mono.empty?
     end
   end
 end

--- a/lib/ohai/plugins/mono.rb
+++ b/lib/ohai/plugins/mono.rb
@@ -21,26 +21,30 @@ Ohai.plugin(:Mono) do
   depends "languages"
 
   collect_data do
-    # Mono JIT compiler version 4.2.3 (Stable 4.2.3.4/832de4b Wed Mar 30 13:57:48 PDT 2016)
-    # Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
-    # 	TLS:           normal
-    # 	SIGSEGV:       altstack
-    # 	Notification:  kqueue
-    # 	Architecture:  amd64
-    # 	Disabled:      none
-    # 	Misc:          softdebug
-    # 	LLVM:          supported, not enabled.
-    # 	GC:            sgen
-    so = shell_out("mono -V")
-    if so.exitstatus == 0
-      output = nil
-      mono = Mash.new
-      output = so.stdout.split
-      mono[:version] = output[4] if output.length >= 4
-      if output.length >= 11
-        mono[:builddate] = "%s %s %s %s %s %s" % [output[7], output[8], output[9], output[10], output[11], output[12].delete!(")")]
+
+    begin
+      # Mono JIT compiler version 4.2.3 (Stable 4.2.3.4/832de4b Wed Mar 30 13:57:48 PDT 2016)
+      # Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
+      # 	TLS:           normal
+      # 	SIGSEGV:       altstack
+      # 	Notification:  kqueue
+      # 	Architecture:  amd64
+      # 	Disabled:      none
+      # 	Misc:          softdebug
+      # 	LLVM:          supported, not enabled.
+      # 	GC:            sgen
+      so = shell_out("mono -V")
+      if so.exitstatus == 0
+        mono = Mash.new
+        output = so.stdout.split
+        mono[:version] = output[4] if output.length >= 4
+        if output.length >= 11
+          mono[:builddate] = "%s %s %s %s %s %s" % [output[7], output[8], output[9], output[10], output[11], output[12].delete!(")")]
+        end
+        languages[:mono] = mono unless mono.empty?
       end
-      languages[:mono] = mono unless mono.empty?
+    rescue Ohai::Exceptions::Exec
+      Ohai::Log.debug('Mono plugin: Could not shell_out "mono -v". Skipping plugin')
     end
   end
 end

--- a/spec/unit/plugins/mono_spec.rb
+++ b/spec/unit/plugins/mono_spec.rb
@@ -19,29 +19,44 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
 
 describe Ohai::System, "plugin mono" do
+  let(:plugin) { get_plugin("mono") }
 
   before(:each) do
-    @plugin = get_plugin("mono")
-    @plugin[:languages] = Mash.new
-    @stdout = "Mono JIT compiler version 1.2.6 (tarball)\nCopyright (C) 2002-2007 Novell, Inc and Contributors. www.mono-project.com\n"
-    allow(@plugin).to receive(:shell_out).with("mono -V").and_return(mock_shell_out(0, @stdout, ""))
+    plugin[:languages] = Mash.new
+    @stdout = <<-OUT
+Mono JIT compiler version 4.2.3 (Stable 4.2.3.4/832de4b Wed Mar 30 13:57:48 PDT 2016)
+Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
+	TLS:           normal
+	SIGSEGV:       altstack
+	Notification:  kqueue
+	Architecture:  amd64
+	Disabled:      none
+	Misc:          softdebug
+	LLVM:          supported, not enabled.
+	GC:            sgen
+OUT
+    allow(plugin).to receive(:shell_out).with("mono -V").and_return(mock_shell_out(0, @stdout, ""))
   end
 
   it "should get the mono version from running mono -V" do
-    expect(@plugin).to receive(:shell_out).with("mono -V").and_return(mock_shell_out(0, @stdout, ""))
-    @plugin.run
+    expect(plugin).to receive(:shell_out).with("mono -V").and_return(mock_shell_out(0, @stdout, ""))
+    plugin.run
   end
 
   it "should set languages[:mono][:version]" do
-    @plugin.run
-    expect(@plugin.languages[:mono][:version]).to eql("1.2.6")
+    plugin.run
+    expect(plugin.languages[:mono][:version]).to eql("4.2.3")
+  end
+
+  it "should set languages[:mono][:builddate]" do
+    plugin.run
+    expect(plugin.languages[:mono][:builddate]).to eql("Wed Mar 30 13:57:48 PDT 2016")
   end
 
   it "should not set the languages[:mono] tree up if mono command fails" do
-    @stdout = "Mono JIT compiler version 1.2.6 (tarball)\nCopyright (C) 2002-2007 Novell, Inc and Contributors. www.mono-project.com\n"
-    allow(@plugin).to receive(:shell_out).with("mono -V").and_return(mock_shell_out(1, @stdout, ""))
-    @plugin.run
-    expect(@plugin.languages).not_to have_key(:mono)
+    allow(plugin).to receive(:shell_out).with("mono -V").and_return(mock_shell_out(1, @stdout, ""))
+    plugin.run
+    expect(plugin.languages).not_to have_key(:mono)
   end
 
 end


### PR DESCRIPTION
We weren't capturing the builddate right based on the latest output.  I don't have an example of the old output to know if something changed or if this ever worked right.  We didn't have specs that included the data or a check for the attribute.  Those are added now.