### PR TITLE
Add Digital Ocean metadata from their metadata API

### DIFF
--- a/lib/ohai/mixin/do_metadata.rb
+++ b/lib/ohai/mixin/do_metadata.rb
@@ -54,17 +54,18 @@ module Ohai
         Net::HTTP.start(DO_METADATA_ADDR).tap { |h| h.read_timeout = 6 }
       end
 
-      def fetch_metadata()
+      def fetch_metadata
         uri = "#{DO_METADATA_URL}"
         response = http_client.get(uri)
         case response.code
         when "200"
-          response.body
+          parser = FFI_Yajl::Parser.new
+          parser.parse(response.body)
         when "404"
-          Ohai::Log.debug("Encountered 404 response retreiving Digital Ocean metadata: #{uri} ; continuing.")
-          Hash.new
+          Ohai::Log.debug("DOMetadata mixin:Encountered 404 response retreiving Digital Ocean metadata: #{uri} ; continuing.")
+          {}
         else
-          raise "Encountered error retrieving Digital Ocean metadata (#{uri} returned #{response.code} response)"
+          raise "DOMetadata mixin:Encountered error retrieving Digital Ocean metadata (#{uri} returned #{response.code} response)"
         end
       end
 

--- a/lib/ohai/mixin/do_metadata.rb
+++ b/lib/ohai/mixin/do_metadata.rb
@@ -21,7 +21,7 @@ module Ohai
   module Mixin
     module DOMetadata
 
-      DO_METADATA_ADDR = "169.254.269.254" unless defined?(DO_METADATA_ADDR)
+      DO_METADATA_ADDR = "169.254.169.254" unless defined?(DO_METADATA_ADDR)
       DO_METADATA_URL = "/metadata/v1.json" unless defined?(DO_METADATA_URL)
 
       def can_metadata_connect?(addr, port, timeout = 2)

--- a/lib/ohai/mixin/do_metadata.rb
+++ b/lib/ohai/mixin/do_metadata.rb
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'net/http'
-require 'socket'
+require "net/http"
+require "socket"
 
 module Ohai
   module Mixin
@@ -24,7 +24,7 @@ module Ohai
       DO_METADATA_ADDR = "169.254.269.254" unless defined?(DO_METADATA_ADDR)
       DO_METADATA_URL = "/metadata/v1.json" unless defined?(DO_METADATA_URL)
 
-      def can_metadata_connect?(addr, port, timeout=2)
+      def can_metadata_connect?(addr, port, timeout = 2)
         t = Socket.new(Socket::Constants::AF_INET, Socket::Constants::SOCK_STREAM, 0)
         saddr = Socket.pack_sockaddr_in(port, addr)
         connected = false
@@ -32,7 +32,7 @@ module Ohai
         begin
           t.connect_nonblock(saddr)
         rescue Errno::EINPROGRESS
-          r,w,e = IO::select(nil,[t],nil,timeout)
+          r, w, e = IO.select(nil, [t], nil, timeout)
           if !w.nil?
             connected = true
           else
@@ -51,7 +51,7 @@ module Ohai
       end
 
       def http_client
-        Net::HTTP.start(DO_METADATA_ADDR).tap {|h| h.read_timeout = 6}
+        Net::HTTP.start(DO_METADATA_ADDR).tap { |h| h.read_timeout = 6 }
       end
 
       def fetch_metadata()

--- a/lib/ohai/mixin/do_metadata.rb
+++ b/lib/ohai/mixin/do_metadata.rb
@@ -1,0 +1,73 @@
+
+# Author:: Dylan Page (<dpage@digitalocean.com>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'net/http'
+require 'socket'
+
+module Ohai
+  module Mixin
+    module DOMetadata
+
+      DO_METADATA_ADDR = "169.254.269.254" unless defined?(DO_METADATA_ADDR)
+      DO_METADATA_URL = "/metadata/v1.json" unless defined?(DO_METADATA_URL)
+
+      def can_metadata_connect?(addr, port, timeout=2)
+        t = Socket.new(Socket::Constants::AF_INET, Socket::Constants::SOCK_STREAM, 0)
+        saddr = Socket.pack_sockaddr_in(port, addr)
+        connected = false
+
+        begin
+          t.connect_nonblock(saddr)
+        rescue Errno::EINPROGRESS
+          r,w,e = IO::select(nil,[t],nil,timeout)
+          if !w.nil?
+            connected = true
+          else
+            begin
+              t.connect_nonblock(saddr)
+            rescue Errno::EISCONN
+              t.close
+              connected = true
+            rescue SystemCallError
+            end
+          end
+        rescue SystemCallError
+        end
+        Ohai::Log.debug("DOMetadata mixin: can_metadata_connect? == #{connected}")
+        connected
+      end
+
+      def http_client
+        Net::HTTP.start(DO_METADATA_ADDR).tap {|h| h.read_timeout = 6}
+      end
+
+      def fetch_metadata()
+        uri = "#{DO_METADATA_URL}"
+        response = http_client.get(uri)
+        case response.code
+        when "200"
+          response.body
+        when "404"
+          Ohai::Log.debug("Encountered 404 response retreiving Digital Ocean metadata: #{uri} ; continuing.")
+          Hash.new
+        else
+          raise "Encountered error retrieving Digital Ocean metadata (#{uri} returned #{response.code} response)"
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ohai/mixin/do_metadata.rb
+++ b/lib/ohai/mixin/do_metadata.rb
@@ -46,7 +46,7 @@ module Ohai
           end
         rescue SystemCallError
         end
-        Ohai::Log.debug("DOMetadata mixin: can_metadata_connect? == #{connected}")
+        Ohai::Log.debug("Mixin DOMetadata: can_metadata_connect? == #{connected}")
         connected
       end
 
@@ -62,10 +62,10 @@ module Ohai
           parser = FFI_Yajl::Parser.new
           parser.parse(response.body)
         when "404"
-          Ohai::Log.debug("DOMetadata mixin:Encountered 404 response retreiving Digital Ocean metadata: #{uri} ; continuing.")
+          Ohai::Log.debug("Mixin DOMetadata: Encountered 404 response retreiving Digital Ocean metadata: #{uri} ; continuing.")
           {}
         else
-          raise "DOMetadata mixin:Encountered error retrieving Digital Ocean metadata (#{uri} returned #{response.code} response)"
+          raise "Mixin DOMetadata: Encountered error retrieving Digital Ocean metadata (#{uri} returned #{response.code} response)"
         end
       end
 

--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -233,17 +233,17 @@ Ohai.plugin(:Cloud) do
 
   # Fill cloud hash with linode values
   def get_digital_ocean_values
-    public_ipv4 = digital_ocean["networks"]["v4"].select { |address| address["type"] == "public" }
-    private_ipv4 = digital_ocean["networks"]["v4"].select { |address| address["type"] == "private" }
-    public_ipv6 = digital_ocean["networks"]["v6"].select { |address| address["type"] == "public" }
-    private_ipv6 = digital_ocean["networks"]["v6"].select { |address| address["type"] == "private" }
+    public_ipv4 = digital_ocean["interfaces"]["public"].map { |iface| iface["ipv4"]["ip_address"] }
+    private_ipv4 = digital_ocean["interfaces"]["private"] ? digital_ocean["interfaces"]["private"].map { |iface| iface["ipv4"]["ip_address"] } : []
+    public_ipv6 = digital_ocean["interfaces"]["public"].map { |iface| iface["ipv6"]["ip_address"] }
+    private_ipv6 = digital_ocean["interfaces"]["private"] ? digital_ocean["interfaces"]["private"].map { |iface| iface["ipv6"]["ip_address"] } : []
     cloud[:public_ips].concat public_ipv4 + public_ipv6
     cloud[:private_ips].concat private_ipv4 + private_ipv6
     cloud[:public_ipv4] = public_ipv4.first
     cloud[:public_ipv6] = public_ipv6.first
     cloud[:local_ipv4] = private_ipv4.first
     cloud[:local_ipv6] = private_ipv6.first
-    cloud[:public_hostname] = digital_ocean["name"]
+    cloud[:public_hostname] = digital_ocean["hostname"]
     cloud[:provider] = "digital_ocean"
   end
 

--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'ohai/mixin/do_metadata'
-require 'yaml'
+require "ohai/mixin/do_metadata"
+require "yaml"
 
 Ohai.plugin(:DigitalOcean) do
   include Ohai::Mixin::DOMetadata
@@ -30,7 +30,7 @@ Ohai.plugin(:DigitalOcean) do
   def has_do_init?
     if File.exist?(DO_CLOUD_INIT_FILE)
       datasource = YAML.load_file(DO_CLOUD_INIT_FILE)
-      if datasource['datasource_list'].include?("DigitalOcean")
+      if datasource["datasource_list"].include?("DigitalOcean")
         Ohai::Log.debug("digital_ocean plugin: has_do_init? == true")
         true
       end
@@ -44,7 +44,7 @@ Ohai.plugin(:DigitalOcean) do
     return true if hint?("digital_ocean")
 
     if has_do_init?
-     return true if can_metadata_connect?(Ohai::Mixin::DOMetadata::DO_METADATA_ADDR,80)
+      return true if can_metadata_connect?(Ohai::Mixin::DOMetadata::DO_METADATA_ADDR, 80)
     end
   end
 

--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -31,11 +31,11 @@ Ohai.plugin(:DigitalOcean) do
     if File.exist?(DO_CLOUD_INIT_FILE)
       datasource = YAML.load_file(DO_CLOUD_INIT_FILE)
       if datasource["datasource_list"].include?("DigitalOcean")
-        Ohai::Log.debug("digital_ocean plugin: has_do_init? == true")
+        Ohai::Log.debug("Plugin DigitalOcean: has_do_init? == true")
         true
       end
     else
-      Ohai::Log.debug("digital_ocean plugin: has_do_init? == false")
+      Ohai::Log.debug("Plugin DigitalOcean: has_do_init? == false")
       false
     end
   end

--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -30,9 +30,10 @@ Ohai.plugin(:DigitalOcean) do
   def has_do_init?
     if File.exist?(DO_CLOUD_INIT_FILE)
       datasource = YAML.load_file(DO_CLOUD_INIT_FILE)
-      puts datasource.inspect
-      Ohai::Log.debug("digital_ocean plugin: has_do_init? == true")
-      true
+      if datasource['datasource_list'].include?("DigitalOcean")
+        Ohai::Log.debug("digital_ocean plugin: has_do_init? == true")
+        true
+      end
     else
       Ohai::Log.debug("digital_ocean plugin: has_do_init? == false")
       false

--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -16,9 +16,11 @@
 # limitations under the License.
 
 require "ohai/mixin/do_metadata"
+require "ohai/mixin/http_helper"
 
 Ohai.plugin(:DigitalOcean) do
   include Ohai::Mixin::DOMetadata
+  include Ohai::Mixin::HttpHelper
 
   provides "digital_ocean"
 
@@ -41,10 +43,8 @@ Ohai.plugin(:DigitalOcean) do
 
   def looks_like_digital_ocean?
     return true if hint?("digital_ocean")
-
-    if has_do_dmi?
-      return true if can_metadata_connect?(Ohai::Mixin::DOMetadata::DO_METADATA_ADDR, 80)
-    end
+    return true if has_do_dmi? && can_socket_connect?(Ohai::Mixin::DOMetadata::DO_METADATA_ADDR, 80)
+    return false
   end
 
   collect_data do

--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -52,7 +52,7 @@ Ohai.plugin(:DigitalOcean) do
       Ohai::Log.debug("Plugin Digitalocean: looks_like_digital_ocean? == true")
       digital_ocean Mash.new
       fetch_metadata.each do |k, v|
-        next if k == 'vendor_data' # this may have sensitive data we shouldn't store
+        next if k == "vendor_data" # this may have sensitive data we shouldn't store
         digital_ocean[k] = v
       end
     else

--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -22,7 +22,6 @@ Ohai.plugin(:DigitalOcean) do
 
   provides "digital_ocean"
 
-  depends "network/interfaces"
   depends "dmi"
 
   # look for digitalocean string in dmi bios data
@@ -53,6 +52,7 @@ Ohai.plugin(:DigitalOcean) do
       Ohai::Log.debug("Plugin Digitalocean: looks_like_digital_ocean? == true")
       digital_ocean Mash.new
       fetch_metadata.each do |k, v|
+        next if k == 'vendor_data' # this may have sensitive data we shouldn't store
         digital_ocean[k] = v
       end
     else

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -215,12 +215,31 @@ describe Ohai::System, "plugin cloud" do
   describe "with digital_ocean mash" do
     before do
       @plugin[:digital_ocean] = Mash.new
-      @plugin[:digital_ocean][:name] = "public.example.com"
-      @plugin[:digital_ocean][:networks] = Mash.new
-      @plugin[:digital_ocean][:networks][:v4] = [{ "ip_address" => "1.2.3.4", "type" => "public" },
-                                                 { "ip_address" => "5.6.7.8", "type" => "private" }]
-      @plugin[:digital_ocean][:networks][:v6] = [{ "ip_address" => "fe80::4240:95ff:fe47:6eee", "type" => "public" },
-                                                 { "ip_address" => "fdf8:f53b:82e4::53", "type" => "private" }]
+      @plugin[:digital_ocean][:hostname] = "public.example.com"
+      @plugin[:digital_ocean][:interfaces] = Mash.new
+      @plugin[:digital_ocean][:interfaces] = {
+        "public" => [
+          {
+            "ipv4" => {
+              "ip_address" => "159.203.92.161",
+              "netmask" => "255.255.240.0",
+              "gateway" => "159.203.80.1",
+            },
+            "ipv6" => {
+              "ip_address" => "2604:A880:0800:00A1:0000:0000:0201:0001",
+              "cidr" => 64,
+              "gateway" => "2604:A880:0800:00A1:0000:0000:0000:0001",
+            },
+            "anchor_ipv4" => {
+              "ip_address" => "10.17.0.5",
+              "netmask" => "255.255.0.0",
+              "gateway" => "10.17.0.1",
+            },
+            "mac" => "04:01:e5:14:03:01",
+            "type" => "public",
+          },
+        ],
+      }
     end
 
     before(:each) do
@@ -236,29 +255,27 @@ describe Ohai::System, "plugin cloud" do
     end
 
     it "populates cloud public ips" do
-      expect(@plugin[:cloud][:public_ips]).to eq(@plugin[:digital_ocean][:networks][:v4].select { |ip| ip["type"] == "public" } +
-                                             @plugin[:digital_ocean][:networks][:v6].select { |ip| ip["type"] == "public" })
+      expect(@plugin[:cloud][:public_ips]).to eq([ "159.203.92.161", "2604:A880:0800:00A1:0000:0000:0201:0001" ])
     end
 
     it "populates cloud private ips" do
-      expect(@plugin[:cloud][:private_ips]).to eq(@plugin[:digital_ocean][:networks][:v4].select { |ip| ip["type"] == "private" } +
-                                              @plugin[:digital_ocean][:networks][:v6].select { |ip| ip["type"] == "private" })
+      expect(@plugin[:cloud][:private_ips]).to be_empty
     end
 
     it "populates cloud public_ipv4" do
-      expect(@plugin[:cloud][:public_ipv4]).to eq(@plugin[:digital_ocean][:networks][:v4].find { |ip| ip["type"] == "public" })
+      expect(@plugin[:cloud][:public_ipv4]).to eq("159.203.92.161")
     end
 
     it "populates cloud local_ipv4" do
-      expect(@plugin[:cloud][:local_ipv4]).to eq(@plugin[:digital_ocean][:networks][:v4].find { |ip| ip["type"] == "private" })
+      expect(@plugin[:cloud][:local_ipv4]).to be_nil
     end
 
     it "populates cloud public_ipv6" do
-      expect(@plugin[:cloud][:public_ipv6]).to eq(@plugin[:digital_ocean][:networks][:v6].find { |ip| ip["type"] == "public" })
+      expect(@plugin[:cloud][:public_ipv6]).to eq("2604:A880:0800:00A1:0000:0000:0201:0001")
     end
 
     it "populates cloud local_ipv6" do
-      expect(@plugin[:cloud][:local_ipv6]).to eq(@plugin[:digital_ocean][:networks][:v6].find { |ip| ip["type"] == "private" })
+      expect(@plugin[:cloud][:local_ipv6]).to be_nil
     end
 
     it "populates cloud provider" do

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -189,4 +189,12 @@ describe Ohai::System, "plugin digital_ocean" do
 >>>>>>> Remove debug code/add proper has_do_init check. Attempt to fix failing tests
     end
   end
+
+  describe "with digital_ocean DMI data" do
+    it_should_behave_like "digital_ocean"
+
+    before(:each) do
+      plugin[:dmi] = { :bios => { :all_records => [ { :Vendor => "DigitalOcean" } ] } }
+    end
+  end
 end

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -157,6 +157,7 @@ describe Ohai::System, "plugin digital_ocean" do
       allow(plugin).to receive(:hint?).with("digital_ocean").and_return(false)
     end
 
+<<<<<<< HEAD
     describe "with the /etc/digitalocean file" do
       before do
         allow(File).to receive(:exist?).with(digitalocean_path).and_return(true)
@@ -170,6 +171,22 @@ describe Ohai::System, "plugin digital_ocean" do
         allow(File).to receive(:exist?).with(digitalocean_path).and_return(false)
       end
       it_behaves_like "!digital_ocean"
+=======
+    yaml_example = <<-EOF
+    datasource_list: [ DigitalOcean, None ]
+    datasource:
+    DigitalOcean:
+     retries: 5
+     timeout: 10
+
+    vendor_data:
+     enabled: True
+    EOF
+
+    before(:each) do
+        expect(File).to receive(:exist?).with("/etc/cloud/cloud.cfg").and_return(true)
+        allow(File).to receive(:read).with("/etc/cloud/cloud.cfg").and_return(yaml_example)
+>>>>>>> Remove debug code/add proper has_do_init check. Attempt to fix failing tests
     end
   end
 end

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -1,4 +1,5 @@
 #
+# Author:: Dylan Page (<dpage@digitalocean.com>)
 # Author:: Stafford Brunk (<stafford.brunk@gmail.com>)
 # License:: Apache License, Version 2.0
 #
@@ -15,12 +16,10 @@
 # limitations under the License.
 #
 
-require "ipaddress"
-require_relative "../../spec_helper.rb"
+require "spec_helper"
 
 describe Ohai::System, "plugin digital_ocean" do
   let(:plugin) { get_plugin("digital_ocean") }
-  let(:digitalocean_path) { "/etc/digitalocean" }
   let(:hint) do
     {
       "droplet_id" => 12345678,
@@ -35,158 +34,63 @@ describe Ohai::System, "plugin digital_ocean" do
     }
   end
 
-  before do
-    plugin[:network] = {
-      "interfaces" => {
-        "eth0" => {
-          "addresses" => {
-            "00:D3:AD:B3:3F:00" => {
-              "family" => "lladdr",
-            },
-            "1.2.3.4" => {
-              "netmask" => "255.255.255.0",
-            },
-            "2400:6180:0000:00d0:0000:0000:0009:7001" => {},
-          },
-        },
-      },
-    }
-
-    allow(plugin).to receive(:hint?).with("digital_ocean").and_return(hint)
+  before(:each) do
+    allow(plugin).to receive(:hint?).with("digital_ocean").and_return(false)
   end
 
   shared_examples_for "!digital_ocean" do
-    before(:each) do
-      plugin.run
-    end
-
-    it "does not create the digital_ocean mash" do
+    it "should NOT attempt to fetch the digital_ocean metadata" do
+      expect(plugin).not_to receive(:http_client)
       expect(plugin[:digital_ocean]).to be_nil
-    end
-  end
-
-  shared_examples_for "digital_ocean_networking" do
-    it "creates the networks attribute" do
-      expect(plugin[:digital_ocean][:networks]).not_to be_nil
-    end
-
-    it "pulls ip addresses from the network interfaces" do
-      expect(plugin[:digital_ocean][:networks][:v4]).to eq([{ "ip_address" => "1.2.3.4",
-                                                              "type" => "public",
-                                                              "netmask" => "255.255.255.0" }])
-      expect(plugin[:digital_ocean][:networks][:v6]).to eq([{ "ip_address" => "2400:6180:0000:00d0:0000:0000:0009:7001",
-                                                              "type" => "public",
-                                                              "cidr" => 128 }])
+      plugin.run
     end
   end
 
   shared_examples_for "digital_ocean" do
     before(:each) do
+      @http_client = double("Net::HTTP client")
+      allow(plugin).to receive(:http_client).and_return(@http_client)
+      allow(IO).to receive(:select).and_return([[], [1], []])
+      t = double("connection")
+      allow(t).to receive(:connect_nonblock).and_raise(Errno::EINPROGRESS)
+      allow(Socket).to receive(:new).and_return(t)
+      allow(Socket).to receive(:pack_sockaddr_in).and_return(nil)
+    end
+
+    let(:body) do
+      '{"droplet_id":2756924,"hostname":"sample-droplet","vendor_data":"#cloud-config\ndisable_root: false\nmanage_etc_hosts: true\n\n# The modules that run in the \'init\' stage\ncloud_init_modules:\n - migrator\n - ubuntu-init-switch\n - seed_random\n - bootcmd\n - write-files\n - growpart\n - resizefs\n - set_hostname\n - update_hostname\n - [ update_etc_hosts, once-per-instance ]\n - ca-certs\n - rsyslog\n - users-groups\n - ssh\n\n# The modules that run in the \'config\' stage\ncloud_config_modules:\n - disk_setup\n - mounts\n - ssh-import-id\n - locale\n - set-passwords\n - grub-dpkg\n - apt-pipelining\n - apt-configure\n - package-update-upgrade-install\n - landscape\n - timezone\n - puppet\n - chef\n - salt-minion\n - mcollective\n - disable-ec2-metadata\n - runcmd\n - byobu\n\n# The modules that run in the \'final\' stage\ncloud_final_modules:\n - rightscale_userdata\n - scripts-vendor\n - scripts-per-once\n - scripts-per-boot\n - scripts-per-instance\n - scripts-user\n - ssh-authkey-fingerprints\n - keys-to-console\n - phone-home\n - final-message\n - power-state-change\n","public_keys":["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDAkMD3PYKHaH0KbDiXrRE6KCBo/OKcFqhM+fmnnb0+LUh4RalJWX4edeJmnT5bxLeqmLV/Yggjlpfq73R+Dy7JB4pbBLuM959mSM9ohBCSnByAGoT2iUPev4aZFZZ/ahUzTCylNxXrhZV/bopD399CvYREt7Q+FlauBv0O8MMuMGR8aC69Z3jNL+r+fGWNq98JVHGFO/UgoNL15wGCaidMhzfRqkt1u+m1nY77SFM5qWJz2R0CEC4fMlOiCg8mWBklnryV4yDEPgiXp2I8Rli1Eu2GHwuY1YX9elMeQS7n3Pzq7l6aIQmSgvcEWx6TgMD2V7nQUWpfcud/8dpp/t7z9UyfzLmNwnULHNmUeEp52sejcH5lYzISnkkWa1LzlKSeIrhF3y45m9AyxIfjEqyh/mlKQtUaW3NVXXLPwrNitxHtMIZPU5b16BODn0wb8bqPxpDNpUYrQd/BS7mWDxNpICP2ObLPhd9LW9KIYRNTzryE+uKwxm9NkMlhRku2fu415fH0G0+7aURsHviNN9SO4zct3Pj6QE5rnbVHqxt3biplUTOScdWxSk2Nv3V2dGdt/lBfu6iRPAV9IAS31s7Po3qK1t2jpEPCJwstaCBOM80kmoi3zAgotiAW50X8CelaWsHNrq5jBBgeHUZWgn/c8BkcI61pUE9l34Q6gsiEMQ== tsmith84@gmail.com"],"region":"nyc3","interfaces":{"public":[{"ipv4":{"ip_address":"159.203.92.161","netmask":"255.255.240.0","gateway":"159.203.80.1"},"ipv6":{"ip_address":"2604:A880:0800:00A1:0000:0000:0201:0001","cidr":64,"gateway":"2604:A880:0800:00A1:0000:0000:0000:0001"},"anchor_ipv4":{"ip_address":"10.17.0.5","netmask":"255.255.0.0","gateway":"10.17.0.1"},"mac":"04:01:e5:14:03:01","type":"public"}]},"floating_ip":{"ipv4":{"active":false}},"dns":{"nameservers":["2001:4860:4860::8844","2001:4860:4860::8888","8.8.8.8"]}}'
+    end
+
+    it "should fetch and properly parse json metadata" do
+      expect(@http_client).to receive(:get).
+        with("/metadata/v1.json").
+        and_return(double("Net::HTTP Response", :body => body, :code => "200"))
       plugin.run
-    end
 
-    it "creates a digital_ocean mash" do
       expect(plugin[:digital_ocean]).not_to be_nil
+      expect(plugin[:digital_ocean]["droplet_id"]).to eq(2756924)
+      expect(plugin[:digital_ocean]["hostname"]).to eq("sample-droplet")
     end
 
-    it "has all hint attributes" do
-      expect(plugin[:digital_ocean][:droplet_id]).not_to be_nil
-      expect(plugin[:digital_ocean][:name]).not_to be_nil
-      expect(plugin[:digital_ocean][:image_id]).not_to be_nil
-      expect(plugin[:digital_ocean][:size_id]).not_to be_nil
-      expect(plugin[:digital_ocean][:region_id]).not_to be_nil
-    end
+    it "should complete the run despite unavailable metadata" do
+      expect(@http_client).to receive(:get).
+        with("/metadata/v1.json").
+        and_return(double("Net::HTTP Response", :body => "", :code => "404"))
+      plugin.run
 
-    it "skips the ip_addresses hint attribute" do
-      expect(plugin[:digital_ocean][:ip_addresses]).to be_nil
+      expect(plugin[:digitalocean]).to be_nil
     end
+  end
 
-    it "has correct values for all hint attributes" do
-      expect(plugin[:digital_ocean][:droplet_id]).to eq(12345678)
-      expect(plugin[:digital_ocean][:name]).to eq("example.com")
-      expect(plugin[:digital_ocean][:image_id]).to eq(3240036)
-      expect(plugin[:digital_ocean][:size_id]).to eq(66)
-      expect(plugin[:digital_ocean][:region_id]).to eq(4)
-    end
-
-    include_examples "digital_ocean_networking"
+  describe "without hint or dmi data" do
+    it_should_behave_like "!digital_ocean"
   end
 
   describe "with digital_ocean hint file" do
-    before do
-      allow(plugin).to receive(:hint?).with("digital_ocean").and_return(hint)
-    end
-
-    context "without private networking enabled" do
-      it_behaves_like "digital_ocean"
-    end
-
-    context "with private networking enabled" do
-      before do
-        plugin[:network][:interfaces][:eth1] = {
-          "addresses" => {
-            "10.128.142.89" => {
-              "netmask" => "255.255.255.0",
-            },
-            "fdf8:f53b:82e4:0000:0000:0000:0000:0053" => {},
-          },
-        }
-
-        plugin.run
-      end
-
-      it "extracts the private networking ips" do
-        expect(plugin[:digital_ocean][:networks][:v4]).to eq([{ "ip_address" => "1.2.3.4",
-                                                                "type" => "public",
-                                                                "netmask" => "255.255.255.0" },
-                                                            { "ip_address" => "10.128.142.89",
-                                                              "type" => "private",
-                                                              "netmask" => "255.255.255.0" }])
-        expect(plugin[:digital_ocean][:networks][:v6]).to eq([{ "ip_address" => "2400:6180:0000:00d0:0000:0000:0009:7001",
-                                                                "type" => "public",
-                                                                "cidr" => 128 },
-                                                           { "ip_address" => "fdf8:f53b:82e4:0000:0000:0000:0000:0053",
-                                                             "type" => "private",
-                                                             "cidr" => 128 }])
-      end
-    end
-  end
-
-  describe "without digital_ocean hint file" do
-    before do
-      allow(plugin).to receive(:hint?).with("digital_ocean").and_return(false)
-    end
-
-<<<<<<< HEAD
-    describe "with the /etc/digitalocean file" do
-      before do
-        allow(File).to receive(:exist?).with(digitalocean_path).and_return(true)
-        plugin.run
-      end
-      it_behaves_like "digital_ocean_networking"
-    end
-
-    describe "without the /etc/digitalocean file" do
-      before do
-        allow(File).to receive(:exist?).with(digitalocean_path).and_return(false)
-      end
-      it_behaves_like "!digital_ocean"
-=======
-    yaml_example = <<-EOF
-    datasource_list: [ DigitalOcean, None ]
-    datasource:
-    DigitalOcean:
-     retries: 5
-     timeout: 10
-
-    vendor_data:
-     enabled: True
-    EOF
+    it_should_behave_like "digital_ocean"
 
     before(:each) do
-        expect(File).to receive(:exist?).with("/etc/cloud/cloud.cfg").and_return(true)
-        allow(File).to receive(:read).with("/etc/cloud/cloud.cfg").and_return(yaml_example)
->>>>>>> Remove debug code/add proper has_do_init check. Attempt to fix failing tests
+      allow(plugin).to receive(:hint?).with("digital_ocean").and_return(true)
     end
   end
 


### PR DESCRIPTION
At the moment we rely on hint data from our digital ocean knife plugin.  Not everyone boostraps with knife though.  Instead of relying on the hint data we should detect digital ocean nodes via DMI or hint file and then fetch all the DO metadata from their API. This builds on the original PR from @GenPage but adds detection of DO droplets via DMI data and updates the cloud plugins.
