### PR TITLE
Remove support for Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ before_install:
   - bundle --version
   - gem --version
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
 
 script:
   - bundle exec chefstyle

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://docs.chef.io/ohai.html"
 
-  s.required_ruby_version = ">= 2.0.0"
+  s.required_ruby_version = ">= 2.1.0"
 
   s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "ffi-yajl", "~> 2.2"


### PR DESCRIPTION
Also test on more specific Ruby versions since the rbenv aliases don't
point to current.