### PR TITLE
Properly poll Openstack detection + other Openstack improvements

### DIFF
--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -189,7 +189,7 @@ Ohai.plugin(:Cloud) do
     cloud[:public_hostname] = openstack["public_hostname"]
     cloud[:local_ipv4] = openstack["local_ipv4"]
     cloud[:local_hostname] = openstack["local_hostname"]
-    cloud[:provider] = "openstack"
+    cloud[:provider] = openstack["provider"]
   end
 
   # ----------------------------------------

--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -183,12 +183,12 @@ Ohai.plugin(:Cloud) do
 
   # Fill cloud hash with openstack values
   def get_openstack_values
-    cloud[:public_ips] << openstack["metadata"]["public_ipv4"]
-    cloud[:private_ips] << openstack["metadata"]["local_ipv4"]
-    cloud[:public_ipv4] = openstack["metadata"]["public_ipv4"]
-    cloud[:public_hostname] = openstack["metadata"]["public_hostname"]
-    cloud[:local_ipv4] = openstack["metadata"]["local_ipv4"]
-    cloud[:local_hostname] = openstack["metadata"]["local_hostname"]
+    cloud[:public_ips] << openstack["public_ipv4"]
+    cloud[:private_ips] << openstack["local_ipv4"]
+    cloud[:public_ipv4] = openstack["public_ipv4"]
+    cloud[:public_hostname] = openstack["public_hostname"]
+    cloud[:local_ipv4] = openstack["local_ipv4"]
+    cloud[:local_hostname] = openstack["local_hostname"]
     cloud[:provider] = "openstack"
   end
 

--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -183,13 +183,13 @@ Ohai.plugin(:Cloud) do
 
   # Fill cloud hash with openstack values
   def get_openstack_values
-    cloud[:public_ips] << openstack["public_ipv4"]
-    cloud[:private_ips] << openstack["local_ipv4"]
-    cloud[:public_ipv4] = openstack["public_ipv4"]
-    cloud[:public_hostname] = openstack["public_hostname"]
-    cloud[:local_ipv4] = openstack["local_ipv4"]
-    cloud[:local_hostname] = openstack["local_hostname"]
-    cloud[:provider] = openstack["provider"]
+    cloud[:public_ips] << openstack["metadata"]["public_ipv4"]
+    cloud[:private_ips] << openstack["metadata"]["local_ipv4"]
+    cloud[:public_ipv4] = openstack["metadata"]["public_ipv4"]
+    cloud[:public_hostname] = openstack["metadata"]["public_hostname"]
+    cloud[:local_ipv4] = openstack["metadata"]["local_ipv4"]
+    cloud[:local_hostname] = openstack["metadata"]["local_hostname"]
+    cloud[:provider] = "openstack"
   end
 
   # ----------------------------------------

--- a/lib/ohai/plugins/cloud_v2.rb
+++ b/lib/ohai/plugins/cloud_v2.rb
@@ -246,7 +246,7 @@ Ohai.plugin(:CloudV2) do
     @cloud_attr_obj.add_ipv4_addr(openstack["local_ipv4"], :private)
     @cloud_attr_obj.public_hostname = openstack["public_hostname"]
     @cloud_attr_obj.local_hostname = openstack["local_hostname"]
-    @cloud_attr_obj.provider = "openstack"
+    @cloud_attr_obj.provider = openstack["provider"]
   end
 
   # ----------------------------------------

--- a/lib/ohai/plugins/cloud_v2.rb
+++ b/lib/ohai/plugins/cloud_v2.rb
@@ -242,10 +242,10 @@ Ohai.plugin(:CloudV2) do
 
   # Fill cloud hash with openstack values
   def get_openstack_values
-    @cloud_attr_obj.add_ipv4_addr(openstack["public_ipv4"], :public)
-    @cloud_attr_obj.add_ipv4_addr(openstack["local_ipv4"], :private)
-    @cloud_attr_obj.public_hostname = openstack["public_hostname"]
-    @cloud_attr_obj.local_hostname = openstack["local_hostname"]
+    @cloud_attr_obj.add_ipv4_addr(openstack["metadata"]["public_ipv4"], :public)
+    @cloud_attr_obj.add_ipv4_addr(openstack["metadata"]["local_ipv4"], :private)
+    @cloud_attr_obj.public_hostname = openstack["metadata"]["public_hostname"]
+    @cloud_attr_obj.local_hostname = openstack["metadata"]["local_hostname"]
     @cloud_attr_obj.provider = "openstack"
   end
 

--- a/lib/ohai/plugins/cloud_v2.rb
+++ b/lib/ohai/plugins/cloud_v2.rb
@@ -242,10 +242,10 @@ Ohai.plugin(:CloudV2) do
 
   # Fill cloud hash with openstack values
   def get_openstack_values
-    @cloud_attr_obj.add_ipv4_addr(openstack["metadata"]["public_ipv4"], :public)
-    @cloud_attr_obj.add_ipv4_addr(openstack["metadata"]["local_ipv4"], :private)
-    @cloud_attr_obj.public_hostname = openstack["metadata"]["public_hostname"]
-    @cloud_attr_obj.local_hostname = openstack["metadata"]["local_hostname"]
+    @cloud_attr_obj.add_ipv4_addr(openstack["public_ipv4"], :public)
+    @cloud_attr_obj.add_ipv4_addr(openstack["local_ipv4"], :private)
+    @cloud_attr_obj.public_hostname = openstack["public_hostname"]
+    @cloud_attr_obj.local_hostname = openstack["local_hostname"]
     @cloud_attr_obj.provider = "openstack"
   end
 

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -49,17 +49,16 @@ Ohai.plugin(:Openstack) do
 
   # grab metadata and return a mash. if we can't connect return nil
   def openstack_metadata
+    metadata = Mash.new
     if can_metadata_connect?("169.254.169.254", 80)
-      metadata = Mash.new
       fetch_metadata.each do |k, v|
         metadata[k] = v
       end
       Ohai::Log.debug("Plugin Openstack: Successfully fetched Openstack metadata from the metadata endpoint")
-      metadata
     else
       Ohai::Log.debug("Plugin Openstack: Timed out connecting to Openstack metadata endpoint. Skipping metadata.")
-      nil
     end
+    metadata
   end
 
   collect_data do

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -65,7 +65,7 @@ Ohai.plugin(:Openstack) do
       openstack[:provider] = openstack_provider
 
       # fetch the metadata if we can do a simple socket connect first
-      if can_metadata_connect?("169.254.169.254", 80)
+      if can_metadata_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
         fetch_metadata.each do |k, v|
           openstack[k] = v
         end

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -57,7 +57,7 @@ Ohai.plugin(:Openstack) do
       Ohai::Log.debug("Plugin Openstack: Successfully fetched Openstack metadata from the metadata endpoint")
       metadata
     else
-      Ohai::Log.warn("Plugin Openstack: Timed out connecting to Openstack metadata endpoint. Skipping metadata.")
+      Ohai::Log.debug("Plugin Openstack: Timed out connecting to Openstack metadata endpoint. Skipping metadata.")
       nil
     end
   end

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -23,6 +23,7 @@ Ohai.plugin(:Openstack) do
 
   provides "openstack"
   depends "dmi"
+  depends "etc"
 
   # do we have the openstack dmi data
   def openstack_dmi?
@@ -47,6 +48,16 @@ Ohai.plugin(:Openstack) do
     end
   end
 
+  # dreamhost systems hae the dhc-user on them
+  def openstack_provider
+    begin
+      return "dreamhost" if etc["passwd"]["dhc-user"]
+    rescue NoMethodError
+      # handle etc not existing on non-linux systems
+    end
+    return "openstack"
+  end
+
   # grab metadata and return a mash. if we can't connect return nil
   def openstack_metadata
     metadata = Mash.new
@@ -65,7 +76,7 @@ Ohai.plugin(:Openstack) do
     # fetch data if we look like openstack
     if openstack_hint? || openstack_dmi?
       openstack Mash.new
-      openstack[:provider] = "openstack" # for now this is our only provider
+      openstack[:provider] = openstack_provider
       openstack[:metadata] = openstack_metadata # fetch metadata or set this to nil
     else
       Ohai::Log.debug("Plugin Openstack: Node does not appear to be an Openstack node")

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -48,7 +48,7 @@ Ohai.plugin(:Openstack) do
     end
   end
 
-  # dreamhost systems hae the dhc-user on them
+  # dreamhost systems have the dhc-user on them
   def openstack_provider
     begin
       return "dreamhost" if etc["passwd"]["dhc-user"]

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -21,45 +21,56 @@ require "ohai/plugins/openstack"
 
 describe "OpenStack Plugin" do
 
-  let(:openstack_hint) { false }
-  let(:hp_hint) { false }
+  let(:plugin) { get_plugin("openstack") }
 
-  let(:ohai_system) { Ohai::System.new }
-  let(:ohai_data) { ohai_system.data }
-
-  let(:openstack_plugin) do
-    plugin = get_plugin("openstack", ohai_system)
-    allow(plugin).to receive(:hint?).with("openstack").and_return(openstack_hint)
-    allow(plugin).to receive(:hint?).with("hp").and_return(hp_hint)
-    plugin
+  before(:each) do
+    allow(plugin).to receive(:hint?).with("openstack").and_return(false)
+    plugin[:dmi] = nil
   end
 
-  before do
-  end
-
-  context "when there is no relevant hint" do
-
+  context "when there is no relevant hint or dmi data" do
     it "does not set any openstack data" do
-      openstack_plugin.run
-      expect(ohai_data).to_not have_key("openstack")
+      plugin.run
+      expect(plugin[:openstack]).to be_nil
     end
-
   end
 
-  context "when there is an `openstack` hint" do
-    let(:openstack_hint) { true }
-
+  context "when DMI data is Openstack" do
     context "and the metadata service is not available" do
-
       before do
-        expect(openstack_plugin).to receive(:can_metadata_connect?).
+        allow(plugin).to receive(:can_metadata_connect?).
           with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80).
           and_return(false)
+        plugin[:dmi] = { :system => { :all_records => [ { :Manufacturer => "OpenStack Foundation" } ] } }
+        plugin.run
       end
 
-      it "does not set any openstack data" do
-        openstack_plugin.run
-        expect(ohai_data).to_not have_key("openstack")
+      it "sets openstack provider attribute if the hint is provided" do
+        expect(plugin[:openstack][:provider]).to eq("openstack")
+      end
+
+      it "sets the metadata attribute to nil" do
+        expect(plugin[:openstack][:metadata]).to be_nil
+      end
+    end
+  end
+
+  context "when the hint is present" do
+    context "and the metadata service is not available" do
+      before do
+        allow(plugin).to receive(:can_metadata_connect?).
+          with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80).
+          and_return(false)
+        allow(plugin).to receive(:hint?).with("openstack").and_return(true)
+        plugin.run
+      end
+
+      it "sets openstack provider attribute if the hint is provided" do
+        expect(plugin[:openstack][:provider]).to eq("openstack")
+      end
+
+      it "sets the metadata attribute to nil" do
+        expect(plugin[:openstack][:metadata]).to be_nil
       end
     end
 
@@ -118,8 +129,8 @@ EOM
         }
       end
 
-      let(:openstack_metadata_version) { "2013-04-04" }
-      let(:openstack_metadata_endpoint) { "http://169.254.169.254/openstack/" }
+      let(:openstack_metadata_version) { "2009-04-04" }
+      let(:openstack_metadata_endpoint) { "http://169.254.169.254/" }
 
       let(:openstack_metadata_values) do
         '{
@@ -140,20 +151,21 @@ EOM
 
       let(:http_client) { double("Net::HTTP", :read_timeout= => nil) }
 
-      def expect_get(url, response_body)
-        expect(http_client).to receive(:get).
+      def allow_get(url, response_body)
+        allow(http_client).to receive(:get).
           with(url).
           and_return(double("HTTP Response", :code => "200", :body => response_body))
       end
 
-      def expect_get_response(url, response_body)
-        expect(http_client).to receive(:get_response).
+      def allow_get_response(url, response_body)
+        allow(http_client).to receive(:get_response).
           with(url, nil, nil).
           and_return(double("HTTP Response", :code => "200", :body => response_body))
       end
 
       before do
-        expect(openstack_plugin).to receive(:can_metadata_connect?).
+        allow(plugin).to receive(:hint?).with("openstack").and_return(true)
+        allow(plugin).to receive(:can_metadata_connect?).
           with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80).
           and_return(true)
 
@@ -161,107 +173,84 @@ EOM
           with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR).
           and_return(http_client)
 
-        allow(openstack_plugin).to receive(:best_api_version).and_return(metadata_version)
+        allow(plugin).to receive(:best_api_version).and_return(metadata_version)
 
-        expect_get("/#{metadata_version}/meta-data/", metadata_root)
+        allow_get("/#{metadata_version}/meta-data/", metadata_root)
 
         metadata_values.each do |md_id, md_value|
-          expect_get("/#{metadata_version}/meta-data/#{md_id}", md_value)
+          allow_get("/#{metadata_version}/meta-data/#{md_id}", md_value)
         end
 
-        expect_get_response(
+        allow_get_response(
           URI.parse("#{openstack_metadata_endpoint}#{openstack_metadata_version}/meta_data.json"),
           openstack_metadata_values
         )
-
-        openstack_plugin.run
+        plugin.run
       end
 
       it "reads the reservation_id from the metadata service" do
-        expect(ohai_data["openstack"]["reservation_id"]).to eq("r-4tjvl99h")
+        expect(plugin["openstack"]["metadata"]["reservation_id"]).to eq("r-4tjvl99h")
       end
       it "reads the public_keys_0_openssh_key from the metadata service" do
-        expect(ohai_data["openstack"]["public_keys_0_openssh_key"]).to eq("SSH KEY DATA")
+        expect(plugin["openstack"]["metadata"]["public_keys_0_openssh_key"]).to eq("SSH KEY DATA")
       end
       it "reads the security_groups from the metadata service" do
-        expect(ohai_data["openstack"]["security_groups"]).to eq(["default"])
+        expect(plugin["openstack"]["metadata"]["security_groups"]).to eq(["default"])
       end
       it "reads the public_ipv4 from the metadata service" do
-        expect(ohai_data["openstack"]["public_ipv4"]).to eq("")
+        expect(plugin["openstack"]["metadata"]["public_ipv4"]).to eq("")
       end
       it "reads the ami_manifest_path from the metadata service" do
-        expect(ohai_data["openstack"]["ami_manifest_path"]).to eq("FIXME")
+        expect(plugin["openstack"]["metadata"]["ami_manifest_path"]).to eq("FIXME")
       end
       it "reads the instance_type from the metadata service" do
-        expect(ohai_data["openstack"]["instance_type"]).to eq("opc-tester")
+        expect(plugin["openstack"]["metadata"]["instance_type"]).to eq("opc-tester")
       end
       it "reads the instance_id from the metadata service" do
-        expect(ohai_data["openstack"]["instance_id"]).to eq("i-0000162a")
+        expect(plugin["openstack"]["metadata"]["instance_id"]).to eq("i-0000162a")
       end
       it "reads the local_ipv4 from the metadata service" do
-        expect(ohai_data["openstack"]["local_ipv4"]).to eq("172.31.7.23")
+        expect(plugin["openstack"]["metadata"]["local_ipv4"]).to eq("172.31.7.23")
       end
       it "reads the ari_id from the metadata service" do
-        expect(ohai_data["openstack"]["ari_id"]).to eq("ari-00000037")
+        expect(plugin["openstack"]["metadata"]["ari_id"]).to eq("ari-00000037")
       end
       it "reads the local_hostname from the metadata service" do
-        expect(ohai_data["openstack"]["local_hostname"]).to eq("ohai-7-system-test.opscode.us")
+        expect(plugin["openstack"]["metadata"]["local_hostname"]).to eq("ohai-7-system-test.opscode.us")
       end
       it "reads the placement_availability_zone from the metadata service" do
-        expect(ohai_data["openstack"]["placement_availability_zone"]).to eq("nova")
+        expect(plugin["openstack"]["metadata"]["placement_availability_zone"]).to eq("nova")
       end
       it "reads the ami_launch_index from the metadata service" do
-        expect(ohai_data["openstack"]["ami_launch_index"]).to eq("0")
+        expect(plugin["openstack"]["metadata"]["ami_launch_index"]).to eq("0")
       end
       it "reads the public_hostname from the metadata service" do
-        expect(ohai_data["openstack"]["public_hostname"]).to eq("ohai-7-system-test.opscode.us")
+        expect(plugin["openstack"]["metadata"]["public_hostname"]).to eq("ohai-7-system-test.opscode.us")
       end
       it "reads the hostname from the metadata service" do
-        expect(ohai_data["openstack"]["hostname"]).to eq("ohai-7-system-test.opscode.us")
+        expect(plugin["openstack"]["metadata"]["hostname"]).to eq("ohai-7-system-test.opscode.us")
       end
       it "reads the ami_id from the metadata service" do
-        expect(ohai_data["openstack"]["ami_id"]).to eq("ami-00000035")
+        expect(plugin["openstack"]["metadata"]["ami_id"]).to eq("ami-00000035")
       end
       it "reads the instance_action from the metadata service" do
-        expect(ohai_data["openstack"]["instance_action"]).to eq("none")
+        expect(plugin["openstack"]["metadata"]["instance_action"]).to eq("none")
       end
       it "reads the aki_id from the metadata service" do
-        expect(ohai_data["openstack"]["aki_id"]).to eq("aki-00000036")
+        expect(plugin["openstack"]["metadata"]["aki_id"]).to eq("aki-00000036")
       end
       it "reads the block_device_mapping_ami from the metadata service" do
-        expect(ohai_data["openstack"]["block_device_mapping_ami"]).to eq("vda")
+        expect(plugin["openstack"]["metadata"]["block_device_mapping_ami"]).to eq("vda")
       end
       it "reads the block_device_mapping_root from the metadata service" do
-        expect(ohai_data["openstack"]["block_device_mapping_root"]).to eq("/dev/vda")
+        expect(plugin["openstack"]["metadata"]["block_device_mapping_root"]).to eq("/dev/vda")
       end
-      it "reads the provider from the metadata service" do
-        expect(ohai_data["openstack"]["provider"]).to eq("openstack")
+      it "sets the provider to openstack" do
+        expect(plugin["openstack"]["provider"]).to eq("openstack")
       end
-
-      context "Retreive openStack specific metadata" do
-        it "reads the availability_zone from the openstack metadata service" do
-          expect(ohai_data["openstack"]["metadata"]["availability_zone"]).to eq("nova")
-        end
-        it "reads the hostname from the openstack metadata service" do
-          expect(ohai_data["openstack"]["metadata"]["hostname"]).to eq("ohai.novalocal")
-        end
-        it "reads the launch_index from the openstack metadata service" do
-          expect(ohai_data["openstack"]["metadata"]["launch_index"]).to eq(0)
-        end
-        it "reads the meta from the openstack metadata service" do
-          expect(ohai_data["openstack"]["metadata"]["meta"]).to eq({ "priority" => "low", "role" => "ohaiserver" })
-        end
-        it "reads the name from the openstack metadata service" do
-          expect(ohai_data["openstack"]["metadata"]["name"]).to eq("ohai_spec")
-        end
-        it "reads the public_keys from the openstack metadata service" do
-          expect(ohai_data["openstack"]["metadata"]["public_keys"]).to eq({ "mykey" => "SSH KEY DATA" })
-        end
-        it "reads the uuid from the openstack metadata service" do
-          expect(ohai_data["openstack"]["metadata"]["uuid"]).to eq("00000000-0000-0000-0000-100000000000")
-        end
+      it "sets the provider to openstack" do
+        expect(plugin["openstack"]["provider"]).to eq("openstack")
       end
     end
-
   end
 end

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -49,8 +49,8 @@ describe "OpenStack Plugin" do
         expect(plugin[:openstack][:provider]).to eq("openstack")
       end
 
-      it "sets the metadata attribute to {}" do
-        expect(plugin[:openstack][:metadata]).to be_empty
+      it "doesn't set metadata attributes" do
+        expect(plugin[:openstack][:instance_id]).to be_nil
       end
     end
   end
@@ -81,8 +81,8 @@ describe "OpenStack Plugin" do
         expect(plugin[:openstack][:provider]).to eq("openstack")
       end
 
-      it "sets the metadata attribute to {}" do
-        expect(plugin[:openstack][:metadata]).to be_empty
+      it "doesn't set metadata attributes" do
+        expect(plugin[:openstack][:instance_id]).to be_nil
       end
     end
 
@@ -201,61 +201,61 @@ EOM
       end
 
       it "reads the reservation_id from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["reservation_id"]).to eq("r-4tjvl99h")
+        expect(plugin["openstack"]["reservation_id"]).to eq("r-4tjvl99h")
       end
       it "reads the public_keys_0_openssh_key from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["public_keys_0_openssh_key"]).to eq("SSH KEY DATA")
+        expect(plugin["openstack"]["public_keys_0_openssh_key"]).to eq("SSH KEY DATA")
       end
       it "reads the security_groups from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["security_groups"]).to eq(["default"])
+        expect(plugin["openstack"]["security_groups"]).to eq(["default"])
       end
       it "reads the public_ipv4 from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["public_ipv4"]).to eq("")
+        expect(plugin["openstack"]["public_ipv4"]).to eq("")
       end
       it "reads the ami_manifest_path from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["ami_manifest_path"]).to eq("FIXME")
+        expect(plugin["openstack"]["ami_manifest_path"]).to eq("FIXME")
       end
       it "reads the instance_type from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["instance_type"]).to eq("opc-tester")
+        expect(plugin["openstack"]["instance_type"]).to eq("opc-tester")
       end
       it "reads the instance_id from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["instance_id"]).to eq("i-0000162a")
+        expect(plugin["openstack"]["instance_id"]).to eq("i-0000162a")
       end
       it "reads the local_ipv4 from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["local_ipv4"]).to eq("172.31.7.23")
+        expect(plugin["openstack"]["local_ipv4"]).to eq("172.31.7.23")
       end
       it "reads the ari_id from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["ari_id"]).to eq("ari-00000037")
+        expect(plugin["openstack"]["ari_id"]).to eq("ari-00000037")
       end
       it "reads the local_hostname from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["local_hostname"]).to eq("ohai-7-system-test.opscode.us")
+        expect(plugin["openstack"]["local_hostname"]).to eq("ohai-7-system-test.opscode.us")
       end
       it "reads the placement_availability_zone from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["placement_availability_zone"]).to eq("nova")
+        expect(plugin["openstack"]["placement_availability_zone"]).to eq("nova")
       end
       it "reads the ami_launch_index from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["ami_launch_index"]).to eq("0")
+        expect(plugin["openstack"]["ami_launch_index"]).to eq("0")
       end
       it "reads the public_hostname from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["public_hostname"]).to eq("ohai-7-system-test.opscode.us")
+        expect(plugin["openstack"]["public_hostname"]).to eq("ohai-7-system-test.opscode.us")
       end
       it "reads the hostname from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["hostname"]).to eq("ohai-7-system-test.opscode.us")
+        expect(plugin["openstack"]["hostname"]).to eq("ohai-7-system-test.opscode.us")
       end
       it "reads the ami_id from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["ami_id"]).to eq("ami-00000035")
+        expect(plugin["openstack"]["ami_id"]).to eq("ami-00000035")
       end
       it "reads the instance_action from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["instance_action"]).to eq("none")
+        expect(plugin["openstack"]["instance_action"]).to eq("none")
       end
       it "reads the aki_id from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["aki_id"]).to eq("aki-00000036")
+        expect(plugin["openstack"]["aki_id"]).to eq("aki-00000036")
       end
       it "reads the block_device_mapping_ami from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["block_device_mapping_ami"]).to eq("vda")
+        expect(plugin["openstack"]["block_device_mapping_ami"]).to eq("vda")
       end
       it "reads the block_device_mapping_root from the metadata service" do
-        expect(plugin["openstack"]["metadata"]["block_device_mapping_root"]).to eq("/dev/vda")
+        expect(plugin["openstack"]["block_device_mapping_root"]).to eq("/dev/vda")
       end
       it "sets the provider to openstack" do
         expect(plugin["openstack"]["provider"]).to eq("openstack")

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -45,13 +45,25 @@ describe "OpenStack Plugin" do
         plugin.run
       end
 
-      it "sets openstack provider attribute if the hint is provided" do
+      it "sets openstack attribute" do
         expect(plugin[:openstack][:provider]).to eq("openstack")
       end
 
       it "sets the metadata attribute to {}" do
         expect(plugin[:openstack][:metadata]).to be_empty
       end
+    end
+  end
+
+  context "when running on dreamhost" do
+    it "sets openstack provider attribute to dreamhost" do
+      plugin["etc"] = { "passwd" => { "dhc-user" => {} } }
+      allow(plugin).to receive(:can_metadata_connect?).
+        with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80).
+        and_return(false)
+      plugin[:dmi] = { :system => { :all_records => [ { :Manufacturer => "OpenStack Foundation" } ] } }
+      plugin.run
+      expect(plugin[:openstack][:provider]).to eq("dreamhost")
     end
   end
 
@@ -244,9 +256,6 @@ EOM
       end
       it "reads the block_device_mapping_root from the metadata service" do
         expect(plugin["openstack"]["metadata"]["block_device_mapping_root"]).to eq("/dev/vda")
-      end
-      it "sets the provider to openstack" do
-        expect(plugin["openstack"]["provider"]).to eq("openstack")
       end
       it "sets the provider to openstack" do
         expect(plugin["openstack"]["provider"]).to eq("openstack")

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -49,8 +49,8 @@ describe "OpenStack Plugin" do
         expect(plugin[:openstack][:provider]).to eq("openstack")
       end
 
-      it "sets the metadata attribute to nil" do
-        expect(plugin[:openstack][:metadata]).to be_nil
+      it "sets the metadata attribute to {}" do
+        expect(plugin[:openstack][:metadata]).to be_empty
       end
     end
   end
@@ -69,8 +69,8 @@ describe "OpenStack Plugin" do
         expect(plugin[:openstack][:provider]).to eq("openstack")
       end
 
-      it "sets the metadata attribute to nil" do
-        expect(plugin[:openstack][:metadata]).to be_nil
+      it "sets the metadata attribute to {}" do
+        expect(plugin[:openstack][:metadata]).to be_empty
       end
     end
 


### PR DESCRIPTION
The existing Openstack metadata logic failed as it was hardcoded to use metadata from 2013 that doesn't seem to exist in standard installs. Instead lets use the logic in the EC2 metadata mixin to find the latest version we support.
Wrap metadata fetching around  socket connection check from the EC2 metadata plugin. This prevents hung Ohai runs on providers that don't support the metadata endpoint
Grab the Openstack data correctly in the Cloud plugins
Detect a system as being on Openstack based on DMI data
Remove HP cloud logic since that's dead
Add debug logging so we can follow what's happening in the logs better

Previously nil data we now have:

```json
 "cloud": {
    "public_ips": [
      "172.16.20.52"
    ],
    "private_ips": [
      "192.168.1.203"
    ],
    "public_ipv4": "172.16.20.52",
    "public_hostname": "ohai.novalocal",
    "local_ipv4": "192.168.1.203",
    "local_hostname": "ohai.novalocal",
    "provider": "openstack"
  },
  "cloud_v2": {
    "public_ipv4_addrs": [
      "172.16.20.52"
    ],
    "local_ipv4_addrs": [
      "192.168.1.203"
    ],
    "provider": "openstack",
    "public_hostname": "ohai.novalocal",
    "local_hostname": "ohai.novalocal",
    "public_ipv4": "172.16.20.52",
    "local_ipv4": "192.168.1.203"
  },
 "openstack": {
    "provider": "openstack",
    "metadata": {
      "ami_id": "ami-00000002",
      "ami_launch_index": "0",
      "ami_manifest_path": "FIXME",
      "block_device_mapping_ami": "vda",
      "block_device_mapping_root": "/dev/vda",
      "hostname": "ohai.novalocal",
      "instance_action": "none",
      "instance_id": "i-00000211",
      "instance_type": "m1.medium",
      "kernel_id": "None",
      "local_hostname": "ohai.novalocal",
      "local_ipv4": "192.168.1.203",
      "placement_availability_zone": "nova",
      "public_hostname": "ohai.novalocal",
      "public_ipv4": "172.16.20.52",
      "public_keys_0_openssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCxAVkrfknXoHFQtyXtYZ6vONLHn7HTKQq4mkwvCOPMKb3gr6gsLQkCdzmO3CQwOcFl7uDWGdfjH/ocuSUSn6xMvfCdsdGzDiLQXcDJ4jGOuuyOioniN1N00IhAD7Tqsf4AvbQJ7gDqfPKDCw6LdlZ0d0d9pWlJf7eKf/Hq3x8RCqWek/+UCoU4l4T1eAM0N/bA5tj3EfvRuDniO8U5ClsuUbtJ1uxJmrWMhFox3jFp6oNrleHWFTiRsNKfbtfTrTJRYlqcOG2jGAb49JY+p6Ykku4vq0ezYZFYXGJki6a0yLu1kMg5aHJo9UX0d9JW6y11KfXbGKN4okeRcH/tSNov jasghar@remasghar01.local",
      "ramdisk_id": "None",
      "reservation_id": "r-nvo4xzvf",
      "security_groups": [
      ]
    }
```