### PR TITLE
C Plugin: Expand GCC data & only shellout to gcc if Xcode is installed on macOS

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,3 +26,7 @@ A new plugin parses the output of the sysconf command to provide information on 
 ## AWS Account ID
 
 The EC2 plugin now fetches the AWS Account ID in addition to previous instance metadata
+
+## GCC Detection
+
+GCC detection has been improved to collect additional information, and to not prompt for the installation of Xcode on macOS systems

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -48,21 +48,23 @@ Ohai.plugin(:C) do
   end
 
   def collect_gcc
-    #gcc
-    collect("gcc -v") do |so|
-      # Sample output:
-      # Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
-      # Apple LLVM version 7.3.0 (clang-703.0.29)
-      # Target: x86_64-apple-darwin15.4.0
-      # Thread model: posix
-      # InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
-      description = so.stderr.split($/).last
-      output = description.split
-      if output.length >= 3
-        c[:gcc] = Mash.new
-        c[:gcc][:version] = output[2]
-        c[:gcc][:description] = description
-      end
+    # gcc
+    # Sample output on os x:
+    # Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
+    # Apple LLVM version 7.3.0 (clang-703.0.29)
+    # Target: x86_64-apple-darwin15.4.0
+    # Thread model: posix
+    # InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
+    #
+    #
+    # Sample output on Linux:
+    # Using built-in specs.
+    # COLLECT_GCC=gcc
+    # COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/5/lto-wrapper
+    # Target: x86_64-linux-gnu
+    # Configured with: ../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.4' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
+    # Thread model: posix
+    # gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
     end
   end
 

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -48,30 +48,6 @@ Ohai.plugin(:C) do
     Ohai::Log.debug("xcode-select binary could not be found. Skipping data.")
   end
 
-  collect_data(:darwin) do
-    if xcode_installed?
-      collect_gcc
-      collect_cc
-    end
-  end
-
-  collect_data(:windows) do
-    check_for_cl
-    check_for_devenv
-  end
-
-  collect_data(:default) do
-    collect_gcc
-    collect_glibc
-    check_for_cl
-    check_for_devenv
-    collect_xlc
-    collect_cc
-    collect_hpux_cc
-  end
-
-  c = Mash.new
-
   def collect_gcc
     #gcc
     collect("gcc -v") do |so|
@@ -171,5 +147,31 @@ Ohai.plugin(:C) do
     end
   end
 
-  languages[:c] = c unless c.empty?
+  collect_data(:darwin) do
+    c = Mash.new
+    if xcode_installed?
+      collect_gcc
+      collect_cc
+    end
+    languages[:c] = c unless c.empty?
+  end
+
+  collect_data(:windows) do
+    c = Mash.new
+    check_for_cl
+    check_for_devenv
+    languages[:c] = c unless c.empty?
+  end
+
+  collect_data(:default) do
+    c = Mash.new
+    collect_gcc
+    collect_glibc
+    check_for_cl
+    check_for_devenv
+    collect_xlc
+    collect_cc
+    collect_hpux_cc
+    languages[:c] = c unless c.empty?
+  end
 end

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -20,7 +20,6 @@ require "rbconfig"
 
 Ohai.plugin(:C) do
   provides "languages/c"
-
   depends "languages"
 
   def collect(cmd, &block)
@@ -38,14 +37,14 @@ Ohai.plugin(:C) do
     Ohai::Log.debug("Checking for Xcode Command Line Tools.")
     so = shell_out("/usr/bin/xcode-select -p")
     if so.exitstatus == 0
-      Ohai::Log.debug("Xcode Command Line Tools found.")
+      Ohai::Log.debug("Plugin C: Xcode Command Line Tools found.")
       return true
     else
-      Ohai::Log.debug("Xcode Command Line Tools not found.")
+      Ohai::Log.debug("Plugin C: Xcode Command Line Tools not found.")
       return false
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug("xcode-select binary could not be found. Skipping data.")
+    Ohai::Log.debug("Plugin C: xcode-select binary could not be found. Skipping data.")
   end
 
   def collect_gcc

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -137,7 +137,7 @@ Ohai.plugin(:C) do
     end
   end
 
-  def collect_cc
+  def collect_sunpro
     # sun pro
     collect("cc -V -flags") do |so|
       output = so.stderr.split
@@ -160,6 +160,13 @@ Ohai.plugin(:C) do
         @c[:hpcc][:description] = description.strip
       end
     end
+  end
+
+  collect_data(:aix) do
+    @c = Mash.new
+    collect_xlc
+    collect_gcc
+    languages[:c] = @c unless @c.empty?
   end
 
   collect_data(:darwin) do
@@ -186,8 +193,7 @@ Ohai.plugin(:C) do
     @c = Mash.new
     collect_gcc
     collect_glibc
-    collect_xlc
-    collect_cc
+    collect_sunpro
     languages[:c] = @c unless @c.empty?
   end
 end

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -79,7 +79,7 @@ Ohai.plugin(:C) do
         end
       end
     end
-    @c[:gcc] = gcc
+    @c[:gcc] = gcc unless gcc.empty?
   end
 
   def collect_glibc

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -147,10 +147,7 @@ Ohai.plugin(:C) do
 
   collect_data(:darwin) do
     c = Mash.new
-    if xcode_installed?
-      collect_gcc
-      collect_cc
-    end
+    collect_gcc if xcode_installed?
     languages[:c] = c unless c.empty?
   end
 

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -76,7 +76,6 @@ Ohai.plugin(:C) do
           c[:glibc][:version] = $1
           c[:glibc][:description] = description
         end
-      end unless c[:glibc] || ::RbConfig::CONFIG["host_os"] =~ /mswin|mingw32|windows/
     end
   end
 

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -163,15 +163,19 @@ Ohai.plugin(:C) do
     languages[:c] = c unless c.empty?
   end
 
-  collect_data(:default) do
+  collect_data(:hpux) do
+    c = Mash.new
+    collect_gcc
+    collect_hpux_cc
+    languages[:c] = c unless c.empty?
+  end
+
+  collect_data(:hpux) do
     c = Mash.new
     collect_gcc
     collect_glibc
-    check_for_cl
-    check_for_devenv
     collect_xlc
     collect_cc
-    collect_hpux_cc
     languages[:c] = c unless c.empty?
   end
 end

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 
-require "rbconfig"
-
 Ohai.plugin(:C) do
   provides "languages/c"
   depends "languages"
@@ -34,7 +32,7 @@ Ohai.plugin(:C) do
   end
 
   def xcode_installed?
-    Ohai::Log.debug("Checking for Xcode Command Line Tools.")
+    Ohai::Log.debug("Plugin C: Checking for Xcode Command Line Tools.")
     so = shell_out("/usr/bin/xcode-select -p")
     if so.exitstatus == 0
       Ohai::Log.debug("Plugin C: Xcode Command Line Tools found.")
@@ -65,57 +63,74 @@ Ohai.plugin(:C) do
     # Configured with: ../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.4' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
     # Thread model: posix
     # gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
+    gcc = Mash.new
+    collect("gcc -v") do |so|
+      so.stderr.each_line do |line|
+        case line
+        when /^(.*version\s(\S*).*)/
+          gcc[:description] = $1
+          gcc[:version] = $2
+        when /^Target:\s(.*)/
+          gcc[:target] = $1
+        when /^Configured with:\s(.*)/
+          gcc[:configured_with] = $1
+        when /^Thread model:\s(.*)/
+          gcc[:thread_model] = $1
+        end
+      end
     end
+    @c[:gcc] = gcc
   end
 
   def collect_glibc
-    #glibc
+    # glibc
     ["/lib/libc.so.6", "/lib64/libc.so.6"].each do |glibc|
       collect( Ohai.abs_path( glibc )) do |so|
         description = so.stdout.split($/).first
         if description =~ /(\d+\.\d+\.?\d*)/
-          c[:glibc] = Mash.new
-          c[:glibc][:version] = $1
-          c[:glibc][:description] = description
+          @c[:glibc] = Mash.new
+          @c[:glibc][:version] = $1
+          @c[:glibc][:description] = description
         end
+      end
     end
   end
 
   def check_for_cl
-    #ms cl
+    # ms cl
     collect("cl /?") do |so|
       description = so.stderr.lines.first.chomp
       if description =~ /Compiler Version ([\d\.]+)/
-        c[:cl] = Mash.new
-        c[:cl][:version] = $1
-        c[:cl][:description] = description
+        @c[:cl] = Mash.new
+        @c[:cl][:version] = $1
+        @c[:cl][:description] = description
       end
     end
   end
 
   def check_for_devenv
-    #ms vs
+    # ms vs
     collect("devenv.com /?") do |so|
       lines = so.stdout.split($/)
       description = lines[0].length == 0 ? lines[1] : lines[0]
       if description =~ /Visual Studio Version ([\d\.]+)/
-        c[:vs] = Mash.new
-        c[:vs][:version] = $1.chop
-        c[:vs][:description] = description
+        @c[:vs] = Mash.new
+        @c[:vs][:version] = $1.chop
+        @c[:vs][:description] = description
       end
     end
   end
 
   def collect_xlc
-    #ibm xlc
+    # ibm xlc
     begin
       so = shell_out("xlc -qversion")
       if so.exitstatus == 0 || (so.exitstatus >> 8) == 249
         description = so.stdout.split($/).first
         if description =~ /V(\d+\.\d+)/
-          c[:xlc] = Mash.new
-          c[:xlc][:version] = $1
-          c[:xlc][:description] = description.strip
+          @c[:xlc] = Mash.new
+          @c[:xlc][:version] = $1
+          @c[:xlc][:description] = description.strip
         end
       end
     rescue Ohai::Exceptions::Exec
@@ -123,56 +138,56 @@ Ohai.plugin(:C) do
   end
 
   def collect_cc
-    #sun pro
+    # sun pro
     collect("cc -V -flags") do |so|
       output = so.stderr.split
       if so.stderr =~ /^cc: Sun C/ && output.size >= 4
-        c[:sunpro] = Mash.new
-        c[:sunpro][:version] = output[3]
-        c[:sunpro][:description] = so.stderr.chomp
+        @c[:sunpro] = Mash.new
+        @c[:sunpro][:version] = output[3]
+        @c[:sunpro][:description] = so.stderr.chomp
       end
     end
   end
 
   def collect_hpux_cc
-    #hpux cc
+    # hpux cc
     collect("what /opt/ansic/bin/cc") do |so|
       description = so.stdout.split($/).select { |line| line =~ /HP C Compiler/ }.first
       if description
         output = description.split
-        c[:hpcc] = Mash.new
-        c[:hpcc][:version] = output[1] if output.size >= 1
-        c[:hpcc][:description] = description.strip
+        @c[:hpcc] = Mash.new
+        @c[:hpcc][:version] = output[1] if output.size >= 1
+        @c[:hpcc][:description] = description.strip
       end
     end
   end
 
   collect_data(:darwin) do
-    c = Mash.new
+    @c = Mash.new
     collect_gcc if xcode_installed?
-    languages[:c] = c unless c.empty?
+    languages[:c] = @c unless @c.empty?
   end
 
   collect_data(:windows) do
-    c = Mash.new
+    @c = Mash.new
     check_for_cl
     check_for_devenv
-    languages[:c] = c unless c.empty?
+    languages[:c] = @c unless @c.empty?
   end
 
   collect_data(:hpux) do
-    c = Mash.new
+    @c = Mash.new
     collect_gcc
     collect_hpux_cc
-    languages[:c] = c unless c.empty?
+    languages[:c] = @c unless @c.empty?
   end
 
-  collect_data(:hpux) do
-    c = Mash.new
+  collect_data(:default) do
+    @c = Mash.new
     collect_gcc
     collect_glibc
     collect_xlc
     collect_cc
-    languages[:c] = c unless c.empty?
+    languages[:c] = @c unless @c.empty?
   end
 end

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -38,11 +38,11 @@ Ohai.plugin(:C) do
     Ohai::Log.debug("Checking for Xcode Command Line Tools.")
     so = shell_out("/usr/bin/xcode-select -p")
     if so.exitstatus == 0
-      return true
       Ohai::Log.debug("Xcode Command Line Tools found.")
+      return true
     else
-      return false
       Ohai::Log.debug("Xcode Command Line Tools not found.")
+      return false
     end
   rescue Ohai::Exceptions::Exec
     Ohai::Log.debug("xcode-select binary could not be found. Skipping data.")

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -28,10 +28,10 @@ Ohai.plugin(:C) do
     if so.exitstatus == 0
       yield(so)
     else
-      Ohai::Log.debug("Plugin C '#{cmd}' failed. Skipping data.")
+      Ohai::Log.debug("Plugin C: '#{cmd}' failed. Skipping data.")
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug("Plugin C '#{cmd}' binary could not be found. Skipping data.")
+    Ohai::Log.debug("Plugin C: '#{cmd}' binary could not be found. Skipping data.")
   end
 
   def xcode_installed?

--- a/spec/unit/plugins/c_spec.rb
+++ b/spec/unit/plugins/c_spec.rb
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 
-require "rbconfig"
-
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
 
 C_GCC = <<EOF
@@ -30,30 +28,7 @@ Thread model: posix
 gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
 EOF
 
-C_GLIBC_2_3_4 = <<EOF
-GNU C Library stable release version 2.3.4, by Roland McGrath et al.
-Copyright (C) 2005 Free Software Foundation, Inc.
-This is free software; see the source for copying conditions.
-There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.
-Compiled by GNU CC version 3.4.6 20060404 (Red Hat 3.4.6-3).
-Compiled on a Linux 2.4.20 system on 2006-08-12.
-Available extensions:
-        GNU libio by Per Bothner
-        crypt add-on version 2.1 by Michael Glad and others
-        linuxthreads-0.10 by Xavier Leroy
-        The C stubs add-on version 2.1.2.
-        BIND-8.2.3-T5B
-        NIS(YP)/NIS+ NSS modules 0.19 by Thorsten Kukuk
-        Glibc-2.0 compatibility add-on by Cristian Gafton
-        GNU Libidn by Simon Josefsson
-        libthread_db work sponsored by Alpha Processor Inc
-Thread-local storage support included.
-For bug reporting instructions, please see:
-<http://www.gnu.org/software/libc/bugs.html>.
-EOF
-
-C_GLIBC_2_5 = <<EOF
+C_GLIBC = <<EOF
 GNU C Library stable release version 2.5, by Roland McGrath et al.
 Copyright (C) 2006 Free Software Foundation, Inc.
 This is free software; see the source for copying conditions.
@@ -103,6 +78,7 @@ C_HPUX = <<EOF
          $ PATCH/11.00:PHCO_27774  Oct  3 2002 09:45:59 $
 EOF
 
+
 describe Ohai::System, "plugin c" do
 
   let(:plugin) { get_plugin("c") }
@@ -112,251 +88,302 @@ describe Ohai::System, "plugin c" do
     plugin[:languages] = Mash.new
     #gcc
     allow(plugin).to receive(:shell_out).with("gcc -v").and_return(mock_shell_out(0, "", C_GCC))
-    #glibc
-    allow(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(0, C_GLIBC_2_3_4, ""))
-    #ms cl
-    allow(plugin).to receive(:shell_out).with("cl /\?").and_return(mock_shell_out(0, "", C_CL))
-    #ms vs
-    allow(plugin).to receive(:shell_out).with("devenv.com /\?").and_return(mock_shell_out(0, C_VS, ""))
-    #ibm xlc
-    allow(plugin).to receive(:shell_out).with("xlc -qversion").and_return(mock_shell_out(0, C_XLC, ""))
-    #sun pro
-    allow(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(0, "", C_SUN))
+  end
+
+
+  context "on HPUX" do
+    before(:each) do
+      allow(plugin).to receive(:collect_os).and_return(:hpux)
+      allow(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_return(mock_shell_out(0, C_HPUX, ""))
+    end
+
     #hpux cc
-    allow(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_return(mock_shell_out(0, C_HPUX, ""))
+    it "gets the cc version from running what cc" do
+      expect(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_return(mock_shell_out(0, C_HPUX, ""))
+      plugin.run
+    end
+
+    it "sets languages[:c][:hpcc][:version]" do
+      plugin.run
+      expect(plugin.languages[:c][:hpcc][:version]).to eql("B.11.11.16")
+    end
+
+    it "sets languages[:c][:hpcc][:description]" do
+      plugin.run
+      expect(plugin.languages[:c][:hpcc][:description]).to eql("HP92453-01 B.11.11.16 HP C Compiler")
+    end
+
+    it "does not set the languages[:c][:hpcc] tree up if cc command exits nonzero" do
+      allow(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_return(mock_shell_out(1, "", ""))
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:hpcc)
+    end
+
+    it "does not set the languages[:c][:hpcc] tree up if cc command fails" do
+      allow(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_raise(Ohai::Exceptions::Exec)
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:hpcc)
+      expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
+    end
   end
 
-  #gcc
-  it "gets the gcc version from running gcc -v" do
-    expect(plugin).to receive(:shell_out).with("gcc -v").and_return(mock_shell_out(0, "", C_GCC))
-    plugin.run
+  context "on Darwin" do
+    before(:each) do
+      allow(plugin).to receive(:shell_out).with("/usr/bin/xcode-select -p").and_return(mock_shell_out(0, "", ""))
+      allow(plugin).to receive(:collect_os).and_return(:darwin)
+    end
+
+    it "shells out to see if xcode is installed" do
+      expect(plugin).to receive(:shell_out).with("/usr/bin/xcode-select -p")
+      plugin.run
+    end
+
+    it "doesnt shellout to gcc if xcode isn't installed" do
+      allow(plugin).to receive(:shell_out).with("/usr/bin/xcode-select -p").and_return(mock_shell_out(1, "", ""))
+      expect(plugin).not_to receive(:shell_out).with("gcc -v")
+      plugin.run
+    end
+
+
   end
 
-  it "sets languages[:c][:gcc][:version]" do
-    plugin.run
-    expect(plugin.languages[:c][:gcc][:version]).to eql("3.4.6")
+  context "on Windows" do
+    before(:each) do
+      allow(plugin).to receive(:collect_os).and_return(:windows)
+      allow(plugin).to receive(:shell_out).with("cl /\?").and_return(mock_shell_out(0, "", C_CL))
+      allow(plugin).to receive(:shell_out).with("devenv.com /\?").and_return(mock_shell_out(0, C_VS, ""))
+    end
+
+    #ms cl
+    it "gets the cl version from running cl /?" do
+      expect(plugin).to receive(:shell_out).with("cl /\?")
+      plugin.run
+    end
+
+    it "sets languages[:c][:cl][:version]" do
+      plugin.run
+      expect(plugin.languages[:c][:cl][:version]).to eql("14.00.50727.762")
+    end
+
+    it "sets languages[:c][:cl][:description]" do
+      plugin.run
+      expect(plugin.languages[:c][:cl][:description]).to eql("Microsoft (R) 32-bit C/C++ Optimizing Compiler Version 14.00.50727.762 for 80x86")
+    end
+
+    it "does not set the languages[:c][:cl] tree up if cl command exits nonzero" do
+      allow(plugin).to receive(:shell_out).with("cl /\?").and_return(mock_shell_out(1, "", ""))
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:cl)
+    end
+
+    it "does not set the languages[:c][:cl] tree up if cl command fails" do
+      allow(plugin).to receive(:shell_out).with("cl /\?").and_raise(Ohai::Exceptions::Exec)
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:cl)
+      expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
+    end
+
+    #ms vs
+    it "gets the vs version from running devenv.com /?" do
+      expect(plugin).to receive(:shell_out).with("devenv.com /\?").and_return(mock_shell_out(0, C_VS, ""))
+      plugin.run
+    end
+
+    it "sets languages[:c][:vs][:version]" do
+      plugin.run
+      expect(plugin.languages[:c][:vs][:version]).to eql("8.0.50727.762")
+    end
+
+    it "sets languages[:c][:vs][:description]" do
+      plugin.run
+      expect(plugin.languages[:c][:vs][:description]).to eql("Microsoft (R) Visual Studio Version 8.0.50727.762.")
+    end
+
+    it "does not set the languages[:c][:vs] tree up if devenv command exits nonzero" do
+      allow(plugin).to receive(:shell_out).with("devenv.com /\?").and_return(mock_shell_out(1, "", ""))
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:vs)
+    end
+
+    it "does not set the languages[:c][:vs] tree up if devenv command fails" do
+      allow(plugin).to receive(:shell_out).with("devenv.com /\?").and_raise(Ohai::Exceptions::Exec)
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:vs)
+      expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
+    end
   end
 
-  it "sets languages[:c][:gcc][:description]" do
-    plugin.run
-    expect(plugin.languages[:c][:gcc][:description]).to eql(C_GCC.split($/).last)
+  context "on Linux" do
+    before(:each) do
+      allow(plugin).to receive(:collect_os).and_return(:linux)
+      # glibc
+      allow(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(0, C_GLIBC, ""))
+      allow(plugin).to receive(:shell_out).with("/lib64/libc.so.6").and_return(mock_shell_out(0, C_GLIBC, ""))
+      #ibm xlc
+      allow(plugin).to receive(:shell_out).with("xlc -qversion").and_return(mock_shell_out(0, C_XLC, ""))
+      #sun pro
+      allow(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(0, "", C_SUN))
+    end
+
+    #gcc
+    it "gets the gcc version from running gcc -v" do
+      expect(plugin).to receive(:shell_out).with("gcc -v")
+      plugin.run
+    end
+
+    it "sets languages[:c][:gcc][:version]" do
+      plugin.run
+      expect(plugin.languages[:c][:gcc][:version]).to eql("5.4.0")
+    end
+
+    it "sets languages[:c][:gcc][:description]" do
+      plugin.run
+      expect(plugin.languages[:c][:gcc][:description]).to eql("gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)")
+    end
+
+    it "sets languages[:c][:gcc][:configured_with]" do
+      plugin.run
+      expect(plugin.languages[:c][:gcc][:configured_with]).to eql("../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.4' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu")
+    end
+
+    it "sets languages[:c][:gcc][:target]" do
+      plugin.run
+      expect(plugin.languages[:c][:gcc][:target]).to eql("x86_64-linux-gnu")
+    end
+
+    it "sets languages[:c][:gcc][:thread_model]" do
+      plugin.run
+      expect(plugin.languages[:c][:gcc][:thread_model]).to eql("posix")
+    end
+
+    it "does not set the languages[:c][:gcc] tree up if gcc command exits nonzero" do
+      allow(plugin).to receive(:shell_out).with("gcc -v").and_return(mock_shell_out(1, "", ""))
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:gcc)
+    end
+
+    it "does not set the languages[:c][:gcc] tree up if gcc command fails" do
+      allow(plugin).to receive(:shell_out).with("gcc -v").and_raise(Ohai::Exceptions::Exec)
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:gcc)
+      expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
+    end
+
+    #glibc
+    it "gets the glibc x.x.x version from running /lib/libc.so.6" do
+      expect(plugin).to receive(:shell_out).with("/lib/libc.so.6")
+      plugin.run
+    end
+
+    it "sets languages[:c][:glibc][:version]", :unix_only do
+      plugin.run
+      expect(plugin.languages[:c][:glibc][:version]).to eql("2.5")
+    end
+
+    it "sets languages[:c][:glibc][:description]" do
+      plugin.run
+      expect(plugin.languages[:c][:glibc][:description]).to eql("GNU C Library stable release version 2.5, by Roland McGrath et al.")
+    end
+
+    it "does not set the languages[:c][:glibc] tree up if glibc exits nonzero" do
+      allow(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(1, "", ""))
+      allow(plugin).to receive(:shell_out).with("/lib64/libc.so.6").and_return(mock_shell_out(1, "", ""))
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:glibc)
+    end
+
+    it "does not set the languages[:c][:glibc] tree up if glibc fails" do
+      allow(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_raise(Ohai::Exceptions::Exec)
+      allow(plugin).to receive(:shell_out).with("/lib64/libc.so.6").and_raise(Ohai::Exceptions::Exec)
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:glibc)
+      expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
+    end
+
+    it "gets the glibc x.x version from running /lib/libc.so.6" do
+      allow(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(0, C_GLIBC, ""))
+      expect(plugin).to receive(:shell_out).with("/lib/libc.so.6")
+      plugin.run
+      expect(plugin.languages[:c][:glibc][:version]).to eql("2.5")
+    end
+
+    #ibm xlc
+    it "gets the xlc version from running xlc -qversion" do
+      expect(plugin).to receive(:shell_out).with("xlc -qversion").and_return(mock_shell_out(0, C_XLC, ""))
+      plugin.run
+    end
+
+    it "sets languages[:c][:xlc][:version]" do
+      plugin.run
+      expect(plugin.languages[:c][:xlc][:version]).to eql("9.0")
+    end
+
+    it "sets languages[:c][:xlc][:description]" do
+      plugin.run
+      expect(plugin.languages[:c][:xlc][:description]).to eql("IBM XL C/C++ Enterprise Edition for AIX, V9.0")
+    end
+
+    it "does not set the languages[:c][:xlc] tree up if xlc command exits nonzero" do
+      allow(plugin).to receive(:shell_out).with("xlc -qversion").and_return(mock_shell_out(1, "", ""))
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:xlc)
+    end
+
+    it "does not set the languages[:c][:xlc] tree up if xlc command fails" do
+      allow(plugin).to receive(:shell_out).with("xlc -qversion").and_raise(Ohai::Exceptions::Exec)
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:xlc)
+      expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
+    end
+
+    it "sets the languages[:c][:xlc] tree up if xlc exit status is 249" do
+      allow(plugin).to receive(:shell_out).with("xlc -qversion").and_return(mock_shell_out(63744, "", ""))
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:xlc)
+    end
+
+    #sun pro
+    it "gets the cc version from running cc -V -flags" do
+      expect(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(0, "", C_SUN))
+      plugin.run
+    end
+
+    it "sets languages[:c][:sunpro][:version]" do
+      plugin.run
+      expect(plugin.languages[:c][:sunpro][:version]).to eql("5.8")
+    end
+
+    it "sets languages[:c][:sunpro][:description]" do
+      plugin.run
+      expect(plugin.languages[:c][:sunpro][:description]).to eql("cc: Sun C 5.8 Patch 121016-06 2007/08/01")
+    end
+
+    it "does not set the languages[:c][:sunpro] tree up if cc command exits nonzero" do
+      allow(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(1, "", ""))
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:sunpro)
+    end
+
+    it "does not set the languages[:c][:sunpro] tree up if cc command fails" do
+      allow(plugin).to receive(:shell_out).with("cc -V -flags").and_raise(Ohai::Exceptions::Exec)
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:sunpro)
+      expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
+    end
+
+    it "does not set the languages[:c][:sunpro] tree if the corresponding cc command fails on linux" do
+      fedora_error_message = "cc: error trying to exec 'i686-redhat-linux-gcc--flags': execvp: No such file or directory"
+
+      allow(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(0, "", fedora_error_message))
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:sunpro)
+    end
+
+    it "does not set the languages[:c][:sunpro] tree if the corresponding cc command fails on hpux" do
+      hpux_error_message = "cc: warning 901: unknown option: `-flags': use +help for online documentation.\ncc: HP C/aC++ B3910B A.06.25 [Nov 30 2009]"
+      allow(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(0, "", hpux_error_message))
+      plugin.run
+      expect(plugin[:languages][:c]).not_to have_key(:sunpro)
+    end
   end
-
-  it "does not set the languages[:c][:gcc] tree up if gcc command exits nonzero" do
-    allow(plugin).to receive(:shell_out).with("gcc -v").and_return(mock_shell_out(1, "", ""))
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:gcc)
-  end
-
-  it "does not set the languages[:c][:gcc] tree up if gcc command fails" do
-    allow(plugin).to receive(:shell_out).with("gcc -v").and_raise(Ohai::Exceptions::Exec)
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:gcc)
-    expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
-  end
-
-  #glibc
-  it "gets the glibc x.x.x version from running /lib/libc.so.6", :unix_only do
-    expect(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(0, C_GLIBC_2_3_4, ""))
-    plugin.run
-  end
-
-  it "sets languages[:c][:glibc][:version]", :unix_only do
-    plugin.run
-    expect(plugin.languages[:c][:glibc][:version]).to eql("2.3.4")
-  end
-
-  it "sets languages[:c][:glibc][:description]", :unix_only do
-    plugin.run
-    expect(plugin.languages[:c][:glibc][:description]).to eql(C_GLIBC_2_3_4.split($/).first)
-  end
-
-  it "does not set the languages[:c][:glibc] tree up if glibc exits nonzero" do
-    allow(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(1, "", ""))
-    allow(plugin).to receive(:shell_out).with("/lib64/libc.so.6").and_return(mock_shell_out(1, "", ""))
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:glibc)
-  end
-
-  it "does not set the languages[:c][:glibc] tree up if glibc fails" do
-    allow(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_raise(Ohai::Exceptions::Exec)
-    allow(plugin).to receive(:shell_out).with("/lib64/libc.so.6").and_raise(Ohai::Exceptions::Exec)
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:glibc)
-    expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
-  end
-
-  it "gets the glibc x.x version from running /lib/libc.so.6", :unix_only do
-    allow(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(0, C_GLIBC_2_5, ""))
-    expect(plugin).to receive(:shell_out).with("/lib/libc.so.6").and_return(mock_shell_out(0, C_GLIBC_2_5, ""))
-    plugin.run
-    expect(plugin.languages[:c][:glibc][:version]).to eql("2.5")
-  end
-
-  #ms cl
-  it "gets the cl version from running cl /?" do
-    expect(plugin).to receive(:shell_out).with("cl /\?").and_return(mock_shell_out(0, "", C_CL))
-    plugin.run
-  end
-
-  it "sets languages[:c][:cl][:version]" do
-    plugin.run
-    expect(plugin.languages[:c][:cl][:version]).to eql("14.00.50727.762")
-  end
-
-  it "sets languages[:c][:cl][:description]" do
-    plugin.run
-    expect(plugin.languages[:c][:cl][:description]).to eql(C_CL.split($/).first)
-  end
-
-  it "does not set the languages[:c][:cl] tree up if cl command exits nonzero" do
-    allow(plugin).to receive(:shell_out).with("cl /\?").and_return(mock_shell_out(1, "", ""))
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:cl)
-  end
-
-  it "does not set the languages[:c][:cl] tree up if cl command fails" do
-    allow(plugin).to receive(:shell_out).with("cl /\?").and_raise(Ohai::Exceptions::Exec)
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:cl)
-    expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
-  end
-
-  #ms vs
-  it "gets the vs version from running devenv.com /?" do
-    expect(plugin).to receive(:shell_out).with("devenv.com /\?").and_return(mock_shell_out(0, C_VS, ""))
-    plugin.run
-  end
-
-  it "sets languages[:c][:vs][:version]" do
-    plugin.run
-    expect(plugin.languages[:c][:vs][:version]).to eql("8.0.50727.762")
-  end
-
-  it "sets languages[:c][:vs][:description]" do
-    plugin.run
-    expect(plugin.languages[:c][:vs][:description]).to eql(C_VS.split($/)[1])
-  end
-
-  it "does not set the languages[:c][:vs] tree up if devenv command exits nonzero" do
-    allow(plugin).to receive(:shell_out).with("devenv.com /\?").and_return(mock_shell_out(1, "", ""))
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:vs)
-  end
-
-  it "does not set the languages[:c][:vs] tree up if devenv command fails" do
-    allow(plugin).to receive(:shell_out).with("devenv.com /\?").and_raise(Ohai::Exceptions::Exec)
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:vs)
-    expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
-  end
-
-  #ibm xlc
-  it "gets the xlc version from running xlc -qversion" do
-    expect(plugin).to receive(:shell_out).with("xlc -qversion").and_return(mock_shell_out(0, C_XLC, ""))
-    plugin.run
-  end
-
-  it "sets languages[:c][:xlc][:version]" do
-    plugin.run
-    expect(plugin.languages[:c][:xlc][:version]).to eql("9.0")
-  end
-
-  it "sets languages[:c][:xlc][:description]" do
-    plugin.run
-    expect(plugin.languages[:c][:xlc][:description]).to eql(C_XLC.split($/).first)
-  end
-
-  it "does not set the languages[:c][:xlc] tree up if xlc command exits nonzero" do
-    allow(plugin).to receive(:shell_out).with("xlc -qversion").and_return(mock_shell_out(1, "", ""))
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:xlc)
-  end
-
-  it "does not set the languages[:c][:xlc] tree up if xlc command fails" do
-    allow(plugin).to receive(:shell_out).with("xlc -qversion").and_raise(Ohai::Exceptions::Exec)
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:xlc)
-    expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
-  end
-
-  it "sets the languages[:c][:xlc] tree up if xlc exit status is 249" do
-    allow(plugin).to receive(:shell_out).with("xlc -qversion").and_return(mock_shell_out(63744, "", ""))
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:xlc)
-  end
-
-  #sun pro
-  it "gets the cc version from running cc -V -flags" do
-    expect(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(0, "", C_SUN))
-    plugin.run
-  end
-
-  it "sets languages[:c][:sunpro][:version]" do
-    plugin.run
-    expect(plugin.languages[:c][:sunpro][:version]).to eql("5.8")
-  end
-
-  it "sets languages[:c][:sunpro][:description]" do
-    plugin.run
-    expect(plugin.languages[:c][:sunpro][:description]).to eql(C_SUN.chomp)
-  end
-
-  it "does not set the languages[:c][:sunpro] tree up if cc command exits nonzero" do
-    allow(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(1, "", ""))
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:sunpro)
-  end
-
-  it "does not set the languages[:c][:sunpro] tree up if cc command fails" do
-    allow(plugin).to receive(:shell_out).with("cc -V -flags").and_raise(Ohai::Exceptions::Exec)
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:sunpro)
-    expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
-  end
-
-  it "does not set the languages[:c][:sunpro] tree if the corresponding cc command fails on linux" do
-    fedora_error_message = "cc: error trying to exec 'i686-redhat-linux-gcc--flags': execvp: No such file or directory"
-
-    allow(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(0, "", fedora_error_message))
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:sunpro)
-  end
-
-  it "does not set the languages[:c][:sunpro] tree if the corresponding cc command fails on hpux" do
-    hpux_error_message = "cc: warning 901: unknown option: `-flags': use +help for online documentation.\ncc: HP C/aC++ B3910B A.06.25 [Nov 30 2009]"
-    allow(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(0, "", hpux_error_message))
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:sunpro)
-  end
-
-  #hpux cc
-  it "gets the cc version from running what cc" do
-    expect(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_return(mock_shell_out(0, C_HPUX, ""))
-    plugin.run
-  end
-
-  it "sets languages[:c][:hpcc][:version]" do
-    plugin.run
-    expect(plugin.languages[:c][:hpcc][:version]).to eql("B.11.11.16")
-  end
-
-  it "sets languages[:c][:hpcc][:description]" do
-    plugin.run
-    expect(plugin.languages[:c][:hpcc][:description]).to eql(C_HPUX.split($/)[3].strip)
-  end
-
-  it "does not set the languages[:c][:hpcc] tree up if cc command exits nonzero" do
-    allow(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_return(mock_shell_out(1, "", ""))
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:hpcc)
-  end
-
-  it "does not set the languages[:c][:hpcc] tree up if cc command fails" do
-    allow(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_raise(Ohai::Exceptions::Exec)
-    plugin.run
-    expect(plugin[:languages][:c]).not_to have_key(:hpcc)
-    expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
-  end
-
 end

--- a/spec/unit/plugins/c_spec.rb
+++ b/spec/unit/plugins/c_spec.rb
@@ -78,7 +78,6 @@ C_HPUX = <<EOF
          $ PATCH/11.00:PHCO_27774  Oct  3 2002 09:45:59 $
 EOF
 
-
 describe Ohai::System, "plugin c" do
 
   let(:plugin) { get_plugin("c") }
@@ -89,7 +88,6 @@ describe Ohai::System, "plugin c" do
     #gcc
     allow(plugin).to receive(:shell_out).with("gcc -v").and_return(mock_shell_out(0, "", C_GCC))
   end
-
 
   context "on HPUX" do
     before(:each) do
@@ -143,7 +141,6 @@ describe Ohai::System, "plugin c" do
       expect(plugin).not_to receive(:shell_out).with("gcc -v")
       plugin.run
     end
-
 
   end
 

--- a/spec/unit/plugins/c_spec.rb
+++ b/spec/unit/plugins/c_spec.rb
@@ -21,10 +21,13 @@ require "rbconfig"
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
 
 C_GCC = <<EOF
-Reading specs from /usr/lib/gcc/x86_64-redhat-linux/3.4.6/specs
-Configured with: ../configure --prefix=/usr ... --host=x86_64-redhat-linux
+Using built-in specs.
+COLLECT_GCC=gcc
+COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/5/lto-wrapper
+Target: x86_64-linux-gnu
+Configured with: ../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.4' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
 Thread model: posix
-gcc version 3.4.6 20060404 (Red Hat 3.4.6-3)
+gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
 EOF
 
 C_GLIBC_2_3_4 = <<EOF


### PR DESCRIPTION
Builds on the work that @erikng did in #941 

Additions:

Rework the specs to be per platform and remove some the guards that existed for *nix plugins on Windows
Add more useful fields to the gcc data
Use the same logging format everywhere
Add specs for the xcode change and rework other specs to run per platform
