### PR TITLE
Adding version for linux module when avalaible

### DIFF
--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -117,6 +117,11 @@ Ohai.plugin(:Kernel) do
     so.stdout.lines do |line|
       if line =~ /([a-zA-Z0-9\_]+)\s+(\d+)\s+(\d+)/
         modules[$1] = { :size => $2, :refcount => $3 }
+        # Making sure to get the module version that has been loaded
+        if File.exist?("/sys/module/#{$1}/version")
+          version = File.read("/sys/module/#{$1}/version").chomp.strip
+          modules[$1]["version"] = version unless version.empty?
+        end
       end
     end
 


### PR DESCRIPTION
Hi,

I wonder if getting the module version for linux in the 'kernel.modules' could be possible?

I have created the Pull Request to get those.

Let me know if it is good feature or not.

Regards,
JM