### PR TITLE
Add platform detection for Arista EOS

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -153,6 +153,10 @@ Ohai.plugin(:Platform) do
     elsif File.exist?("/etc/alpine-release")
       platform "alpine"
       platform_version File.read("/etc/alpine-release").strip()
+    elsif File.exist?("/etc/Eos-release")
+      platform "arista_eos"
+      platform_version File.read("/etc/Eos-release").strip.split[-1]
+      platform_family "fedora"
     elsif os_release_file_is_cisco?
       raise "unknown Cisco /etc/os-release or /etc/cisco-release ID_LIKE field" if
         os_release_info["ID_LIKE"].nil? || ! os_release_info["ID_LIKE"].include?("wrlinux")

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -26,6 +26,7 @@ describe Ohai::System, "Linux plugin platform" do
   let(:have_gentoo_release) { false }
   let(:have_exherbo_release) { false }
   let(:have_alpine_release) { false }
+  let(:have_eos_release) { false }
   let(:have_suse_release) { false }
   let(:have_arch_release) { false }
   let(:have_system_release) { false }

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -46,6 +46,7 @@ describe Ohai::System, "Linux plugin platform" do
     allow(File).to receive(:exist?).with("/etc/gentoo-release").and_return(have_gentoo_release)
     allow(File).to receive(:exist?).with("/etc/exherbo-release").and_return(have_exherbo_release)
     allow(File).to receive(:exist?).with("/etc/alpine-release").and_return(have_alpine_release)
+    allow(File).to receive(:exist?).with("/etc/Eos-release").and_return(have_eos_release)
     allow(File).to receive(:exist?).with("/etc/SuSE-release").and_return(have_suse_release)
     allow(File).to receive(:exist?).with("/etc/arch-release").and_return(have_arch_release)
     allow(File).to receive(:exist?).with("/etc/system-release").and_return(have_system_release)
@@ -243,6 +244,23 @@ describe Ohai::System, "Linux plugin platform" do
       expect(@plugin[:platform]).to eq("alpine")
       expect(@plugin[:platform_family]).to eq("alpine")
       expect(@plugin[:platform_version]).to eq("3.2.3")
+    end
+  end
+
+  describe "on arista eos" do
+
+    let(:have_eos_release) { true }
+
+    before(:each) do
+      @plugin.lsb = nil
+    end
+
+    it "should set platform to arista_eos" do
+      expect(File).to receive(:read).with("/etc/Eos-release").and_return("Arista Networks EOS 4.16.7M")
+      @plugin.run
+      expect(@plugin[:platform]).to eq("arista_eos")
+      expect(@plugin[:platform_family]).to eq("fedora")
+      expect(@plugin[:platform_version]).to eq("4.16.7M")
     end
   end
 


### PR DESCRIPTION
Arista EOS can be detected based on the /etc/Eos-release file which includes the EOS version string.