### PR TITLE
Remove deprecated config logic

### DIFF
--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -19,7 +19,6 @@
 
 require "chef-config/config"
 require "ohai/exception"
-require "ohai/log"
 require "ohai/plugin_config"
 
 module Ohai
@@ -28,98 +27,14 @@ module Ohai
   # Reopens ChefConfig::Config to add Ohai configuration settings.
   # see: https://github.com/chef/chef/blob/master/lib/chef/config.rb
   class Config
-    # These methods need to be defined before they are used as config defaults,
-    # otherwise they will get method_missing'd to nil.
-
-    class << self
-      def merge_deprecated_config
-        [ :hints_path, :plugin_path ].each do |option|
-          if has_key?(option) && send(option) != send("default_#{option}".to_sym)
-            Ohai::Log.warn(option_deprecated(option))
-          end
-        end
-
-        ohai.merge!(configuration)
-      end
-
-      def default_hints_path
-        [ ChefConfig::Config.platform_specific_path("/etc/chef/ohai/hints") ]
-      end
-
-      def default_plugin_path
-        [ File.expand_path(File.join(File.dirname(__FILE__), "plugins")) ]
-      end
-    end
-
-    # Copy deprecated configuration options into the ohai config context.
-
-    # Keep "old" config defaults around so anyone calling Ohai::Config[:key]
-    # won't be broken. Also allows users to append to configuration options
-    # (e.g., Ohai::Config[:plugin_path] << some_path) in their config files.
-    default :disabled_plugins, []
-    default :hints_path, default_hints_path
-    default :log_level, :auto
-    default :log_location, STDERR
-    default :plugin_path, default_plugin_path
-
-    # Log deprecation warning when a top-level configuration option is set.
-    # TODO: Should we implement a config_attr_reader so that deprecation
-    # warnings will be generatd on read?
-    [
-      :directory,
-      :disabled_plugins,
-      :log_level,
-      :log_location,
-      :version,
-    ].each do |option|
-      # https://docs.chef.io/config_rb_client.html#ohai-settings
-      # hints_path and plugin_path are intentionally excluded here; warnings for
-      # setting these attributes are generated in merge_deprecated_config since
-      # append (<<) operations bypass the config writer.
-      config_attr_writer option do |value|
-        # log_level and log_location are common configuration options for chef
-        # and other chef applications. When configuration files are read there
-        # is no distinction between log_level and Ohai::Config[:log_level] and
-        # we may emit a false deprecation warning. The deprecation warnings for
-        # these settings reflect that possibility.
-        # Furthermore, when the top-level config settings are removed we will
-        # need to ensure that Ohai.config[:log_level] can be set by writing
-        # log_level in a configuration file for consistent behavior with chef.
-        deprecation_warning = if [ :log_level, :log_location ].include?(value)
-                                option_might_be_deprecated(option)
-                              else
-                                option_deprecated(option)
-                              end
-        Ohai::Log.warn(deprecation_warning)
-        value
-      end
-    end
 
     config_context :ohai do
       default :disabled_plugins, []
-      default :hints_path, Ohai::Config.default_hints_path
+      default :hints_path, [ ChefConfig::Config.platform_specific_path("/etc/chef/ohai/hints") ]
       default :log_level, :auto
       default :log_location, STDERR
       default :plugin, Ohai::PluginConfig.new { |h, k| h[k] = Ohai::PluginConfig.new }
-      default :plugin_path, Ohai::Config.default_plugin_path
-    end
-
-    class << self
-      def option_deprecated(option)
-        <<-EOM.chomp!.tr("\n", " ")
-Ohai::Config[:#{option}] is set. Ohai::Config[:#{option}] is deprecated and will
-be removed in future releases of ohai. Use ohai.#{option} in your configuration
-file to configure :#{option} for ohai.
-        EOM
-      end
-
-      def option_might_be_deprecated(option)
-        option_deprecated(option) + <<-EOM.chomp!.tr("\n", " ")
- If your configuration file is used with other applications which configure
-:#{option}, and you have not configured Ohai::Config[:#{option}], you may
-disregard this warning.
-        EOM
-      end
+      default :plugin_path, [ File.expand_path(File.join(File.dirname(__FILE__), "plugins")), ChefConfig::Config.platform_specific_path("/etc/chef/ohai/plugins") ]
     end
   end
 

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -208,7 +208,6 @@ module Ohai
     private
 
     def configure_ohai
-      Ohai::Config.merge_deprecated_config
       Ohai.config.merge!(@config)
 
       if Ohai.config[:directory] &&

--- a/spec/functional/application_spec.rb
+++ b/spec/functional/application_spec.rb
@@ -86,45 +86,6 @@ RSpec.describe "Ohai::Application" do
       end
     end
 
-    context "when the configuration file contains deprecated config options" do
-      # For the purpose of these tests it doesn't matter if the configuration
-      # file was specified via command line or discovered on the local
-      # workstation. It's easier if we pass the configuration file as a cli
-      # argument (there's less to stub).
-
-      let(:argv) { [ "-c", config_location ] }
-
-      let(:config_content) do
-        <<-CONFIG
-log_location "#{log_location}"
-log_level    :#{log_level}
-Ohai::Config[:disabled_plugins] = #{disabled_plugins}
-Ohai::Config[:plugin_path] << "#{plugin_path}"
-CONFIG
-      end
-
-      # config settings
-      let(:disabled_plugins) { [ :Foo, :Baz ] }
-
-      let(:log_level) { :debug }
-
-      let(:log_location) { "path/to/log" }
-
-      let(:plugin_path) { "/path/to/plugins" }
-
-      it "logs warnings for deprecated top-level options" do
-        # deprecation warnings for options need to be stubbed in the order
-        # they are received, in this case it's the order they appear in the
-        # configuration file.
-        options = [ :log_location, :log_level, :disabled_plugins ]
-        options.each do |option|
-          expect(Ohai::Log).to receive(:warn).
-            with(/Ohai::Config\[:#{option}\] is deprecated/)
-        end
-        app.configure_ohai
-      end
-    end
-
     context "when the configuration file has a syntax error" do
       # For the purpose of these tests it doesn't matter if the configuration
       # file was specified via command line or discovered on the local

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -22,74 +22,6 @@ require "ohai/config"
 
 RSpec.describe Ohai::Config do
 
-  describe "top-level configuration options" do
-    shared_examples_for "option" do
-      it "logs a deprecation warning and sets the value" do
-        expect(Ohai::Log).to receive(:warn).
-          with(/Ohai::Config\[:#{option}\] is deprecated/)
-        Ohai::Config[option] = value
-        expect(Ohai::Config[option]).to eq(value)
-      end
-    end
-
-    shared_examples_for "appendable option" do
-      it "sets the value" do
-        expect(Ohai::Log).to_not receive(:warn)
-        Ohai::Config[option] << value
-        expect(Ohai::Config[option]).to include(value)
-      end
-    end
-
-    describe ":directory" do
-      include_examples "option" do
-        let(:option) { :directory }
-        let(:value)  { "/some/fantastic/plugins" }
-      end
-    end
-
-    describe ":disabled_plugins" do
-      include_examples "option" do
-        let(:option) { :disabled_plugins }
-        let(:value)  { [ :Foo, :Baz ] }
-      end
-    end
-
-    describe ":hints_path" do
-      include_examples "appendable option" do
-        let(:option) { :hints_path }
-        let(:value)  { "/some/helpful/hints" }
-      end
-    end
-
-    describe ":log_level" do
-      include_examples "option" do
-        let(:option) { :log_level }
-        let(:value)  { :cheese }
-      end
-    end
-
-    describe ":log_location" do
-      include_examples "option" do
-        let(:option) { :log_location }
-        let(:value)  { "/etc/chef/cache/loooogs" }
-      end
-    end
-
-    describe ":plugin_path" do
-      include_examples "appendable option" do
-        let(:option) { :plugin_path }
-        let(:value)  { "/some/fantastic/plugins" }
-      end
-    end
-
-    describe ":version" do
-      include_examples "option" do
-        let(:option) { :version }
-        let(:value)  { "8.2.0" }
-      end
-    end
-  end
-
   describe "config_context :ohai" do
     describe "option :plugin" do
       it "gets configured with a value" do
@@ -114,48 +46,6 @@ RSpec.describe Ohai::Config do
         value = { :bar => true, "baz" => true }
         expect { Ohai::Config.ohai[:plugin][:foo] = value }.
           to raise_error(Ohai::Exceptions::PluginConfigError, /Expected Symbol/)
-      end
-    end
-  end
-
-  describe "::merge_deprecated_config" do
-    before(:each) do
-      allow(Ohai::Log).to receive(:warn)
-      configure_ohai
-    end
-
-    def configure_ohai
-      Ohai::Config[:directory] = "/some/fantastic/plugins"
-      Ohai::Config[:disabled_plugins] = [ :Foo, :Baz ]
-      Ohai::Config[:log_level] = :debug
-    end
-
-    it "merges top-level config values into the ohai config context" do
-      Ohai::Config.merge_deprecated_config
-      expect(Ohai::Config.ohai.configuration).to eq (Ohai::Config.configuration)
-    end
-
-    shared_examples_for "delayed warn" do
-      it "logs a deprecation warning and merges the value" do
-        expect(Ohai::Log).to receive(:warn).
-          with(/Ohai::Config\[:#{option}\] is deprecated/)
-        Ohai::Config[option] << value
-        Ohai::Config.merge_deprecated_config
-        expect(Ohai::Config.ohai[option]).to include(value)
-      end
-    end
-
-    context "when :hints_path is set" do
-      include_examples "delayed warn" do
-        let(:option) { :hints_path }
-        let(:value)  { "/some/helpful/hints" }
-      end
-    end
-
-    context "when :plugin_path is set" do
-      include_examples "delayed warn" do
-        let(:option) { :plugin_path }
-        let(:value)  { "/some/fantastic/plugins" }
       end
     end
   end

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -38,16 +38,6 @@ describe "Ohai::System" do
       expect(ohai.v6_dependency_solver).to be_a_kind_of(Hash)
     end
 
-    it "merges deprecated config settings into the ohai config context" do
-      expect(Ohai::Log).to receive(:warn).
-        with(/Ohai::Config\[:disabled_plugins\] is deprecated/)
-      Ohai::Config[:disabled_plugins] = [ :Foo, :Baz ]
-      expect(Ohai::Config).to receive(:merge_deprecated_config).
-        and_call_original
-      Ohai::System.new
-      expect(Ohai.config[:disabled_plugins]).to eq([ :Foo, :Baz ])
-    end
-
     it "merges provided configuration options into the ohai config context" do
       config = {
         disabled_plugins: [ :Foo, :Baz ],
@@ -68,30 +58,6 @@ describe "Ohai::System" do
         Ohai.config[:directory] = directory
         Ohai::System.new
         expect(Ohai.config[:plugin_path]).to include(directory)
-      end
-    end
-
-    shared_examples_for "appendable deprecated configuration option" do
-      it "logs a warning and configures the option on the ohai config context" do
-        Ohai::Config[option] << value
-        expect(Ohai::Log).to receive(:warn).
-          with(/Ohai::Config\[:#{option}\] is deprecated/)
-        Ohai::System.new
-        expect(Ohai.config[option]).to include(value)
-      end
-    end
-
-    context "when a top-level hints_path is configured" do
-      include_examples "appendable deprecated configuration option" do
-        let(:option) { :hints_path }
-        let(:value) { "/path/to/hints" }
-      end
-    end
-
-    context "when a top-level plugin_path is configured" do
-      include_examples "appendable deprecated configuration option" do
-        let(:option) { :plugin_path }
-        let(:value) { "/path/to/plugins" }
       end
     end
 


### PR DESCRIPTION
Start of the deprecation of the old config logic. Removes a ton of confusing duplicate logic and resolves 2 bogus deprecation warnings that were thrown every time Ohai ran. Specs are going to need to be cleaned up still.

Also bonus gift: This adds /etc/chef/ohai/plugins to the plugin path so the ohai_plugin resource will work without configuration mess by the user now. I'll probably port that same 1 line fix over to Ohai 8.X so we can get that in for Chef 12 users.

Signed-off-by: Tim Smith <tsmith@chef.io>
