### PR TITLE
Detect lxd

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -194,5 +194,15 @@ Ohai.plugin(:Virtualization) do
       virtualization[:role] = "guest"
       virtualization[:systems][:docker] = "guest"
     end
+
+    # Detect LXD
+    # See https://github.com/lxc/lxd/blob/master/doc/dev-lxd.md
+    if File.exist?("/dev/lxd/sock")
+      virtualization[:system] = "lxd"
+      virtualization[:role] = "guest"
+    elsif File.exist?("/var/lib/lxd/devlxd")
+      virtualization[:system] = "lxd"
+      virtualization[:role] = "host"
+    end
   end
 end

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -38,6 +38,8 @@ describe Ohai::System, "Linux virtualization platform" do
     allow(File).to receive(:exist?).with("/.dockerinit").and_return(false)
     allow(File).to receive(:exist?).with("/proc/bus/pci/devices").and_return(false)
     allow(File).to receive(:exist?).with("/sys/devices/virtual/misc/kvm").and_return(false)
+    allow(File).to receive(:exist?).with("/dev/lxd/sock").and_return(false)
+    allow(File).to receive(:exist?).with("/var/lib/lxd/devlxd").and_return(false)
 
     # default the which wrappers to nil
     allow(plugin).to receive(:lxc_version_exists?).and_return(false)
@@ -461,6 +463,24 @@ OUTPUT
       allow(File).to receive(:read).with("/proc/bus/pci/devices").and_return(devices)
       plugin.run
       expect(plugin[:virtualization]).to eq({ "systems" => {} })
+    end
+  end
+
+  describe "when we are checking for lxd" do
+    it "sets lxc guest if /dev/lxd/sock exists" do
+      expect(File).to receive(:exist?).with("/dev/lxd/sock").and_return(true)
+
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("lxd")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+    end
+
+    it "setx lxd host if /var/lib/lxd/devlxd exists" do
+      expect(File).to receive(:exist?).with("/var/lib/lxd/devlxd").and_return(true)
+
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("lxd")
+      expect(plugin[:virtualization][:role]).to eq("host")
     end
   end
 


### PR DESCRIPTION
Similar to [857](https://github.com/chef/ohai/pull/857/filesl) i.e detect lxd using [/dev/lxd](https://github.com/lxc/lxd/blob/master/doc/dev-lxd.md).  

I have added tests as well as code to say that the current host is an lxd host. 

