### PR TITLE
Bump ruby versions and test on ruby head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,12 @@ before_install:
   - gem --version
 rvm:
   - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.3
+  - ruby-head
+
+allow_failures:
+  - rvm: ruby-head
 
 script:
   - bundle exec chefstyle


### PR DESCRIPTION
Test ruby 2.2.6 and 2.3.3 and now ruby-head, which is allowed to fail