### PR TITLE
Properly detect Cumulus Linux platform / version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,21 +9,6 @@ Details about the thing that changed that needs to get included in the Release N
 
 # Ohai Release Notes:
 
-## Haskell Language plugin
+## Cumulus Linux Platform
 
-Haskell is now detected in a new haskell language plugin:
-
-```javascript
-"languages": {
-  "haskell": {
-    "stack": {
-      "version": "1.2.0",
-      "description": "Version 1.2.0 x86_64 hpack-0.14.0"
-    }
-  }
-}
-```
-
-## LSB Release Detection
-
-The lsb_release command line tool is now preferred to the contents of /etc/lsb-release. This resolves an issue where a distro can be upgraded, but /etc/lsb-release is not upgraded to reflect the change
+Cumulus Linux will now be detected as platform `cumulus` instead of `debian` and the `platform_version` will be properly set to the Cumulus Linux release.

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -166,12 +166,6 @@ Ohai.plugin(:Platform) do
       contents = File.read("/etc/system-release").chomp
       platform get_redhatish_platform(contents)
       platform_version get_redhatish_version(contents)
-    elsif File.exist?("/etc/gentoo-release")
-      platform "gentoo"
-      # the gentoo release version is the base version used to bootstrap
-      # a node and doesn't have a lot of meaning in a rolling release distro
-      # kernel release will be used - ex. 3.18.7-gentoo
-      platform_version `uname -r`.strip
     elsif File.exist?("/etc/SuSE-release")
       suse_release = File.read("/etc/SuSE-release")
       suse_version = suse_release.scan(/VERSION = (\d+)\nPATCHLEVEL = (\d+)/).flatten.join(".")
@@ -187,22 +181,6 @@ Ohai.plugin(:Platform) do
       else
         platform "suse"
       end
-    elsif File.exist?("/etc/slackware-version")
-      platform "slackware"
-      platform_version File.read("/etc/slackware-version").scan(/(\d+|\.+)/).join
-    elsif File.exist?("/etc/arch-release")
-      platform "arch"
-      # no way to determine platform_version in a rolling release distribution
-      # kernel release will be used - ex. 2.6.32-ARCH
-      platform_version `uname -r`.strip
-    elsif File.exist?("/etc/exherbo-release")
-      platform "exherbo"
-      # no way to determine platform_version in a rolling release distribution
-      # kernel release will be used - ex. 3.13
-      platform_version `uname -r`.strip
-    elsif File.exist?("/etc/alpine-release")
-      platform "alpine"
-      platform_version File.read("/etc/alpine-release").strip()
     elsif File.exist?("/etc/Eos-release")
       platform "arista_eos"
       platform_version File.read("/etc/Eos-release").strip.split[-1]
@@ -222,6 +200,28 @@ Ohai.plugin(:Platform) do
 
       platform_family "wrlinux"
       platform_version os_release_info["VERSION"]
+    elsif File.exist?("/etc/gentoo-release")
+      platform "gentoo"
+      # the gentoo release version is the base version used to bootstrap
+      # a node and doesn't have a lot of meaning in a rolling release distro
+      # kernel release will be used - ex. 3.18.7-gentoo
+      platform_version `uname -r`.strip
+    elsif File.exist?("/etc/slackware-version")
+      platform "slackware"
+      platform_version File.read("/etc/slackware-version").scan(/(\d+|\.+)/).join
+    elsif File.exist?("/etc/arch-release")
+      platform "arch"
+      # no way to determine platform_version in a rolling release distribution
+      # kernel release will be used - ex. 2.6.32-ARCH
+      platform_version `uname -r`.strip
+    elsif File.exist?("/etc/exherbo-release")
+      platform "exherbo"
+      # no way to determine platform_version in a rolling release distribution
+      # kernel release will be used - ex. 3.13
+      platform_version `uname -r`.strip
+    elsif File.exist?("/etc/alpine-release")
+      platform "alpine"
+      platform_version File.read("/etc/alpine-release").strip()
     elsif lsb[:id] =~ /RedHat/i
       platform "redhat"
       platform_version lsb[:release]

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -99,7 +99,7 @@ Ohai.plugin(:Platform) do
   end
 
   #
-  # Determines the platform_family based on the platform_family
+  # Determines the platform_family based on the platform
   #
   # @returns [String] platform_family value
   #

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -176,7 +176,6 @@ describe Ohai::System, "Linux plugin platform" do
     context "on cumulus" do
 
       let(:have_cumulus_dir) { true }
-      let(:have_cumulus_release) { true }
       let(:cumulus_release_content) do
         <<-OS_RELEASE
 NAME="Cumulus Linux"
@@ -193,7 +192,6 @@ OS_RELEASE
       end
 
       before(:each) do
-        expect(File).to receive(:exist?).with("/etc/cumulus/etc.replace/os-release").and_return(true)
         expect(File).to receive(:read).with("/etc/cumulus/etc.replace/os-release").and_return(cumulus_release_content)
       end
 

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -17,7 +17,6 @@
 #
 
 require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
 
 describe Ohai::System, "Linux plugin platform" do
 
@@ -37,6 +36,7 @@ describe Ohai::System, "Linux plugin platform" do
   let(:have_raspi_config) { false }
   let(:have_os_release) { false }
   let(:have_cisco_release) { false }
+  let(:have_cumulus_dir) { false }
 
   before(:each) do
     @plugin = get_plugin("linux/platform")
@@ -58,6 +58,7 @@ describe Ohai::System, "Linux plugin platform" do
     allow(File).to receive(:exist?).with("/usr/bin/raspi-config").and_return(have_raspi_config)
     allow(File).to receive(:exist?).with("/etc/os-release").and_return(have_os_release)
     allow(File).to receive(:exist?).with("/etc/shared/os-release").and_return(have_cisco_release)
+    allow(Dir).to receive(:exist?).with("/etc/cumulus").and_return(have_cumulus_dir)
 
     allow(File).to receive(:read).with("PLEASE STUB ALL File.read CALLS")
   end
@@ -171,6 +172,43 @@ describe Ohai::System, "Linux plugin platform" do
         expect(@plugin[:platform_family]).to eq("debian")
       end
     end
+
+    context "on cumulus" do
+
+      let(:have_cumulus_dir) { true }
+      let(:have_cumulus_release) { true }
+      let(:cumulus_release_content) do
+        <<-OS_RELEASE
+NAME="Cumulus Linux"
+VERSION_ID=3.1.2
+VERSION="Cumulus Linux 3.1.2"
+PRETTY_NAME="Cumulus Linux"
+ID=cumulus-linux
+ID_LIKE=debian
+CPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:3.1.2
+HOME_URL="http://www.cumulusnetworks.com/"
+SUPPORT_URL="http://support.cumulusnetworks.com/"
+
+OS_RELEASE
+      end
+
+      before(:each) do
+        expect(File).to receive(:exist?).with("/etc/cumulus/etc.replace/os-release").and_return(true)
+        expect(File).to receive(:read).with("/etc/cumulus/etc.replace/os-release").and_return(cumulus_release_content)
+      end
+
+      # Cumulus is a debian derivative
+      it "should detect Cumulus as itself with debian as the family" do
+        @plugin.run
+        expect(@plugin[:platform]).to eq("cumulus")
+        expect(@plugin[:platform_family]).to eq("debian")
+      end
+
+      it "should detect Cumulus platform_version" do
+        @plugin.run
+        expect(@plugin[:platform_version]).to eq("3.1.2")
+      end
+    end
   end
 
   describe "on slackware" do
@@ -186,6 +224,12 @@ describe Ohai::System, "Linux plugin platform" do
       @plugin.run
       expect(@plugin[:platform]).to eq("slackware")
       expect(@plugin[:platform_family]).to eq("slackware")
+    end
+
+    it "should set platform_version on slackware" do
+      expect(File).to receive(:read).with("/etc/slackware-version").and_return("Slackware 12.0.0")
+      @plugin.run
+      expect(@plugin[:platform_version]).to eq("12.0.0")
     end
   end
 


### PR DESCRIPTION
### Description

Detect cumulus Linux systems if they have /etc/cumulus directory. Use platform of ‘cumulus’ and platform_family debian since it’s Debian 8.5. Parse version from their config directory.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
