### PR TITLE
Windows guest support on Hyper-v and Xen.

### DIFF
--- a/lib/ohai/plugins/windows/virtualization.rb
+++ b/lib/ohai/plugins/windows/virtualization.rb
@@ -44,6 +44,14 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "kvm"
       virtualization[:role] = "guest"
       virtualization[:systems][:kvm] = "guest"
+    when "American Megatrends Inc."
+      virtualization[:system] = "hyper-v"
+      virtualization[:role] = "guest"
+      virtualization[:systems][:hyperv] = "guest"
+    when "Xen"
+      virtualization[:system] = "xen"
+      virtualization[:role] = "guest"
+      virtualization[:systems][:xen] = "guest"
     end
 
     # vmware fusion detection

--- a/lib/ohai/plugins/windows/virtualization.rb
+++ b/lib/ohai/plugins/windows/virtualization.rb
@@ -45,9 +45,11 @@ Ohai.plugin(:Virtualization) do
       virtualization[:role] = "guest"
       virtualization[:systems][:kvm] = "guest"
     when "American Megatrends Inc."
-      virtualization[:system] = "hyper-v"
-      virtualization[:role] = "guest"
-      virtualization[:systems][:hyperv] = "guest"
+      if bios[0]["version"] =~ /VRTUAL -/
+        virtualization[:system] = "hyper-v"
+        virtualization[:role] = "guest"
+        virtualization[:systems][:hyperv] = "guest"
+      end
     when "Xen"
       virtualization[:system] = "xen"
       virtualization[:role] = "guest"

--- a/spec/unit/plugins/windows/virtualization_spec.rb
+++ b/spec/unit/plugins/windows/virtualization_spec.rb
@@ -175,7 +175,7 @@ describe Ohai::System, "Windows virtualization platform" do
 
   context "when running on hyper-v" do
     it "system is hyper-v" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "bioscharacteristics" => [4,7,9,11,12,14,15,16,17,19,22,23,24,25,26,27,28,29,30,34,36,37,40],
+      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "bioscharacteristics" => [4, 7, 9, 11, 12, 14, 15, 16, 17, 19, 22, 23, 24, 25, 26, 27, 28, 29, 30, 34, 36, 37, 40],
                                                                                                      "biosversion" => ["VRTUAL - 4001628, BIOS Date: 04/28/16 13:00:17  Ver: 09.00.06, BIOS Date: 04/28/16 13:00:17 Ver: 09.00.06"],
                                                                                                      "buildnumber" => nil,
                                                                                                      "codeset" => nil,
@@ -202,10 +202,10 @@ describe Ohai::System, "Windows virtualization platform" do
                                                                                                      "targetoperatingsystem" => 0,
                                                                                                      "version" => "VRTUAL - 4001628",
       }])
-    plugin.run
-    expect(plugin[:virtualization][:system]).to eq("hyper-v")
-    expect(plugin[:virtualization][:role]).to eq("guest")
-    expect(plugin[:virtualization][:systems][:hyperv]).to eq("guest")
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("hyper-v")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+      expect(plugin[:virtualization][:systems][:hyperv]).to eq("guest")
     end
   end
 
@@ -215,13 +215,13 @@ describe Ohai::System, "Windows virtualization platform" do
                                                                                                      "manufacturer" => "Xen",
                                                                                                      "name" => "Revision: 1.221",
                                                                                                      "serialnumber" => "ec2b487f-d9ed-7d17-c7c0-1d4599d6c1da",
-                                                                                                     "version" => "Xen - 0"
+                                                                                                     "version" => "Xen - 0",
       }])
-    plugin.run
-    expect(plugin[:virtualization][:system]).to eq("xen")
-    expect(plugin[:virtualization][:role]).to eq("guest")
-    expect(plugin[:virtualization][:systems][:xen]).to eq("guest")
-    end    
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("xen")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+      expect(plugin[:virtualization][:systems][:xen]).to eq("guest")
+    end
   end
 
   context "when running on a hardware system" do

--- a/spec/unit/plugins/windows/virtualization_spec.rb
+++ b/spec/unit/plugins/windows/virtualization_spec.rb
@@ -173,6 +173,57 @@ describe Ohai::System, "Windows virtualization platform" do
     end
   end
 
+  context "when running on hyper-v" do
+    it "system is hyper-v" do
+      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "bioscharacteristics" => [4,7,9,11,12,14,15,16,17,19,22,23,24,25,26,27,28,29,30,34,36,37,40],
+                                                                                                     "biosversion" => ["VRTUAL - 4001628, BIOS Date: 04/28/16 13:00:17  Ver: 09.00.06, BIOS Date: 04/28/16 13:00:17 Ver: 09.00.06"],
+                                                                                                     "buildnumber" => nil,
+                                                                                                     "codeset" => nil,
+                                                                                                     "currentlanguage" => "enUS",
+                                                                                                     "description" => "BIOS Date: 04/28/16 13:00:17  Ver: 09.00.06",
+                                                                                                     "identificationcode" => nil,
+                                                                                                     "installablelanguages" => 1,
+                                                                                                     "installdate" => nil,
+                                                                                                     "languageedition" => nil,
+                                                                                                     "listoflanguages" => ["enUS"],
+                                                                                                     "manufacturer" => "American Megatrends Inc.",
+                                                                                                     "name" => "BIOS Date: 04/28/16 13:00:17  Ver: 09.00.06",
+                                                                                                     "othertargetos" => nil,
+                                                                                                     "primarybios" => true,
+                                                                                                     "releasedate" => "20160428000000.000000+000",
+                                                                                                     "serialnumber" => "1158-1757-7941-3855-2170-4122-00",
+                                                                                                     "smbiosbiosversion" => "090006",
+                                                                                                     "smbiosmajorversion" => 2,
+                                                                                                     "smbiosminorversion" => 3,
+                                                                                                     "smbiospresent" => true,
+                                                                                                     "softwareelementid" => "BIOS Date: 04/28/16 13:00:17  Ver: 09.00.06",
+                                                                                                     "softwareelementstate" => 3,
+                                                                                                     "status" => "OK",
+                                                                                                     "targetoperatingsystem" => 0,
+                                                                                                     "version" => "VRTUAL - 4001628",
+      }])
+    plugin.run
+    expect(plugin[:virtualization][:system]).to eq("hyper-v")
+    expect(plugin[:virtualization][:role]).to eq("guest")
+    expect(plugin[:virtualization][:systems][:hyperv]).to eq("guest")
+    end
+  end
+
+  context "when running on xen" do
+    it "system is xen" do
+      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "smbiosbiosversion" => ["4.2.amazon"],
+                                                                                                     "manufacturer" => "Xen",
+                                                                                                     "name" => "Revision: 1.221",
+                                                                                                     "serialnumber" => "ec2b487f-d9ed-7d17-c7c0-1d4599d6c1da",
+                                                                                                     "version" => "Xen - 0"
+      }])
+    plugin.run
+    expect(plugin[:virtualization][:system]).to eq("xen")
+    expect(plugin[:virtualization][:role]).to eq("guest")
+    expect(plugin[:virtualization][:systems][:xen]).to eq("guest")
+    end    
+  end
+
   context "when running on a hardware system" do
     it "does not set virtualization attributes" do
       allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "bioscharacteristics" => [7, 11, 12, 15, 16, 17, 19, 23, 24, 25, 26, 27, 28, 29, 32, 33, 40, 42, 43],


### PR DESCRIPTION
### Description

This change allows Windows guest systems to detect the virtualization platform when running on both Hyper-v and Xen.

### Issues Resolved

#664 

### Check List

- [ X] New functionality includes tests
- [ X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Bob Dean <radean@hotmail.com>