### PR TITLE
Fix installs on Ruby 2.1 and rspec testing with rspec 3.5

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "github_changelog_generator", "1.13.1"
 
   # github_changelog_generator -> github-api -> oauth2 -> rack
-  # rack being unconstrained breaks Ruby 2.1 instals
+  # rack being unconstrained breaks Ruby 2.1 installs
   s.add_development_dependency "rack", "~> 1.0"
 
   s.bindir = "bin"

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-mocks", "~> 3.0"
   s.add_development_dependency "rspec-collection_matchers", "~> 1.0"
   s.add_development_dependency "rspec_junit_formatter"
-  s.add_development_dependency "github_changelog_generator", "1.11.3"
+  s.add_development_dependency "github_changelog_generator", "1.13.1"
 
   s.bindir = "bin"
   s.executables = %w{ohai}

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -43,6 +43,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec_junit_formatter"
   s.add_development_dependency "github_changelog_generator", "1.13.1"
 
+  # github_changelog_generator -> github-api -> oauth2 -> rack
+  # rack being unconstrained breaks Ruby 2.1 instals
+  s.add_development_dependency "rack", "~> 1.0"
+
   s.bindir = "bin"
   s.executables = %w{ohai}
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require "rspec"
 require "rspec/collection_matchers"
 
 # require 'pry-debugger'


### PR DESCRIPTION
Bump github changelog generator the the latest, constrain rack to < 2 and fix a require in the spec helper that is causing failures in rspec 3.5. Get the build green again basically

Signed-off-by: Tim Smith <tsmith@chef.io>