### PR TITLE
TEST: Attempt to upgrade RVM in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,17 @@ sudo: false
 branches:
   only:
     - master
-    - 7.4-stable
 
 before_install:
+  - rvm get stable
   - gem update --system
   - gem install bundler
   - bundle --version
   - gem --version
 rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.1
+  - 2.2
+  - 2.3
 
 script:
   - bundle exec chefstyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
 
 before_install:
   - rvm get stable
+  - rvm alias list
   - gem update --system
   - gem install bundler
   - bundle --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,9 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "200"
     - ruby_version: "21"
     - ruby_version: "22"
+    - ruby_version: "23"
 
 clone_folder: c:\projects\ohai
 clone_depth: 1
@@ -16,8 +16,6 @@ skip_tags: true
 branches:
   only:
     - master
-    - 8-stable
-    - 7.4-stable
 
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%


### PR DESCRIPTION
Upgrading gets us the latest version aliases so we can switch back to
things like 2.2 vs. 2.2.5

Signed-off-by: Tim Smith <tsmith@chef.io>