### PR TITLE
Prefer the LSB standard configurator.

### DIFF
--- a/lib/ohai/plugins/linux/lsb.rb
+++ b/lib/ohai/plugins/linux/lsb.rb
@@ -22,21 +22,8 @@ Ohai.plugin(:LSB) do
   collect_data(:linux) do
     lsb Mash.new
 
-    if File.exists?("/etc/lsb-release")
-      File.open("/etc/lsb-release").each do |line|
-        case line
-        when /^DISTRIB_ID=["']?(.+?)["']?$/
-          lsb[:id] = $1
-        when /^DISTRIB_RELEASE=["']?(.+?)["']?$/
-          lsb[:release] = $1
-        when /^DISTRIB_CODENAME=["']?(.+?)["']?$/
-          lsb[:codename] = $1
-        when /^DISTRIB_DESCRIPTION=["']?(.+?)["']?$/
-          lsb[:description] = $1
-        end
-      end
-    elsif File.exists?("/usr/bin/lsb_release")
-      # Fedora/Redhat, requires redhat-lsb package
+    if File.exists?("/usr/bin/lsb_release")
+      # From package redhat-lsb on Fedora/Redhat, lsb-release on Debian/Ubuntu
       so = shell_out("lsb_release -a")
       so.stdout.lines do |line|
         case line
@@ -50,6 +37,20 @@ Ohai.plugin(:LSB) do
           lsb[:codename] = $1
         else
           lsb[:id] = line
+        end
+      end
+    elsif File.exists?("/etc/lsb-release")
+      # Old, non-standard Debian support
+      File.open("/etc/lsb-release").each do |line|
+        case line
+        when /^DISTRIB_ID=["']?(.+?)["']?$/
+          lsb[:id] = $1
+        when /^DISTRIB_RELEASE=["']?(.+?)["']?$/
+          lsb[:release] = $1
+        when /^DISTRIB_CODENAME=["']?(.+?)["']?$/
+          lsb[:codename] = $1
+        when /^DISTRIB_DESCRIPTION=["']?(.+?)["']?$/
+          lsb[:description] = $1
         end
       end
     else

--- a/spec/unit/plugins/linux/lsb_spec.rb
+++ b/spec/unit/plugins/linux/lsb_spec.rb
@@ -35,6 +35,7 @@ describe Ohai::System, "Linux lsb plugin" do
         and_yield("DISTRIB_CODENAME=hardy").
         and_yield('DISTRIB_DESCRIPTION="Ubuntu 8.04"')
       allow(File).to receive(:open).with("/etc/lsb-release").and_return(@double_file)
+      allow(File).to receive(:exists?).with("/usr/bin/lsb_release").and_return(false)
       allow(File).to receive(:exists?).with("/etc/lsb-release").and_return(true)
     end
 
@@ -61,7 +62,6 @@ describe Ohai::System, "Linux lsb plugin" do
 
   describe "on systems with /usr/bin/lsb_release" do
     before(:each) do
-      allow(File).to receive(:exists?).with("/etc/lsb-release").and_return(false)
       allow(File).to receive(:exists?).with("/usr/bin/lsb_release").and_return(true)
 
       @stdin = double("STDIN", { :close => true })


### PR DESCRIPTION
There isn't and has never been mention of /etc/lsb-release in the
official LSB universe. The "correct" way to discover LSB data is with
lsb_release, so this uses that facility first, before falling back to
oddball support.

Without this change, some upgraded boxen will have the wrong results
because an outdated /etc/lsb-release may have been left behind with
different contents than what would come from the lsb_release util.

See:
http://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/lsbrelease.html
http://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/etc.html