### PR TITLE
Move timezone value under time

### DIFF
--- a/lib/ohai/plugins/timezone.rb
+++ b/lib/ohai/plugins/timezone.rb
@@ -15,9 +15,10 @@
 # limitations under the License.
 
 Ohai.plugin(:Timezone) do
-  provides "timezone"
+  provides "time/timezone"
 
   collect_data(:default) do
-    timezone Time.now.getlocal.zone
+    time Mash.new unless time
+    time[:timezone] = Time.now.getlocal.zone
   end
 end

--- a/spec/unit/plugins/timezone_spec.rb
+++ b/spec/unit/plugins/timezone_spec.rb
@@ -25,6 +25,6 @@ describe Ohai::System, "timezone plugin" do
 
   it "should get the local timezone" do
     @plugin.run
-    expect(@plugin["timezone"]).to eq("ZZZ")
+    expect(@plugin["time"]["timezone"]).to eq("ZZZ")
   end
 end


### PR DESCRIPTION
This prevents us from breaking the various timezone cookbooks that
already use that namespace. Attributes are hard. Good thing lamont is
going to fix this all ;)

Signed-off-by: Tim Smith <tsmith@chef.io>