### PR TITLE
Use name for Windows CPU model_name

### DIFF
--- a/lib/ohai/plugins/windows/cpu.rb
+++ b/lib/ohai/plugins/windows/cpu.rb
@@ -60,7 +60,8 @@ Ohai.plugin(:CPU) do
                                        processor["stepping"]
                                      end
       cpu[current_cpu]["physical_id"] = processor["deviceid"]
-      cpu[current_cpu]["model_name"] = processor["description"]
+      cpu[current_cpu]["model_name"] = processor["name"]
+      cpu[current_cpu]["description"] = processor["description"]
       cpu[current_cpu]["mhz"] = processor["maxclockspeed"].to_s
       cpu[current_cpu]["cache_size"] = "#{processor['l2cachesize']} KB"
     end

--- a/spec/unit/plugins/windows/cpu_spec.rb
+++ b/spec/unit/plugins/windows/cpu_spec.rb
@@ -32,8 +32,13 @@ shared_examples "a cpu" do |cpu_no|
       expect(@plugin[:cpu]["#{cpu_no}"][:vendor_id]).to eq("GenuineIntel")
     end
 
-    it "should set model_name to Intel64 Family 6 Model 70 Stepping 1" do
+    it "should set model_name to Intel(R) Core(TM) i7-4500U CPU @ 1.80GHz" do
       expect(@plugin[:cpu]["#{cpu_no}"][:model_name])
+        .to eq("Intel(R) Core(TM) i7-4500U CPU @ 1.80GHz")
+    end
+
+    it "should set description to Intel64 Family 6 Model 70 Stepping 1" do
+      expect(@plugin[:cpu]["#{cpu_no}"][:description])
         .to eq("Intel64 Family 6 Model 70 Stepping 1")
     end
 
@@ -64,6 +69,7 @@ describe Ohai::System, "Windows cpu plugin" do
     @double_wmi_instance = instance_double(WmiLite::Wmi)
 
     @processors = [{ "description" => "Intel64 Family 6 Model 70 Stepping 1",
+                     "name" => "Intel(R) Core(TM) i7-4500U CPU @ 1.80GHz",
                      "deviceid" => "CPU0",
                      "family" => 2,
                      "manufacturer" => "GenuineIntel",
@@ -75,6 +81,7 @@ describe Ohai::System, "Windows cpu plugin" do
                      "l2cachesize" => 64 },
 
                    { "description" => "Intel64 Family 6 Model 70 Stepping 1",
+                     "name" => "Intel(R) Core(TM) i7-4500U CPU @ 1.80GHz",
                      "deviceid" => "CPU1",
                      "family" => 2,
                      "manufacturer" => "GenuineIntel",


### PR DESCRIPTION
### Description

Use the "name" value for the model_name, and move description to the
description field.

### Issues Resolved

* COOL-626
* Fixes #904 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Tom Duffield <tom@chef.io>