### PR TITLE
Extra debug logging and error handling in plugin loading

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -33,7 +33,7 @@ class Ohai::Application
   option :directory,
     :short       => "-d DIRECTORY",
     :long        => "--directory DIRECTORY",
-    :description => "A directory to add to the Ohai search path",
+    :description => "A directory to add to the Ohai plugin search path",
     :proc        => lambda { |path| Ohai::Config.platform_specific_path(path) }
 
   option :log_level,

--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -39,6 +39,7 @@ module Ohai
 
       # Finds all the *.rb files under the configured paths in :plugin_path
       def self.find_all_in(plugin_dir)
+        Ohai::Log.debug("Searching for Ohai plugins in #{plugin_dir}")
         # escape_glob_dir does not exist in 12.7 or below
         if ChefConfig::PathHelper.respond_to?(:escape_glob_dir)
           escaped = ChefConfig::PathHelper.escape_glob_dir(plugin_dir)
@@ -105,6 +106,7 @@ module Ohai
       # Read the contents of the plugin to understand if it's a V6 or V7 plugin.
       contents = ""
       begin
+        Ohai::Log.debug("Loading plugin at #{plugin_path}")
         contents << IO.read(plugin_path)
       rescue IOError, Errno::ENOENT
         Ohai::Log.warn("Unable to open or read plugin at #{plugin_path}")

--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -39,7 +39,13 @@ module Ohai
 
       # Finds all the *.rb files under the configured paths in :plugin_path
       def self.find_all_in(plugin_dir)
+        unless Dir.exist?(plugin_dir)
+          Ohai::Log.warn("The plugin path #{plugin_dir} does not exist. Skipping...")
+          return []
+        end
+
         Ohai::Log.debug("Searching for Ohai plugins in #{plugin_dir}")
+
         # escape_glob_dir does not exist in 12.7 or below
         if ChefConfig::PathHelper.respond_to?(:escape_glob_dir)
           escaped = ChefConfig::PathHelper.escape_glob_dir(plugin_dir)

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -215,6 +215,8 @@ module Ohai
           !Ohai.config[:plugin_path].include?(Ohai.config[:directory])
         Ohai.config[:plugin_path] << Ohai.config[:directory]
       end
+
+      Ohai::Log.debug("Running Ohai with the following configuration: #{Ohai.config.configuration}")
     end
 
     def configure_logging

--- a/spec/unit/dsl/plugin_spec.rb
+++ b/spec/unit/dsl/plugin_spec.rb
@@ -587,6 +587,7 @@ describe Ohai::DSL::Plugin::VersionVI do
     let(:ohai) { Ohai::System.new }
 
     it "logs a debug message when provides is used" do
+      allow(Ohai::Log).to receive(:debug)
       expect(Ohai::Log).to receive(:debug).with(/Skipping provides/)
       plugin = Ohai::DSL::Plugin::VersionVI.new(ohai, "/some/plugin/path.rb", "/some/plugin")
       plugin.provides("attribute")

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -219,6 +219,14 @@ EOF
           expect { loader.load_plugin(path_to("bad_name.rb")) }.not_to raise_error
         end
       end
+
+      describe "when plugin directory does not exist" do
+        it "logs an invalid plugin path warning" do
+          expect(Ohai::Log).to receive(:warn).with(/The plugin path.*does not exist/)
+          allow(Dir).to receive(:exist?).with("/bogus/dir").and_return(false)
+          Ohai::Loader::PluginFile.find_all_in("/bogus/dir")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Pretty simple stuff here. Add the plugin paths and the discovered plugins to debug logging. Add the config too so you can see where we're getting the paths from.  Then if you pass in a bogus dir make sure we warn instead of silently continuing like we do now.