### PR TITLE
Properly detect PHP 7

### DIFF
--- a/lib/ohai/plugins/php.rb
+++ b/lib/ohai/plugins/php.rb
@@ -33,7 +33,7 @@ Ohai.plugin(:PHP) do
         php = Mash.new
         so.stdout.each_line do |line|
           case line
-          when /PHP (\S+).+built: ([^)]+)/
+          when /^PHP (\S+)(?:.*built: ([^)]+))?/
             php[:version] = $1
             php[:builddate] = $2
           when /Zend Engine v([^\s]+),/

--- a/spec/unit/plugins/php_spec.rb
+++ b/spec/unit/plugins/php_spec.rb
@@ -21,70 +21,77 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
 
 describe Ohai::System, "plugin php" do
+  let(:plugin) { get_plugin("php") }
 
   before(:each) do
-    @plugin = get_plugin("php")
-    @plugin[:languages] = Mash.new
+    plugin[:languages] = Mash.new
     @stdout = <<-OUT
 PHP 5.1.6 (cli) (built: Jul 16 2008 19:52:52)
 Copyright (c) 1997-2006 The PHP Group
 Zend Engine v2.1.0, Copyright (c) 1998-2006 Zend Technologies
 OUT
-    allow(@plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, @stdout, ""))
+    allow(plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, @stdout, ""))
   end
 
-  it "should get the php version from running php -V" do
-    expect(@plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, @stdout, ""))
-    @plugin.run
+  it "gets the php version by running php -V" do
+    expect(plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, @stdout, ""))
+    plugin.run
   end
 
-  it "should set languages[:php][:version]" do
-    @plugin.run
-    expect(@plugin.languages[:php][:version]).to eql("5.1.6")
+  it "sets languages[:php][:version] on PHP 5.X" do
+    plugin.run
+    expect(plugin.languages[:php][:version]).to eql("5.1.6")
   end
 
-  it "should not set the languages[:php] tree up if php command fails" do
-    @stdout = <<-OUT
-PHP 5.1.6 (cli) (built: Jul 16 2008 19:52:52)
-Copyright (c) 1997-2006 The PHP Group
-Zend Engine v2.1.0, Copyright (c) 1998-2006 Zend Technologies
+  it "sets languages[:php][:version] on PHP 7.0" do
+    stdout = <<-OUT
+PHP 7.0.4-7ubuntu2.1 (cli) ( NTS )
+Copyright (c) 1997-2016 The PHP Group
+Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies
+    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
 OUT
-    allow(@plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(1, @stdout, ""))
-    @plugin.run
-    expect(@plugin.languages).not_to have_key(:php)
+    allow(plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, stdout, ""))
+    plugin.run
+    expect(plugin.languages[:php][:version]).to eql("7.0.4-7ubuntu2.1")
   end
 
-  it "should parse builddate even if it's suhosin patched" do
-    @stdout = <<-OUT
+  it "does not set the languages[:php] tree up if php command fails" do
+    allow(plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(1, "", ""))
+    plugin.run
+    expect(plugin.languages).not_to have_key(:php)
+  end
+
+  it "parses builddate even if PHP is Suhosin patched" do
+    stdout = <<-OUT
 PHP 5.3.27 with Suhosin-Patch (cli) (built: Aug 30 2013 04:30:30)
 Copyright (c) 1997-2013 The PHP Group
 Zend Engine v2.3.0, Copyright (c) 1998-2013 Zend Technologies
 OUT
-    allow(@plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, @stdout, ""))
-    @plugin.run
-    expect(@plugin.languages[:php][:builddate]).to eql("Aug 30 2013 04:30:30")
+    allow(plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, stdout, ""))
+    plugin.run
+    expect(plugin.languages[:php][:builddate]).to eql("Aug 30 2013 04:30:30")
   end
 
-  it "should not set zend_optcache_version if not compiled with opcache" do
-    @stdout = <<-OUT
+  it "does not set zend_optcache_version if not compiled with opcache" do
+    stdout = <<-OUT
 PHP 5.1.6 (cli) (built: Jul 16 2008 19:52:52)
 Copyright (c) 1997-2006 The PHP Group
 Zend Engine v2.1.0, Copyright (c) 1998-2006 Zend Technologies
 OUT
-    allow(@plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, @stdout, ""))
-    @plugin.run
-    expect(@plugin.languages[:php]).not_to have_key(:zend_opcache_version)
+    allow(plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, stdout, ""))
+    plugin.run
+    expect(plugin.languages[:php]).not_to have_key(:zend_opcache_version)
   end
 
-  it "should parse zend_optcache_version if compiled with opcache" do
-    @stdout = <<-OUT
+  it "sets zend_optcache_version if compiled with opcache" do
+    stdout = <<-OUT
 PHP 5.5.9-1ubuntu4.5 (cli) (built: Oct 29 2014 11:59:10)
 Copyright (c) 1997-2014 The PHP Group
 Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
     with Zend OPcache v7.0.3, Copyright (c) 1999-2014, by Zend Technologies
 OUT
-    allow(@plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, @stdout, ""))
-    @plugin.run
-    expect(@plugin.languages[:php][:zend_opcache_version]).to eql("7.0.3")
+    allow(plugin).to receive(:shell_out).with("php -v").and_return(mock_shell_out(0, stdout, ""))
+    plugin.run
+    expect(plugin.languages[:php][:zend_opcache_version]).to eql("7.0.3")
   end
 end


### PR DESCRIPTION
PHP 7 strings have changed and our old regex broke as the build date is no longer included. Update the regex to make the build data optional and add tests for the new strings

Signed-off-by: Tim Smith <tsmith@chef.io>