### PR TITLE
Require Ruby 2.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
   - bundle --version
   - gem --version
 rvm:
-  - 2.1.9
   - 2.2.6
   - 2.3.3
+  - 2.4.0
   - ruby-head
 
 allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,4 @@ group :development do
   gem "rspec-collection_matchers", "~> 1.0"
   gem "rspec_junit_formatter"
   gem "github_changelog_generator", git: "https://github.com/tduffield/github-changelog-generator", branch: "adjust-tag-section-mapping"
-  gem "activesupport", "< 5.0" if RUBY_VERSION <= "2.2.2" # github_changelog_generator dep
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "21"
     - ruby_version: "22"
     - ruby_version: "23"
 

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://docs.chef.io/ohai.html"
 
-  s.required_ruby_version = ">= 2.1.0"
+  s.required_ruby_version = ">= 2.2.0"
 
   s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "ffi-yajl", "~> 2.2"


### PR DESCRIPTION
chef/chef already requires Ruby 2.2. We've removed support for Ruby 2.1
in our other projects and community tooling.

Signed-off-by: Tim Smith <tsmith@chef.io>

I think this is a pretty minor impact, but we can wait till Ohai 13 in April if we want.