### PR TITLE
Switch to kernel version to identify Gentoo versions

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -118,7 +118,10 @@ Ohai.plugin(:Platform) do
       platform_version get_redhatish_version(contents)
     elsif File.exist?("/etc/gentoo-release")
       platform "gentoo"
-      platform_version File.read("/etc/gentoo-release").scan(/(\d+|\.+)/).join
+      # the gentoo release version is the base version used to bootstrap
+      # a node and doesn't have a lot of meaning in a rolling release distro
+      # kernel release will be used - ex. 3.18.7-gentoo
+      platform_version `uname -r`.strip
     elsif File.exist?("/etc/SuSE-release")
       suse_release = File.read("/etc/SuSE-release")
       suse_version = suse_release.scan(/VERSION = (\d+)\nPATCHLEVEL = (\d+)/).flatten.join(".")

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -217,10 +217,15 @@ describe Ohai::System, "Linux plugin platform" do
     end
 
     it "should set platform and platform_family to gentoo" do
-      expect(File).to receive(:read).with("/etc/gentoo-release").and_return("Gentoo Base System release 1.20.1.1")
       @plugin.run
       expect(@plugin[:platform]).to eq("gentoo")
       expect(@plugin[:platform_family]).to eq("gentoo")
+    end
+
+    it "should set platform_version to kernel release" do
+      expect(@plugin).to receive(:`).with("uname -r").and_return("3.18.7-gentoo")
+      @plugin.run
+      expect(@plugin[:platform_version]).to eq("3.18.7-gentoo")
     end
   end
 


### PR DESCRIPTION
We're looking at the gentoo release file to identify the version currently which is 2.2. It's been 2.2 for years since that's just the Gentoo Base System version which never changes. We should do what we do on Arch and use the kernel version string.  This is a copy / paste of that code.

Signed-off-by: Tim Smith <tsmith@chef.io>