### PR TITLE
Ohai uptime plugin hangs in Windows.

### DIFF
--- a/lib/ohai/plugins/uptime.rb
+++ b/lib/ohai/plugins/uptime.rb
@@ -29,7 +29,7 @@ require "ohai/mixin/seconds_to_human"
 Ohai.plugin(:Uptime) do
   provides "uptime", "uptime_seconds"
   provides "idletime", "idletime_seconds" # linux only
-  depends "platform"
+  depends "platform_version"
 
   def collect_uptime(path)
     # kern.boottime: { sec = 1232765114, usec = 823118 } Fri Jan 23 18:45:14 2009
@@ -97,7 +97,7 @@ Ohai.plugin(:Uptime) do
   collect_data(:windows) do
     require "wmi-lite/wmi"
     wmi = WmiLite::Wmi.new
-    if platform_version.to_f >= 6.0  ## for newer version of Windows starting from Windows Server 2008 ##
+    if platform_version.to_f >= 6.0 ## for newer version of Windows starting from Windows Server 2008 ##
       last_boot_up_time = wmi.first_of("Win32_OperatingSystem")["lastbootuptime"]
       uptime_seconds Time.new.to_i - Time.parse(last_boot_up_time).to_i
     else ## for older version of Windows starting from Windows Server 2003 ##

--- a/lib/ohai/plugins/uptime.rb
+++ b/lib/ohai/plugins/uptime.rb
@@ -96,7 +96,8 @@ Ohai.plugin(:Uptime) do
   collect_data(:windows) do
     require "wmi-lite/wmi"
     wmi = WmiLite::Wmi.new
-    uptime_seconds wmi.first_of("Win32_PerfFormattedData_PerfOS_System")["systemuptime"].to_i
+    last_boot_up_time = wmi.first_of("Win32_OperatingSystem")["lastbootuptime"]
+    uptime_seconds Time.new.to_i - Time.parse(last_boot_up_time).to_i
     uptime seconds_to_human(uptime_seconds)
   end
 

--- a/lib/ohai/plugins/uptime.rb
+++ b/lib/ohai/plugins/uptime.rb
@@ -29,6 +29,7 @@ require "ohai/mixin/seconds_to_human"
 Ohai.plugin(:Uptime) do
   provides "uptime", "uptime_seconds"
   provides "idletime", "idletime_seconds" # linux only
+  depends "platform"
 
   def collect_uptime(path)
     # kern.boottime: { sec = 1232765114, usec = 823118 } Fri Jan 23 18:45:14 2009
@@ -96,8 +97,12 @@ Ohai.plugin(:Uptime) do
   collect_data(:windows) do
     require "wmi-lite/wmi"
     wmi = WmiLite::Wmi.new
-    last_boot_up_time = wmi.first_of("Win32_OperatingSystem")["lastbootuptime"]
-    uptime_seconds Time.new.to_i - Time.parse(last_boot_up_time).to_i
+    if platform_version.to_f >= 6.0  ## for newer version of Windows starting from Windows Server 2008 ##
+      last_boot_up_time = wmi.first_of("Win32_OperatingSystem")["lastbootuptime"]
+      uptime_seconds Time.new.to_i - Time.parse(last_boot_up_time).to_i
+    else ## for older version of Windows starting from Windows Server 2003 ##
+      uptime_seconds wmi.first_of("Win32_PerfFormattedData_PerfOS_System")["systemuptime"].to_i
+    end
     uptime seconds_to_human(uptime_seconds)
   end
 

--- a/spec/functional/plugins/windows/uptime_spec.rb
+++ b/spec/functional/plugins/windows/uptime_spec.rb
@@ -1,0 +1,81 @@
+#
+# Author:: Aliasgar Batterywala (<aliasgar.batterywala@msystechnologies.com>)
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+
+describe Ohai::System, "Windows plugin uptime" do
+
+  context "for newer version of Windows" do
+    let(:uptime_plugin) do
+      get_plugin("uptime").tap do |plugin|
+        plugin[:platform_version] = "6.3.9600"
+      end
+    end
+
+    let(:wmi) do
+      double("wmi", { :first_of =>
+        { "lastbootuptime" => "20160912103128.597219+330" },
+      })
+    end
+
+    before(:each) do
+      allow(uptime_plugin).to receive(:collect_os).and_return(:windows)
+      allow(WmiLite::Wmi).to receive(:new).and_return(wmi)
+      allow(Time).to receive_message_chain(:new, :to_i).and_return(1473756619)
+    end
+
+    it "should set uptime_seconds to uptime" do
+      uptime_plugin.run
+      expect(uptime_plugin[:uptime_seconds]).to be == 100131
+    end
+
+    it "should set uptime to a human readable value" do
+      uptime_plugin.run
+      expect(uptime_plugin[:uptime]).to eq("1 day 03 hours 48 minutes 51 seconds")
+    end
+  end
+
+  context "for older version of Windows" do
+    let(:uptime_plugin) do
+      get_plugin("uptime").tap do |plugin|
+        plugin[:platform_version] = "5.0.2195"
+      end
+    end
+
+    let(:wmi) do
+      double("wmi", { :first_of =>
+        { "systemuptime" => "785345" },
+      })
+    end
+
+    before(:each) do
+      allow(uptime_plugin).to receive(:collect_os).and_return(:windows)
+      allow(WmiLite::Wmi).to receive(:new).and_return(wmi)
+    end
+
+    it "should set uptime_seconds to uptime" do
+      uptime_plugin.run
+      expect(uptime_plugin[:uptime_seconds]).to be == 785345
+    end
+
+    it "should set uptime to a human readable value" do
+      uptime_plugin.run
+      expect(uptime_plugin[:uptime]).to eq("9 days 02 hours 09 minutes 05 seconds")
+    end
+  end
+end

--- a/spec/functional/plugins/windows/uptime_spec.rb
+++ b/spec/functional/plugins/windows/uptime_spec.rb
@@ -29,7 +29,7 @@ describe Ohai::System, "Windows plugin uptime" do
 
     let(:wmi) do
       double("wmi", { :first_of =>
-        { "lastbootuptime" => "20160912103128.597219+330" },
+        { "lastbootuptime" => "20160912103128.597219+0000" },
       })
     end
 
@@ -41,12 +41,12 @@ describe Ohai::System, "Windows plugin uptime" do
 
     it "should set uptime_seconds to uptime" do
       uptime_plugin.run
-      expect(uptime_plugin[:uptime_seconds]).to be == 100131
+      expect(uptime_plugin[:uptime_seconds]).to be == 80331
     end
 
     it "should set uptime to a human readable value" do
       uptime_plugin.run
-      expect(uptime_plugin[:uptime]).to eq("1 day 03 hours 48 minutes 51 seconds")
+      expect(uptime_plugin[:uptime]).to eq("22 hours 18 minutes 51 seconds")
     end
   end
 

--- a/spec/unit/plugins/windows/uptime_spec.rb
+++ b/spec/unit/plugins/windows/uptime_spec.rb
@@ -1,0 +1,88 @@
+#
+# Author:: Aliasgar Batterywala (<aliasgar.batterywala@msystechnologies.com>)
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+
+describe Ohai::System, "Windows plugin uptime" do
+
+  let(:wmi) { double("wmi", { :first_of => "" }) }
+
+  before(:each) do
+    allow(WmiLite::Wmi).to receive(:new).and_return(wmi)
+  end
+
+  ## Windows newer versions category here includes server OS starting from Windows Server 2008 ##
+  shared_context "WMI class to use to fetch system uptime for newer versions of Windows platform" do
+    before do
+      allow(uptime_plugin).to receive(:collect_os).and_return(:windows)
+    end
+
+    it "uses Win32_OperatingSystem WMI class to fetch the system's uptime" do
+      expect(wmi).to receive(:first_of).with("Win32_OperatingSystem")
+      expect(Time).to receive(:new)
+      expect(Time).to receive(:parse)
+      expect(uptime_plugin).to receive(:seconds_to_human)
+      uptime_plugin.run
+    end
+  end
+
+  ## Windows older versions category here includes server OS starting from Windows Server 2003 ##
+  shared_context "WMI class to use to fetch system uptime for older versions of Windows platform" do
+    before do
+      allow(uptime_plugin).to receive(:collect_os).and_return(:windows)
+    end
+
+    it "uses Win32_PerfFormattedData_PerfOS_System WMI class to fetch the system's uptime" do
+      expect(wmi).to receive(:first_of).with("Win32_PerfFormattedData_PerfOS_System")
+      expect(Time).to_not receive(:new)
+      expect(Time).to_not receive(:parse)
+      expect(uptime_plugin).to receive(:seconds_to_human)
+      uptime_plugin.run
+    end
+  end
+
+  context "platform is Windows Server 2008 R2" do
+    let(:uptime_plugin) do
+      get_plugin("uptime").tap do |plugin|
+        plugin[:platform_version] = "6.1.7601"
+      end
+    end
+
+    include_context "WMI class to use to fetch system uptime for newer versions of Windows platform"
+  end
+
+  context "platform is Windows Server 2003 R2" do
+    let(:uptime_plugin) do
+      get_plugin("uptime").tap do |plugin|
+        plugin[:platform_version] = "5.2.3790"
+      end
+    end
+
+    include_context "WMI class to use to fetch system uptime for older versions of Windows platform"
+  end
+
+  context "platform is Windows Server 2012" do
+    let(:uptime_plugin) do
+      get_plugin("uptime").tap do |plugin|
+        plugin[:platform_version] = "6.2.9200"
+      end
+    end
+
+    include_context "WMI class to use to fetch system uptime for newer versions of Windows platform"
+  end
+end

--- a/spec/unit/plugins/windows/uptime_spec.rb
+++ b/spec/unit/plugins/windows/uptime_spec.rb
@@ -27,7 +27,7 @@ describe Ohai::System, "Windows plugin uptime" do
   end
 
   ## Windows newer versions category here includes server OS starting from Windows Server 2008 ##
-  shared_context "WMI class to use to fetch system uptime for newer versions of Windows platform" do
+  shared_context "WMI class for newer versions of Windows platform" do
     before do
       allow(uptime_plugin).to receive(:collect_os).and_return(:windows)
     end
@@ -42,7 +42,7 @@ describe Ohai::System, "Windows plugin uptime" do
   end
 
   ## Windows older versions category here includes server OS starting from Windows Server 2003 ##
-  shared_context "WMI class to use to fetch system uptime for older versions of Windows platform" do
+  shared_context "WMI class for older versions of Windows platform" do
     before do
       allow(uptime_plugin).to receive(:collect_os).and_return(:windows)
     end
@@ -63,7 +63,7 @@ describe Ohai::System, "Windows plugin uptime" do
       end
     end
 
-    include_context "WMI class to use to fetch system uptime for newer versions of Windows platform"
+    include_context "WMI class for newer versions of Windows platform"
   end
 
   context "platform is Windows Server 2003 R2" do
@@ -73,7 +73,7 @@ describe Ohai::System, "Windows plugin uptime" do
       end
     end
 
-    include_context "WMI class to use to fetch system uptime for older versions of Windows platform"
+    include_context "WMI class for older versions of Windows platform"
   end
 
   context "platform is Windows Server 2012" do
@@ -83,6 +83,6 @@ describe Ohai::System, "Windows plugin uptime" do
       end
     end
 
-    include_context "WMI class to use to fetch system uptime for newer versions of Windows platform"
+    include_context "WMI class for newer versions of Windows platform"
   end
 end


### PR DESCRIPTION
Ohai uptime plugin hangs in Windows, solution:

1. Changed WMI class to `Win32_OperatingSystem` for newer versions of Windows.
2. Kept the old WMI class `Win32_PerfFormattedData_PerfOS_System` for older versions of Windows.

WMI class is from where we retrieve the system's uptime for Windows platform.