### PR TITLE
Solaris_update_version: Create kernel[:update] for solaris 2

### DIFF
--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -151,7 +151,7 @@ Ohai.plugin(:Kernel) do
     so = shell_out("uname -s")
     kernel[:os] = so.stdout.split($/)[0]
 
-    so = File.open('/etc/release') { |file| file.gets }
+    so = File.open("/etc/release") { |file| file.gets }
     md = /(?<update>\d.*\d)/.match(so)
     kernel[:update] = md[:update] if md
 

--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -151,6 +151,10 @@ Ohai.plugin(:Kernel) do
     so = shell_out("uname -s")
     kernel[:os] = so.stdout.split($/)[0]
 
+    so = File.open('/etc/release') { |file| file.gets }
+    md = /(?<update>\d.*\d)/.match(so)
+    kernel[:update] = md[:update] if md
+
     modules = Mash.new
 
     so = shell_out("modinfo")

--- a/spec/unit/plugins/solaris2/kernel_spec.rb
+++ b/spec/unit/plugins/solaris2/kernel_spec.rb
@@ -139,7 +139,30 @@ describe Ohai::System, "Solaris2.X kernel plugin" do
     allow(@plugin).to receive(:init_kernel).and_return({})
     allow(@plugin).to receive(:shell_out).with("uname -s").and_return(mock_shell_out(0, "SunOS\n", ""))
     allow(@plugin).to receive(:shell_out).with("modinfo").and_return(mock_shell_out(0, MODINFO, ""))
+    @release = StringIO.new("                   Oracle Solaris 10 1/13 s10s_u11wos_24a SPARC\n Assembled 17 January 2013")
+    allow(File).to receive(:open).with("/etc/release").and_yield(@release)
   end
+
+  it "should give the Solaris update version informtion" do
+    @release = StringIO.new("                      Solaris 10 10/08 s10s_u6wos_07b SPARC\n Use is subject to license terms.\n Assembled 27 October 2008")
+    allow(File).to receive(:open).with("/etc/release").and_yield(@release)
+    @plugin.run
+    expect(@plugin[:kernel][:update]).to eq('10 10/08 s10s_u6wos_07')
+  end 
+
+  it "should give the Oracle Solaris update version informtion" do
+    @release = StringIO.new("                   Oracle Solaris 10 1/13 s10s_u11wos_24a SPARC\n Assembled 17 January 2013")
+    allow(File).to receive(:open).with("/etc/release").and_yield(@release)
+    @plugin.run
+    expect(@plugin[:kernel][:update]).to eq('10 1/13 s10s_u11wos_24')
+  end 
+
+  it "should give the Solaris 11 update version informtion" do
+    @release = StringIO.new("                            Oracle Solaris 11.3 SPARC\n Assembled 25 July 2016")
+    allow(File).to receive(:open).with("/etc/release").and_yield(@release)
+    @plugin.run
+    expect(@plugin[:kernel][:update]).to eq('11.3')
+  end 
 
   it_should_check_from_deep_mash("solaris2::kernel", "kernel", "os", "uname -s", [0, "SunOS\n", ""])
 

--- a/spec/unit/plugins/solaris2/kernel_spec.rb
+++ b/spec/unit/plugins/solaris2/kernel_spec.rb
@@ -143,21 +143,21 @@ describe Ohai::System, "Solaris2.X kernel plugin" do
     allow(File).to receive(:open).with("/etc/release").and_yield(@release)
   end
 
-  it "should give the Solaris update version informtion" do
+  it "should give the Solaris update version information" do
     @release = StringIO.new("                      Solaris 10 10/08 s10s_u6wos_07b SPARC\n Use is subject to license terms.\n Assembled 27 October 2008")
     allow(File).to receive(:open).with("/etc/release").and_yield(@release)
     @plugin.run
     expect(@plugin[:kernel][:update]).to eq("10 10/08 s10s_u6wos_07")
   end
 
-  it "should give the Oracle Solaris update version informtion" do
+  it "should give the Oracle Solaris update version information" do
     @release = StringIO.new("                   Oracle Solaris 10 1/13 s10s_u11wos_24a SPARC\n Assembled 17 January 2013")
     allow(File).to receive(:open).with("/etc/release").and_yield(@release)
     @plugin.run
     expect(@plugin[:kernel][:update]).to eq("10 1/13 s10s_u11wos_24")
   end
 
-  it "should give the Solaris 11 update version informtion" do
+  it "should give the Solaris 11 update version information" do
     @release = StringIO.new("                            Oracle Solaris 11.3 SPARC\n Assembled 25 July 2016")
     allow(File).to receive(:open).with("/etc/release").and_yield(@release)
     @plugin.run

--- a/spec/unit/plugins/solaris2/kernel_spec.rb
+++ b/spec/unit/plugins/solaris2/kernel_spec.rb
@@ -147,22 +147,22 @@ describe Ohai::System, "Solaris2.X kernel plugin" do
     @release = StringIO.new("                      Solaris 10 10/08 s10s_u6wos_07b SPARC\n Use is subject to license terms.\n Assembled 27 October 2008")
     allow(File).to receive(:open).with("/etc/release").and_yield(@release)
     @plugin.run
-    expect(@plugin[:kernel][:update]).to eq('10 10/08 s10s_u6wos_07')
-  end 
+    expect(@plugin[:kernel][:update]).to eq("10 10/08 s10s_u6wos_07")
+  end
 
   it "should give the Oracle Solaris update version informtion" do
     @release = StringIO.new("                   Oracle Solaris 10 1/13 s10s_u11wos_24a SPARC\n Assembled 17 January 2013")
     allow(File).to receive(:open).with("/etc/release").and_yield(@release)
     @plugin.run
-    expect(@plugin[:kernel][:update]).to eq('10 1/13 s10s_u11wos_24')
-  end 
+    expect(@plugin[:kernel][:update]).to eq("10 1/13 s10s_u11wos_24")
+  end
 
   it "should give the Solaris 11 update version informtion" do
     @release = StringIO.new("                            Oracle Solaris 11.3 SPARC\n Assembled 25 July 2016")
     allow(File).to receive(:open).with("/etc/release").and_yield(@release)
     @plugin.run
-    expect(@plugin[:kernel][:update]).to eq('11.3')
-  end 
+    expect(@plugin[:kernel][:update]).to eq("11.3")
+  end
 
   it_should_check_from_deep_mash("solaris2::kernel", "kernel", "os", "uname -s", [0, "SunOS\n", ""])
 


### PR DESCRIPTION
Extract the Solaris version update information from /etc/release.

The solaris version update information is not reported by Ohai.  Chef is making decisions about chef-client support based on the version update of the solaris os.   Reporting the os information might make it simpler to find older servers that need to be upgraded.  