### PR TITLE
Avoid defining WINDOWS_ATTRIBUTE_ALIASES multiple times

### DIFF
--- a/lib/ohai/plugins/packages.rb
+++ b/lib/ohai/plugins/packages.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Packages) do
     "DisplayVersion" => "version",
     "Publisher" => "publisher",
     "InstallDate" => "installdate",
-  }
+  } unless defined?(WINDOWS_ATTRIBUTE_ALIASES)
 
   collect_data(:linux) do
     packages Mash.new


### PR DESCRIPTION
This has the added benefit of preventing a very very very very large number of warnings in test output once https://github.com/chef/chef/pull/4841 is merged. So we'll need to do a patch release.