### PR TITLE
Add shard plugin support for platforms other than Linux and Darwin

### DIFF
--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -56,6 +56,12 @@ Ohai.plugin(:ShardSeed) do
     shard_seed Digest::MD5.hexdigest(data)[0...7].to_i(16)
   end
 
+  collect_data(:default) do
+    create_seed do
+      ''
+    end
+  end
+
   collect_data(:darwin) do
     create_seed do |src|
       case src


### PR DESCRIPTION
Shard is set up in a way to provide sharding regardless of platform, however we don't define a `:default` collect_data, so shards only work on Darwin and Linux.

This allows other platforms to use shard with the basic seed types (so not hardware identifiers).