### PR TITLE
fix gcc and cc for darwin (no cli tools installed)

### DIFF
--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -48,30 +48,6 @@ Ohai.plugin(:C) do
     Ohai::Log.debug("xcode-select binary could not be found. Skipping data.")
   end
 
-  collect_data(:darwin) do
-    if xcode_installed?
-      collect_gcc
-      collect_cc
-    end
-  end
-
-  collect_data(:windows) do
-    check_for_cl
-    check_for_devenv
-  end
-
-  collect_data(:default) do
-    collect_gcc
-    collect_glibc
-    check_for_cl
-    check_for_devenv
-    collect_xlc
-    collect_cc
-    collect_hpux_cc
-  end
-
-  c = Mash.new
-
   def collect_gcc
     #gcc
     collect("gcc -v") do |so|
@@ -171,5 +147,31 @@ Ohai.plugin(:C) do
     end
   end
 
-  languages[:c] = c unless c.empty?
+  collect_data(:darwin) do
+    c = Mash.new
+    if xcode_installed?
+      collect_gcc
+      collect_cc
+    end
+    languages[:c] = c unless c.empty?
+  end
+
+  collect_data(:windows) do
+    c = Mash.new
+    check_for_cl
+    check_for_devenv
+    languages[:c] = c unless c.empty?
+  end
+
+  collect_data(:default) do
+    c = Mash.new
+    collect_gcc
+    collect_glibc
+    check_for_cl
+    check_for_devenv
+    collect_xlc
+    collect_cc
+    collect_hpux_cc
+    languages[:c] = c unless c.empty?
+  end
 end

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -38,11 +38,11 @@ Ohai.plugin(:C) do
     Ohai::Log.debug("Checking for Xcode Command Line Tools.")
     so = shell_out("/usr/bin/xcode-select -p")
     if so.exitstatus == 0
-      return true
       Ohai::Log.debug("Xcode Command Line Tools found.")
+      return true
     else
-      return false
       Ohai::Log.debug("Xcode Command Line Tools not found.")
+      return false
     end
   rescue Ohai::Exceptions::Exec
     Ohai::Log.debug("xcode-select binary could not be found. Skipping data.")

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -28,10 +28,10 @@ Ohai.plugin(:C) do
     if so.exitstatus == 0
       yield(so)
     else
-      Ohai::Log.debug("Plugin C '#{cmd}' failed. Skipping data.")
+      Ohai::Log.debug("Plugin C: '#{cmd}' failed. Skipping data.")
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug("Plugin C '#{cmd}' binary could not be found. Skipping data.")
+    Ohai::Log.debug("Plugin C: '#{cmd}' binary could not be found. Skipping data.")
   end
 
   def xcode_installed?


### PR DESCRIPTION
If darwin is found:
1. shell out to /usr/bin/xcode-select -p
2a. If it returns an exit code other than 0, assume xcode command line tools are not installed and do not run these commands.
2b. If it returns an exit code of 0, run the commands.

Signed-off-by: Erik Gomez <e@eriknicolasgomez.com>

### Description

This removes the requirement for both Ohai and Chef to have the Xcode command line tools installed on macOS machines.

This is a huge win for managing client devices as the Xcode Command Line tools were previously a dependency. Companies have worked around these issues, but they are not ideal and require additional management overhead/engineering effort.

One such example: https://github.com/facebook/IT-CPE/blob/master/chef/tools/chef_bootstrap.py#L239-L284

### Issues Resolved

Fixes https://github.com/chef/ohai/issues/940

### Check List
Since this only impacts Darwin, I have tested both use cases where xcode command line tools are installed and when they are not installed. 
