### PR TITLE
PHP 7.0 not detected by Ohai

### DIFF
--- a/lib/ohai/plugins/php.rb
+++ b/lib/ohai/plugins/php.rb
@@ -36,6 +36,8 @@ Ohai.plugin(:PHP) do
           when /PHP (\S+).+built: ([^)]+)/
             php[:version] = $1
             php[:builddate] = $2
+          when /PHP (\S+) \(/
+            php[:version] = $1
           when /Zend Engine v([^\s]+),/
             php[:zend_engine_version] = $1
           when /Zend OPcache v([^\s]+),/


### PR DESCRIPTION
I met different "php -v" format with ubuntu16.04 and php7.0-cli
It cannot take a php['version'] .

Ohai Version : 8.5.0
Platform Version : Ubuntu 16.04

```
# php -v
PHP 7.0.4-7ubuntu2.1 (cli) ( NTS )
Copyright (c) 1997-2016 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
```
