### PR TITLE
Prevent parallels spec from checking the filesystem

### DIFF
--- a/spec/unit/plugins/darwin/virtualization_spec.rb
+++ b/spec/unit/plugins/darwin/virtualization_spec.rb
@@ -24,6 +24,7 @@ describe Ohai::System, "Darwin virtualization platform" do
   before(:each) do
     allow(plugin).to receive(:collect_os).and_return(:darwin)
     allow(plugin).to receive(:prlctl_exists?).and_return(false)
+    allow(plugin).to receive(:ioreg_exists?).and_return(false)
   end
 
   describe "when we are checking for parallels" do


### PR DESCRIPTION
This spec was taking 1.8 secs since it was looking for this binary in
all the specs.  Now it takes .282 secs.