### PR TITLE
Remove Ruby 1.8 / 1.9 spec helpers

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -109,8 +109,6 @@ RSpec.configure do |config|
 
   config.filter_run_excluding :windows_only => true unless windows?
   config.filter_run_excluding :unix_only => true unless unix?
-  config.filter_run_excluding :ruby_18_only => true unless ruby_18?
-  config.filter_run_excluding :ruby_19_only => true unless ruby_19?
   config.filter_run_excluding :requires_root => true unless ENV["USER"] == "root"
   config.filter_run_excluding :requires_unprivileged_user => true if ENV["USER"] == "root"
 

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -1,16 +1,6 @@
-def ruby_19?
-  !!(RUBY_VERSION =~ /^1.9/)
-end
-
-def ruby_18?
-  !!(RUBY_VERSION =~ /^1.8/)
-end
-
 def windows?
   !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
 end
-
-# def jruby?
 
 def unix?
   !windows?


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>