### PR TITLE
Config is used in system so require it there.

### DIFF
--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -28,6 +28,7 @@ require "ohai/mixin/constant_helper"
 require "ohai/provides_map"
 require "ohai/hints"
 require "mixlib/shellout"
+require "ohai/config"
 
 module Ohai
   class System


### PR DESCRIPTION
COOL team found this when using ohai/system directly. It worked in 8.X, but not post deprecation of the old config logic.

Signed-off-by: Tim Smith <tsmith@chef.io>