### PR TITLE
fixing solaris2 ohai plugin regex

### DIFF
--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -101,7 +101,7 @@ Ohai.plugin(:Network) do
     cint = nil
 
     so.stdout.lines do |line|
-      if line =~ /^([0-9a-zA-Z\.\:\-]+):/
+      if line =~ /^([0-9a-zA-Z\.\:\-]+)\S/
         cint = $1
         iface[cint] = Mash.new unless iface[cint]
         iface[cint][:mtu] = $2

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -58,7 +58,7 @@ ETHERNET_ENCAPS = %w{ afe amd8111s arn atge ath bfe bge bnx bnxe ce cxgbe
                       dmfe e1000g efe elxl emlxs eri hermon hme hxge igb
                       iprb ipw iwh iwi iwk iwp ixgb ixgbe mwl mxfe myri10ge
                       nge ntxn nxge pcn platform qfe qlc ral rge rtls rtw rwd
-                      rwn sfe tavor vr wpi xge yge } unless defined?(ETHERNET_ENCAPS)
+                      rwn sfe tavor vr wpi xge yge aggr} unless defined?(ETHERNET_ENCAPS)
 
 Ohai.plugin(:Network) do
   provides "network", "network/interfaces"
@@ -101,7 +101,7 @@ Ohai.plugin(:Network) do
     cint = nil
 
     so.stdout.lines do |line|
-      if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+) index (\d+)/
+      if line =~ /^([0-9a-zA-Z\.\:\-]+):/
         cint = $1
         iface[cint] = Mash.new unless iface[cint]
         iface[cint][:mtu] = $2

--- a/spec/unit/plugins/solaris2/network_spec.rb
+++ b/spec/unit/plugins/solaris2/network_spec.rb
@@ -176,7 +176,7 @@ ROUTE_GET
     end
 
     it "finds the default interface for a solaris 11 zone" do
-      expect(@plugin[:network][:default_interface]).to eq("net1:1")
+      expect(@plugin[:network][:default_interface]).to eq("net1")
     end
   end
 

--- a/spec/unit/plugins/solaris2/network_spec.rb
+++ b/spec/unit/plugins/solaris2/network_spec.rb
@@ -147,7 +147,7 @@ ROUTE_GET
     end
 
     it "detects the interfaces" do
-      expect(@plugin["network"]["interfaces"].keys.sort).to eq(["e1000g0:3", "e1000g2:1", "eri0", "ip.tun0", "ip.tun0:1", "lo0", "lo0:3", "net0", "net1:1", "qfe1"])
+      expect(@plugin["network"]["interfaces"].keys.sort).to eq(["e1000g0:3", "e1000g2:1", "eri0", "ip.tun0", "ip.tun0:1", "ip6.tun0", "lo0", "lo0:3", "net0", "net1:1", "qfe1", "vni0"])
     end
 
     it "detects the ip addresses of the interfaces" do


### PR DESCRIPTION
The current regex in place does not properly catch the interfaces. Updating this regex allows for the network information to actually populate. 