### PR TITLE
Only explicitly initialize a logger when needed

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -83,6 +83,8 @@ class Ohai::Application
     @attributes = nil if @attributes.empty?
 
     load_workstation_config
+
+    Ohai::Log.init(Ohai.config[:log_location])
   end
 
   def run_application

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -220,10 +220,6 @@ module Ohai
     end
 
     def configure_logging
-      return if Ohai::Log.configured?
-
-      Ohai::Log.init(Ohai.config[:log_location])
-
       if Ohai.config[:log_level] == :auto
         Ohai::Log.level = :info
       else

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -101,7 +101,6 @@ describe "Ohai::System" do
       it "configures logging" do
         log_level = :debug
         Ohai.config[:log_level] = log_level
-        expect(Ohai::Log).to receive(:init).with(Ohai.config[:log_location])
         expect(Ohai::Log).to receive(:level=).with(log_level)
         Ohai::System.new
       end


### PR DESCRIPTION
When we're running Ohai as a standalone application, we need to fire up
the logger with our desired location, but when we're run from inside
Chef, we're passed the client's loggers.

( https://github.com/chef/chef/blob/master/lib/chef/application/client.rb#L398 )

Fixes: #878