### PR TITLE
updating cloud plugin to populate azure private_ip as it's currently nil

### DIFF
--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -208,6 +208,7 @@ Ohai.plugin(:Cloud) do
   # Fill cloud hash with azure values
   def get_azure_values
     cloud[:vm_name] = azure["vm_name"]
+    cloud[:private_ips] << azure["private_ip"]
     cloud[:public_ips] << azure["public_ip"]
     cloud[:public_ipv4] = azure["public_ip"]
     cloud[:public_fqdn] = azure["public_fqdn"]

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -162,6 +162,12 @@ describe Ohai::System, "plugin cloud" do
       @plugin[:azure] = Mash.new()
     end
 
+    it "populates cloud private ip" do
+      @plugin[:azure]["private_ip"] = "10.0.0.1"
+      @plugin.run
+      expect(@plugin[:cloud][:private_ips][0]).to eq(@plugin[:azure]["private_ip"])
+    end
+
     it "populates cloud public ip" do
       @plugin[:azure]["public_ip"] = "174.129.150.8"
       @plugin.run


### PR DESCRIPTION
### Description
Updates the cloud plugin to populate the node['cloud']['private'] ip array from the azure mash. 

### Issues Resolved
None created
### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
