### PR TITLE
Correct the version detection in erlang plugin

### DIFF
--- a/lib/ohai/plugins/erlang.rb
+++ b/lib/ohai/plugins/erlang.rb
@@ -18,26 +18,44 @@
 
 Ohai.plugin(:Erlang) do
   provides "languages/erlang"
-
   depends "languages"
 
   collect_data do
-    output = nil
-
     erlang = Mash.new
-    so = shell_out("erl +V")
-    if so.exitstatus == 0
-      output = so.stderr.split
-      if output.length >= 6
-        options = output[1]
-        options.gsub!(/(\(|\))/, "")
-        erlang[:version] = output[5]
-        erlang[:options] = options.split(",")
-        erlang[:emulator] = output[2].gsub!(/(\(|\))/, "")
-        if erlang[:version] && erlang[:options] && erlang[:emulator]
-          languages[:erlang] = erlang
+
+    begin
+      so = shell_out("erl -eval 'erlang:display(erlang:system_info(otp_release)), erlang:display(erlang:system_info(version)), erlang:display(erlang:system_info(nif_version)), halt().'  -noshell")
+      # Sample output:
+      # "18"
+      # "7.3"
+      # "2.10"
+      if so.exitstatus == 0
+        output = so.stdout.split(/\r\n/).map! { |x| x.delete('\\"') }
+        erlang[:version] = output[0]
+        erlang[:erts_version] = output[1]
+        erlang[:nif_version] = output[2]
+      end
+    rescue Ohai::Exceptions::Exec
+      Ohai::Log.debug('Erlang plugin: Could not shell_out "erl -eval \'erlang:display(erlang:system_info(otp_release)), erlang:display(erlang:system_info(version)), erlang:display(erlang:system_info(nif_version)), halt().\'  -noshell". Skipping data')
+    end
+
+    begin
+      so = shell_out("erl +V")
+      # Sample output:
+      # Erlang (SMP,ASYNC_THREADS,HIPE) (BEAM) emulator version 7.3
+      if so.exitstatus == 0
+        output = so.stderr.split
+        if output.length >= 6
+          options = output[1]
+          options.gsub!(/(\(|\))/, "")
+          erlang[:options] = options.split(",")
+          erlang[:emulator] = output[2].gsub!(/(\(|\))/, "")
         end
       end
+    rescue Ohai::Exceptions::Exec
+      Ohai::Log.debug('Erlang plugin: Could not shell_out "erl +V". Skipping data')
     end
+
+    languages[:erlang] = erlang unless erlang.empty?
   end
 end


### PR DESCRIPTION
We weren't correctly identifying the erlang version.  Instead we were detecting the erts version.

Old result:
```javascript
    "erlang": {
      "version": "7.3",
      "options": [
        "SMP",
        "ASYNC_THREADS",
        "HIPE"
      ],
      "emulator": "BEAM"
    },
```

New result
```javascript
    "erlang": {
      "version": "18",
      "erts_version": "7.3",
      "nif_version": "2.10",
      "options": [
        "SMP",
        "ASYNC_THREADS",
        "HIPE"
      ],
      "emulator": "BEAM"
    },
```