### PR TITLE
Move dev deps to the Gemfile and bump changelog generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,17 @@ gemspec
 group :development do
   gem "sigar", :platform => "ruby"
 
-  gem "chefstyle", "= 0.4.0"
+  gem "chefstyle"
   gem "overcommit", ">= 0.34.1"
   gem "pry-byebug"
   gem "pry-stack_explorer"
   gem "rb-readline"
+  gem "rake", ">= 10.1.0", "< 12.0.0"
+  gem "rspec-core", "~> 3.0"
+  gem "rspec-expectations", "~> 3.0"
+  gem "rspec-mocks", "~> 3.0"
+  gem "rspec-collection_matchers", "~> 1.0"
+  gem "rspec_junit_formatter"
+  gem "github_changelog_generator", ">= 1.14"
+  gem "activesupport", "< 5.0" if RUBY_VERSION <= "2.2.2" # github_changelog_generator dep
 end

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -35,18 +35,6 @@ Gem::Specification.new do |s|
   # Chef 13 starts, otherwise builds will break.
   s.add_dependency "chef-config", ">= 12.5.0.alpha.1", "< 13"
 
-  s.add_development_dependency "rake", ">= 10.1.0", "< 12.0.0"
-  s.add_development_dependency "rspec-core", "~> 3.0"
-  s.add_development_dependency "rspec-expectations", "~> 3.0"
-  s.add_development_dependency "rspec-mocks", "~> 3.0"
-  s.add_development_dependency "rspec-collection_matchers", "~> 1.0"
-  s.add_development_dependency "rspec_junit_formatter"
-  s.add_development_dependency "github_changelog_generator", "1.13.1"
-
-  # github_changelog_generator -> github-api -> oauth2 -> rack
-  # rack being unconstrained breaks Ruby 2.1 installs
-  s.add_development_dependency "rack", "~> 1.0"
-
   s.bindir = "bin"
   s.executables = %w{ohai}
 


### PR DESCRIPTION
This removes the need for Rack 1.X which we had to pin due to the old github changelog generator release. We now have a new active support pin to keep Ruby 2.1 support

Signed-off-by: Tim Smith <tsmith@chef.io>