### PR TITLE
Cleanup attribute access in cloud plugins

### DIFF
--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -38,17 +38,14 @@ Ohai.plugin(:EC2) do
   # look for amazon string in dmi bios data
   # this gets us detection of HVM instances that are within a VPC
   def has_ec2_dmi?
-    begin
-      # detect a version of '4.2.amazon'
-      if dmi[:bios][:all_records][0][:Version] =~ /amazon/
-        Ohai::Log.debug("Plugin EC2: has_ec2_dmi? == true")
-        return true
-      end
-    rescue NoMethodError
-      # dmi[:bios][:all_records][0][:Version] may not exist
+    # detect a version of '4.2.amazon'
+    if get_attribute(:dmi, :bios, :all_records, 0, :Version) =~ /amazon/
+      Ohai::Log.debug("Plugin EC2: has_ec2_dmi? == true")
+      return true
+    else
+      Ohai::Log.debug("Plugin EC2: has_ec2_dmi? == false")
+      return false
     end
-    Ohai::Log.debug("Plugin EC2: has_ec2_dmi? == false")
-    return false
   end
 
   # looks for a xen UUID that starts with ec2
@@ -67,17 +64,14 @@ Ohai.plugin(:EC2) do
   # looks for the Amazon.com Organization in Windows Kernel data
   # this gets us detection of Windows systems
   def has_amazon_org?
-    begin
-      # detect an Organization of 'Amazon.com'
-      if kernel[:os_info][:organization] =~ /Amazon/
-        Ohai::Log.debug("Plugin EC2: has_amazon_org? == true")
-        return true
-      end
-    rescue NoMethodError
-      # kernel[:os_info][:organization] may not exist
+    # detect an Organization of 'Amazon.com'
+    if get_attribute(:kernel, :os_info, :organization) =~ /Amazon/
+      Ohai::Log.debug("Plugin EC2: has_amazon_org? == true")
+      return true
+    else
+      Ohai::Log.debug("Plugin EC2: has_amazon_org? == false")
+      return false
     end
-    Ohai::Log.debug("Plugin EC2: has_amazon_org? == false")
-    return false
   end
 
   def looks_like_ec2?

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -28,13 +28,13 @@ Ohai.plugin(:Openstack) do
   # do we have the openstack dmi data
   def openstack_dmi?
     # detect a manufacturer of OpenStack Foundation
-    if dmi[:system][:all_records][0][:Manufacturer] =~ /OpenStack/
+    if get_attribute(:dmi, :system, :all_records, 0, :Manufacturer) =~ /OpenStack/
       Ohai::Log.debug("Plugin Openstack: has_openstack_dmi? == true")
-      true
+      return true
+    else
+      Ohai::Log.debug("Plugin Openstack: has_openstack_dmi? == false")
+      return false
     end
-  rescue NoMethodError
-    Ohai::Log.debug("Plugin Openstack: has_openstack_dmi? == false")
-    false
   end
 
   # check for the ohai hint and log debug messaging
@@ -50,11 +50,7 @@ Ohai.plugin(:Openstack) do
 
   # dreamhost systems have the dhc-user on them
   def openstack_provider
-    begin
-      return "dreamhost" if etc["passwd"]["dhc-user"]
-    rescue NoMethodError
-      # handle etc not existing on non-linux systems
-    end
+    return "dreamhost" if get_attribute("etc", "passwd", "dhc-user")
     return "openstack"
   end
 


### PR DESCRIPTION
Use get_attribute to simplify code in places where we previously had to rescue NoMethodError