### PR TITLE
Update PowerShell Version Compat Detection / Unblock bundler on Appveyor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ group :development do
   gem "sigar", :platform => "ruby"
 
   gem "chefstyle", "= 0.3.1"
-  # gem 'pry-byebug'
-  # gem 'pry-stack_explorer'
+  gem "overcommit", ">= 0.34.1"
+  gem "pry-byebug"
+  gem "pry-stack_explorer"
+  gem "rb-readline"
 end

--- a/lib/ohai/plugins/powershell.rb
+++ b/lib/ohai/plugins/powershell.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "base64"
 
 Ohai.plugin(:Powershell) do
   provides "languages/powershell"

--- a/spec/unit/plugins/powershell_spec.rb
+++ b/spec/unit/plugins/powershell_spec.rb
@@ -43,8 +43,10 @@ PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0}
 PSRemotingProtocolVersion      2.2
 
 END
+    compat_version_array = ["1.0", "2.0", "3.0", "4.0"]
 
     allow(plugin).to receive(:shell_out).with(anything()).and_return(mock_shell_out(0, v4_output, ""))
+    allow(plugin).to receive(:parse_compatible_versions).and_return(compat_version_array)
     plugin.run
     expect(plugin.languages[:powershell][:version]).to eql("4.0")
     expect(plugin.languages[:powershell][:ws_man_stack_version]).to eql("3.0")


### PR DESCRIPTION
- [x] Update overcommit to prevent install failures on Windows.
- [x] Update PowerShell Version Compat Detection Resolves #831 