### PR TITLE
Update travis/appveyer preinstall to resolve rainbow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,16 @@ sudo: false
 branches:
   only:
     - master
+    - 8-stable
 
 before_install:
   - gem update --system
+  - gem --version
+  - gem uninstall bundler -a -x -I
+  - rvm @global do gem uninstall bundler -a -x -I
   - gem install bundler
   - bundle --version
-  - gem --version
+  - rm -f .bundle/config
 rvm:
   - 2.2.6
   - 2.3.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,9 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%
   - ruby --version
+  - gem update --system
   - gem --version
+  - gem uninstall bundler -a -x -I
   - gem install bundler --quiet --no-ri --no-rdoc
   - bundler --version
 

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -25,15 +25,11 @@ Gem::Specification.new do |s|
   s.add_dependency "ipaddress"
   s.add_dependency "wmi-lite", "~> 1.0"
   s.add_dependency "ffi", "~> 1.9"
+  s.add_dependency "chef-config", ">= 12.5.0.alpha.1", "< 14"
   # Note for ohai developers: If chef-config causes you grief, try:
   #     bundle install --with development
   # this should work as long as chef is a development dependency in Gemfile.
   #
-  # Chef depends on ohai and chef-config. Ohai depends on chef-config. The
-  # version of chef-config that chef depends on is whatver version chef
-  # happens to be on master. This will need to be updated again once work on
-  # Chef 13 starts, otherwise builds will break.
-  s.add_dependency "chef-config", ">= 12.5.0.alpha.1", "< 13"
 
   s.bindir = "bin"
   s.executables = %w{ohai}


### PR DESCRIPTION
This same change was made in chef/chef to fix failures

Signed-off-by: Tim Smith <tsmith@chef.io>