### PR TITLE
Require at least mixlib-log 1.7.1

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "mixlib-cli"
   s.add_dependency "mixlib-config", "~> 2.0"
-  s.add_dependency "mixlib-log"
+  s.add_dependency "mixlib-log", ">= 1.7.1", "< 2.0"
   s.add_dependency "mixlib-shellout", "~> 2.0"
   s.add_dependency "plist", "~> 3.1"
   s.add_dependency "ipaddress"


### PR DESCRIPTION
Our use of the configured method now fails if we're not on 1.7.1.

Signed-off-by: Tim Smith <tsmith@chef.io>