### PR TITLE
Fix Elixir version detection on newer Elixir releases

### DIFF
--- a/lib/ohai/plugins/elixir.rb
+++ b/lib/ohai/plugins/elixir.rb
@@ -15,18 +15,24 @@
 
 Ohai.plugin(:Elixir) do
   provides "languages/elixir"
-
   depends "languages"
 
   collect_data do
-    output = nil
-
-    elixir = Mash.new
-    so = shell_out("elixir -v")
-    if so.exitstatus == 0
-      output = so.stdout.split
-      elixir[:version] = output[1]
-      languages[:elixir] = elixir if elixir[:version]
+    begin
+      so = shell_out("elixir -v")
+      # Sample output:
+      # Erlang/OTP 18 [erts-7.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
+      #
+      # Elixir 1.2.4
+      if so.exitstatus == 0
+        elixir = Mash.new
+        if so.stdout =~ /^Elixir (\S*)/
+          elixir[:version] = $1
+          languages[:elixir] = elixir
+        end
+      end
+    rescue Ohai::Exceptions::Exec
+      Ohai::Log.debug('Elixir plugin: Could not shell_out "elixir -v". Skipping plugin')
     end
   end
 end

--- a/spec/unit/plugins/elixir_spec.rb
+++ b/spec/unit/plugins/elixir_spec.rb
@@ -17,29 +17,39 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
 
 describe Ohai::System, "plugin elixir" do
+  let(:plugin) { get_plugin("elixir") }
 
   before(:each) do
-    @plugin = get_plugin("elixir")
-    @plugin[:languages] = Mash.new
-    @stdout = "Elixir 1.0.2"
-    allow(@plugin).to receive(:shell_out).with("elixir -v").and_return(mock_shell_out(0, @stdout, ""))
+    plugin[:languages] = Mash.new
   end
 
-  it "should get the elixir version" do
-    expect(@plugin).to receive(:shell_out).with("elixir -v").and_return(mock_shell_out(0, @stdout, ""))
-    @plugin.run
+  it "should shellout to elixir -v" do
+    expect(plugin).to receive(:shell_out).with("elixir -v").and_return(mock_shell_out(0, "Elixir 1.0.2", ""))
+    plugin.run
   end
 
-  it "should set languages[:elixir][:version]" do
-    @plugin.run
-    expect(@plugin.languages[:elixir][:version]).to eql("1.0.2")
+  it "sets languages[:elixir][:version] on older elixir" do
+    allow(plugin).to receive(:shell_out).with("elixir -v").and_return(mock_shell_out(0, "Elixir 1.0.2", ""))
+    plugin.run
+    expect(plugin.languages[:elixir][:version]).to eql("1.0.2")
   end
 
-  it "should not set the languages[:elixir] if elixir command fails" do
-    @stdout = "Elixir 1.0.2\n"
-    allow(@plugin).to receive(:shell_out).with("elixir -v").and_return(mock_shell_out(1, @stdout, ""))
-    @plugin.run
-    expect(@plugin.languages).not_to have_key(:elixir)
+  it "sets languages[:elixir][:version] on newer elixir" do
+    new_stdout = "Erlang/OTP 18 [erts-7.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]\n\nElixir 1.2.4\n"
+    allow(plugin).to receive(:shell_out).with("elixir -v").and_return(mock_shell_out(0, new_stdout, ""))
+    plugin.run
+    expect(plugin.languages[:elixir][:version]).to eql("1.2.4")
   end
 
+  it "does not set languages[:elixir] if elixir command fails" do
+    allow(plugin).to receive(:shell_out).with("elixir -v").and_return(mock_shell_out(1, "", ""))
+    plugin.run
+    expect(plugin.languages).not_to have_key(:elixir)
+  end
+
+  it "does not set languages[:elixir] if elixir command doesn't exist" do
+    allow(plugin).to receive(:shell_out).and_raise(Ohai::Exceptions::Exec)
+    plugin.run
+    expect(plugin.languages).not_to have_key(:elixir)
+  end
 end


### PR DESCRIPTION
Add specs for the new format + error logging + general fixes

Old output that incorrectly identifies the Erlang version as the Elixir version:
```javascript
  "languages": {
    "elixir": {
      "version": "18"
    },
```

New correct output:
```javascript
  "languages": {
    "elixir": {
      "version": "1.2.4"
    },
```