### PR TITLE
Minor spec file cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :development do
   gem "rspec-collection_matchers", "~> 1.0"
   gem "rspec_junit_formatter"
   gem "github_changelog_generator", git: "https://github.com/tduffield/github-changelog-generator", branch: "adjust-tag-section-mapping"
+  gem "ipaddr_extensions"
 end

--- a/platform_simulation_specs/common/ohai_plugin_common_spec.rb
+++ b/platform_simulation_specs/common/ohai_plugin_common_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/ohai_plugin_common.rb")
+require_relative "ohai_plugin_common.rb"
 
 describe OhaiPluginCommon, "subsumes?" do
   before(:each) do

--- a/platform_simulation_specs/plugins/c_spec.rb
+++ b/platform_simulation_specs/plugins/c_spec.rb
@@ -17,9 +17,8 @@
 #
 
 require "rbconfig"
-
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "plugin c" do
   test_plugin(%w{languages c}, [ "/lib/libc.so.6", "/lib64/libc.so.6", "gcc", "cl", "devenv.com", "xlc", "cc", "what" ]) do |p|

--- a/platform_simulation_specs/plugins/erlang_spec.rb
+++ b/platform_simulation_specs/plugins/erlang_spec.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "plugin erlang" do
   test_plugin(%w{languages erlang}, [ "erl" ]) do |p|

--- a/platform_simulation_specs/plugins/go_spec.rb
+++ b/platform_simulation_specs/plugins/go_spec.rb
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "plugin go" do
   test_plugin(%w{languages go}, [ "go" ]) do |p|

--- a/platform_simulation_specs/plugins/groovy_spec.rb
+++ b/platform_simulation_specs/plugins/groovy_spec.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "plugin groovy" do
   test_plugin(%w{languages groovy}, [ "groovy" ]) do |p|

--- a/platform_simulation_specs/plugins/java_spec.rb
+++ b/platform_simulation_specs/plugins/java_spec.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "plugin java (Java5 Client VM)" do
   test_plugin(%w{languages java}, [ "java" ]) do |p|

--- a/platform_simulation_specs/plugins/kernel_spec.rb
+++ b/platform_simulation_specs/plugins/kernel_spec.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "../../../spec_helper.rb")
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "Linux kernel plugin" do
   test_plugin([ "kernel" ], %w{uname env}) do |p|

--- a/platform_simulation_specs/plugins/lua_spec.rb
+++ b/platform_simulation_specs/plugins/lua_spec.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "plugin lua" do
   test_plugin(%w{languages lua}, [ "lua" ]) do |p|

--- a/platform_simulation_specs/plugins/nodejs_spec.rb
+++ b/platform_simulation_specs/plugins/nodejs_spec.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "plugin nodejs" do
   test_plugin(%w{languages nodejs}, [ "node" ]) do |p|

--- a/platform_simulation_specs/plugins/perl_spec.rb
+++ b/platform_simulation_specs/plugins/perl_spec.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "plugin perl" do
   test_plugin(%w{languages perl}, [ "perl" ]) do |p|

--- a/platform_simulation_specs/plugins/php_spec.rb
+++ b/platform_simulation_specs/plugins/php_spec.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "plugin php" do
   test_plugin(%w{languages php}, [ "php" ]) do |p|

--- a/platform_simulation_specs/plugins/python_spec.rb
+++ b/platform_simulation_specs/plugins/python_spec.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
-require File.expand_path( File.join( File.dirname( __FILE__ ), "..", "common", "ohai_plugin_common.rb" ))
+require_relative "../../spec_helper.rb"
+require_relative "../common/ohai_plugin_common.rb"
 
 describe Ohai::System, "plugin python" do
   test_plugin(%w{languages python}, [ "python" ]) do |p|

--- a/platform_simulation_specs/tools/grab_data.rb
+++ b/platform_simulation_specs/tools/grab_data.rb
@@ -30,7 +30,7 @@ require "set"
 require "mixlib/shellout"
 require "mixlib/cli"
 require "optparse"
-require File.expand_path(File.dirname(__FILE__) + "/../spec/unit/path/ohai_plugin_common.rb")
+require_relative "../spec/unit/path/ohai_plugin_common.rb"
 
 #get options
 class MyCLI

--- a/spec/functional/application_spec.rb
+++ b/spec/functional/application_spec.rb
@@ -17,7 +17,6 @@
 #
 
 require_relative "../spec_helper"
-
 require "ohai/application"
 
 RSpec.describe "Ohai::Application" do

--- a/spec/functional/plugins/powershell_spec.rb
+++ b/spec/functional/plugins/powershell_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "languages plugin" do
   VERSION_MATCHING_REGEX = /^(?:[\d]+\.)+[\d]+$/

--- a/spec/functional/plugins/root_group_spec.rb
+++ b/spec/functional/plugins/root_group_spec.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "root_group plugin" do
   let(:plugin) { get_plugin("root_group") }

--- a/spec/functional/plugins/windows/uptime_spec.rb
+++ b/spec/functional/plugins/windows/uptime_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Windows plugin uptime" do
 

--- a/spec/ohai_spec.rb
+++ b/spec/ohai_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
+require_relative "spec_helper.rb"
 
 describe Ohai do
 

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -1,3 +1,20 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You may
+# obtain a copy of the license at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expressed or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+
 require "tmpdir"
 
 module IntegrationSupport

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -1,3 +1,20 @@
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You may
+# obtain a copy of the license at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expressed or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+
 def windows?
   !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
 end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -17,7 +17,6 @@
 #
 
 require_relative "../spec_helper"
-
 require "ohai/application"
 
 RSpec.describe "Ohai::Application" do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -17,7 +17,6 @@
 #
 
 require_relative "../spec_helper"
-
 require "ohai/config"
 
 RSpec.describe Ohai::Config do

--- a/spec/unit/dsl/plugin_spec.rb
+++ b/spec/unit/dsl/plugin_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License
 #
 
-require File.expand_path("../../../spec_helper.rb", __FILE__)
+require_relative "../../spec_helper.rb"
 
 shared_examples "Ohai::DSL::Plugin" do
   context "#initialize" do

--- a/spec/unit/hints_spec.rb
+++ b/spec/unit/hints_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper.rb"
 
 describe "Ohai::Hints" do
   # We are using the plugins directory infrastructure to test hints

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper.rb"
 
 describe Ohai::Loader do
   extend IntegrationSupport

--- a/spec/unit/mixin/command_spec.rb
+++ b/spec/unit/mixin/command_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::Mixin::Command, "shell_out" do
   let(:cmd) { "sparkle-dream --version" }

--- a/spec/unit/mixin/ec2_metadata_spec.rb
+++ b/spec/unit/mixin/ec2_metadata_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 require "ohai/mixin/ec2_metadata"
 
 describe Ohai::Mixin::Ec2Metadata do

--- a/spec/unit/mixin/softlayer_metadata_spec.rb
+++ b/spec/unit/mixin/softlayer_metadata_spec.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 require "ohai/mixin/softlayer_metadata"
 
 describe ::Ohai::Mixin::SoftlayerMetadata do

--- a/spec/unit/plugin_config_spec.rb
+++ b/spec/unit/plugin_config_spec.rb
@@ -16,7 +16,6 @@
 #
 
 require_relative "../spec_helper"
-
 require "ohai/plugin_config"
 
 describe "Ohai::PluginConfig" do

--- a/spec/unit/plugins/abort_spec.rb
+++ b/spec/unit/plugins/abort_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 tmp = ENV["TMPDIR"] || ENV["TMP"] || ENV["TEMP"] || "/tmp"
 

--- a/spec/unit/plugins/aix/cpu_spec.rb
+++ b/spec/unit/plugins/aix/cpu_spec.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "AIX cpu plugin" do
   before(:each) do

--- a/spec/unit/plugins/aix/filesystem_spec.rb
+++ b/spec/unit/plugins/aix/filesystem_spec.rb
@@ -15,7 +15,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "AIX filesystem plugin" do
   before(:each) do

--- a/spec/unit/plugins/aix/hostname_spec.rb
+++ b/spec/unit/plugins/aix/hostname_spec.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "AIX hostname plugin" do
   before(:each) do

--- a/spec/unit/plugins/aix/kernel_spec.rb
+++ b/spec/unit/plugins/aix/kernel_spec.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "AIX kernel plugin" do
   before(:each) do

--- a/spec/unit/plugins/aix/memory_spec.rb
+++ b/spec/unit/plugins/aix/memory_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "AIX memory plugin" do
   before(:each) do

--- a/spec/unit/plugins/aix/network_spec.rb
+++ b/spec/unit/plugins/aix/network_spec.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "AIX network plugin" do
 

--- a/spec/unit/plugins/aix/os_spec.rb
+++ b/spec/unit/plugins/aix/os_spec.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "AIX os plugin" do
   before(:each) do

--- a/spec/unit/plugins/aix/platform_spec.rb
+++ b/spec/unit/plugins/aix/platform_spec.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Aix plugin platform" do
   before(:each) do

--- a/spec/unit/plugins/aix/uptime_spec.rb
+++ b/spec/unit/plugins/aix/uptime_spec.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Aix plugin uptime" do
 

--- a/spec/unit/plugins/aix/virtualization_spec.rb
+++ b/spec/unit/plugins/aix/virtualization_spec.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "spec_helper"
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "AIX virtualization plugin" do
 

--- a/spec/unit/plugins/azure_spec.rb
+++ b/spec/unit/plugins/azure_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 require "open-uri"
 
 describe Ohai::System, "plugin azure" do

--- a/spec/unit/plugins/bsd/filesystem_spec.rb
+++ b/spec/unit/plugins/bsd/filesystem_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "BSD filesystem plugin" do
   let(:plugin) { get_plugin("bsd/filesystem") }

--- a/spec/unit/plugins/bsd/virtualization_spec.rb
+++ b/spec/unit/plugins/bsd/virtualization_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "BSD virtualization plugin" do
   before(:each) do

--- a/spec/unit/plugins/c_spec.rb
+++ b/spec/unit/plugins/c_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 C_GCC = <<EOF
 Using built-in specs.

--- a/spec/unit/plugins/chef_spec.rb
+++ b/spec/unit/plugins/chef_spec.rb
@@ -19,8 +19,7 @@
 #
 
 begin
-  require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
-
+  require_relative "../../spec_helper.rb"
   require "chef/version"
 
   describe Ohai::System, "plugin chef" do

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin cloud" do
   before(:each) do

--- a/spec/unit/plugins/cloud_v2_spec.rb
+++ b/spec/unit/plugins/cloud_v2_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 require "ipaddr"
 
 describe "CloudAttrs object" do

--- a/spec/unit/plugins/darwin/cpu_spec.rb
+++ b/spec/unit/plugins/darwin/cpu_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Darwin cpu plugin" do
   before(:each) do

--- a/spec/unit/plugins/darwin/filesystem2_spec.rb
+++ b/spec/unit/plugins/darwin/filesystem2_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "darwin filesystem2 plugin" do
   let (:plugin) { get_plugin("darwin/filesystem2") }

--- a/spec/unit/plugins/darwin/filesystem_spec.rb
+++ b/spec/unit/plugins/darwin/filesystem_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "darwin filesystem plugin" do
   let (:plugin) { get_plugin("darwin/filesystem") }

--- a/spec/unit/plugins/darwin/hardware_spec.rb
+++ b/spec/unit/plugins/darwin/hardware_spec.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
-require File.expand_path("#{File.dirname(__FILE__)}/hardware_system_profiler_output.rb")
+require_relative "../../../spec_helper.rb"
+require_relative "hardware_system_profiler_output.rb"
 
 describe Ohai::System, "Darwin hardware plugin", :unix_only do
   let (:plugin) { get_plugin("darwin/hardware") }

--- a/spec/unit/plugins/darwin/hostname_spec.rb
+++ b/spec/unit/plugins/darwin/hostname_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Darwin hostname plugin" do
   before(:each) do

--- a/spec/unit/plugins/darwin/kernel_spec.rb
+++ b/spec/unit/plugins/darwin/kernel_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Darwin kernel plugin" do
   before(:each) do

--- a/spec/unit/plugins/darwin/memory_spec.rb
+++ b/spec/unit/plugins/darwin/memory_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Darwin Memory Plugin" do
   before(:each) do

--- a/spec/unit/plugins/darwin/network_spec.rb
+++ b/spec/unit/plugins/darwin/network_spec.rb
@@ -16,7 +16,7 @@
 #  limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Darwin Network Plugin" do
   before(:each) do

--- a/spec/unit/plugins/darwin/platform_spec.rb
+++ b/spec/unit/plugins/darwin/platform_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Darwin plugin platform" do
   before(:each) do

--- a/spec/unit/plugins/darwin/system_profiler_spec.rb
+++ b/spec/unit/plugins/darwin/system_profiler_spec.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
-require File.expand_path("#{File.dirname(__FILE__)}/system_profiler_output.rb")
+require_relative "../../../spec_helper.rb"
+require_relative "system_profiler_output.rb"
 
 begin
   require "plist"

--- a/spec/unit/plugins/darwin/virtualization_spec.rb
+++ b/spec/unit/plugins/darwin/virtualization_spec.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Darwin virtualization platform" do
   let(:plugin) { get_plugin("darwin/virtualization") }

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -16,7 +16,7 @@
 #
 
 require "ipaddress"
-require "spec_helper"
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin digital_ocean" do
   let(:plugin) { get_plugin("digital_ocean") }

--- a/spec/unit/plugins/dmi_spec.rb
+++ b/spec/unit/plugins/dmi_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 # NOTE: These data lines must be prefixed with one or two tabs, not spaces.
 DMI_OUT = <<-EOS

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 require "open-uri"
 require "base64"
 

--- a/spec/unit/plugins/elixir_spec.rb
+++ b/spec/unit/plugins/elixir_spec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin elixir" do
   let(:plugin) { get_plugin("elixir") }

--- a/spec/unit/plugins/erlang_spec.rb
+++ b/spec/unit/plugins/erlang_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin erlang" do
   let(:plugin) { get_plugin("erlang") }

--- a/spec/unit/plugins/eucalyptus_spec.rb
+++ b/spec/unit/plugins/eucalyptus_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 require "open-uri"
 
 describe Ohai::System, "plugin eucalyptus" do

--- a/spec/unit/plugins/fail_spec.rb
+++ b/spec/unit/plugins/fail_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 tmp = ENV["TMPDIR"] || ENV["TMP"] || ENV["TEMP"] || "/tmp"
 

--- a/spec/unit/plugins/freebsd/cpu_spec.rb
+++ b/spec/unit/plugins/freebsd/cpu_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "FreeBSD cpu plugin on FreeBSD >=10.2" do
   before(:each) do

--- a/spec/unit/plugins/freebsd/hostname_spec.rb
+++ b/spec/unit/plugins/freebsd/hostname_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "FreeBSD hostname plugin" do
   before(:each) do

--- a/spec/unit/plugins/freebsd/kernel_spec.rb
+++ b/spec/unit/plugins/freebsd/kernel_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "FreeBSD kernel plugin" do
   before(:each) do

--- a/spec/unit/plugins/freebsd/os_spec.rb
+++ b/spec/unit/plugins/freebsd/os_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "FreeBSD plugin os" do
   before(:each) do

--- a/spec/unit/plugins/freebsd/platform_spec.rb
+++ b/spec/unit/plugins/freebsd/platform_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "FreeBSD plugin platform" do
   before(:each) do

--- a/spec/unit/plugins/gce_spec.rb
+++ b/spec/unit/plugins/gce_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 require "open-uri"
 
 describe Ohai::System, "plugin gce" do

--- a/spec/unit/plugins/go_spec.rb
+++ b/spec/unit/plugins/go_spec.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin go" do
   let(:plugin) { get_plugin("go") }

--- a/spec/unit/plugins/groovy_spec.rb
+++ b/spec/unit/plugins/groovy_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin groovy" do
   let(:plugin) { get_plugin("groovy") }

--- a/spec/unit/plugins/haskell_spec.rb
+++ b/spec/unit/plugins/haskell_spec.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin haskell" do
 

--- a/spec/unit/plugins/hostname_spec.rb
+++ b/spec/unit/plugins/hostname_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "hostname plugin" do
   before(:each) do

--- a/spec/unit/plugins/init_package_spec.rb
+++ b/spec/unit/plugins/init_package_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "Init package" do
   let(:plugin) do

--- a/spec/unit/plugins/ip_scopes_spec.rb
+++ b/spec/unit/plugins/ip_scopes_spec.rb
@@ -1,9 +1,21 @@
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-begin
-  require "ipaddr_extensions"
-rescue LoadError
-end
+require_relative "../../spec_helper.rb"
+require "ipaddr_extensions"
 
 describe Ohai::System, "plugin ip_scopes" do
   let(:plugin) { get_plugin("ip_scopes") }

--- a/spec/unit/plugins/java_spec.rb
+++ b/spec/unit/plugins/java_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin java (Java5 Client VM)" do
   let(:plugin) { get_plugin("java") }

--- a/spec/unit/plugins/joyent_spec.rb
+++ b/spec/unit/plugins/joyent_spec.rb
@@ -1,4 +1,20 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin joyent" do
   let(:plugin) { get_plugin("joyent") }

--- a/spec/unit/plugins/kernel_spec.rb
+++ b/spec/unit/plugins/kernel_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin kernel" do
   before(:each) do

--- a/spec/unit/plugins/linode_spec.rb
+++ b/spec/unit/plugins/linode_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin linode" do
   let(:plugin) { get_plugin("linode") }

--- a/spec/unit/plugins/linux/block_device_spec.rb
+++ b/spec/unit/plugins/linux/block_device_spec.rb
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux Block Device Plugin" do
   DISKS = {

--- a/spec/unit/plugins/linux/cpu_spec.rb
+++ b/spec/unit/plugins/linux/cpu_spec.rb
@@ -17,8 +17,7 @@
 #
 
 require "tempfile"
-
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 shared_examples "Common cpu info" do |total_cpu, real_cpu|
   describe "cpu" do

--- a/spec/unit/plugins/linux/filesystem2_spec.rb
+++ b/spec/unit/plugins/linux/filesystem2_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux filesystem plugin" do
   let (:plugin) { get_plugin("linux/filesystem2") }

--- a/spec/unit/plugins/linux/filesystem_spec.rb
+++ b/spec/unit/plugins/linux/filesystem_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux filesystem plugin" do
   let(:plugin) { get_plugin("linux/filesystem") }

--- a/spec/unit/plugins/linux/fips_spec.rb
+++ b/spec/unit/plugins/linux/fips_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "plugin fips" do
   let(:enabled) { "0" }

--- a/spec/unit/plugins/linux/hostname_spec.rb
+++ b/spec/unit/plugins/linux/hostname_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux hostname plugin" do
   before(:each) do

--- a/spec/unit/plugins/linux/hostnamectl_spec.rb
+++ b/spec/unit/plugins/linux/hostnamectl_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux hostnamectl plugin" do
   let(:plugin) { get_plugin("linux/hostnamectl") }

--- a/spec/unit/plugins/linux/kernel_spec.rb
+++ b/spec/unit/plugins/linux/kernel_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux kernel plugin" do
   before(:each) do

--- a/spec/unit/plugins/linux/lsb_spec.rb
+++ b/spec/unit/plugins/linux/lsb_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 # We do not alter case for lsb attributes and consume them as provided
 

--- a/spec/unit/plugins/linux/machineid_spec.rb
+++ b/spec/unit/plugins/linux/machineid_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Machine id plugin" do
   let(:plugin) { get_plugin("linux/machineid") }

--- a/spec/unit/plugins/linux/mdadm_spec.rb
+++ b/spec/unit/plugins/linux/mdadm_spec.rb
@@ -16,7 +16,7 @@
 #  limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux Mdadm Plugin" do
   before(:each) do

--- a/spec/unit/plugins/linux/memory_spec.rb
+++ b/spec/unit/plugins/linux/memory_spec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux memory plugin" do
   before(:each) do

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -17,14 +17,8 @@
 #  limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
-
-begin
-  require "ipaddress"
-rescue LoadError => e
-  puts "The linux network plugin spec tests will fail without the 'ipaddress' library/gem.\n\n"
-  raise e
-end
+require_relative "../../../spec_helper.rb"
+require "ipaddress"
 
 describe Ohai::System, "Linux Network Plugin" do
   let(:plugin) { get_plugin("linux/network") }

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux plugin platform" do
 

--- a/spec/unit/plugins/linux/sessions_spec.rb
+++ b/spec/unit/plugins/linux/sessions_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux sessions plugin" do
   let(:plugin) { get_plugin("linux/sessions") }

--- a/spec/unit/plugins/linux/uptime_spec.rb
+++ b/spec/unit/plugins/linux/uptime_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux plugin uptime" do
   before(:each) do

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux virtualization platform" do
   let(:plugin) { get_plugin("linux/virtualization") }

--- a/spec/unit/plugins/lua_spec.rb
+++ b/spec/unit/plugins/lua_spec.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin lua" do
 

--- a/spec/unit/plugins/mono_spec.rb
+++ b/spec/unit/plugins/mono_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin mono" do
   let(:plugin) { get_plugin("mono") }

--- a/spec/unit/plugins/netbsd/hostname_spec.rb
+++ b/spec/unit/plugins/netbsd/hostname_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "NetBSD hostname plugin" do
   before(:each) do

--- a/spec/unit/plugins/netbsd/kernel_spec.rb
+++ b/spec/unit/plugins/netbsd/kernel_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "NetBSD kernel plugin" do
   before(:each) do

--- a/spec/unit/plugins/netbsd/platform_spec.rb
+++ b/spec/unit/plugins/netbsd/platform_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "NetBSD plugin platform" do
   before(:each) do

--- a/spec/unit/plugins/network_spec.rb
+++ b/spec/unit/plugins/network_spec.rb
@@ -16,7 +16,7 @@
 #  limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 def it_doesnt_fail
   it "doesnt fail" do

--- a/spec/unit/plugins/nodejs_spec.rb
+++ b/spec/unit/plugins/nodejs_spec.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin nodejs" do
 

--- a/spec/unit/plugins/ohai_spec.rb
+++ b/spec/unit/plugins/ohai_spec.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin ohai" do
   before(:each) do

--- a/spec/unit/plugins/ohai_time_spec.rb
+++ b/spec/unit/plugins/ohai_time_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin ohai_time" do
   before(:each) do

--- a/spec/unit/plugins/openbsd/hostname_spec.rb
+++ b/spec/unit/plugins/openbsd/hostname_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "OpenBSD hostname plugin" do
   before(:each) do

--- a/spec/unit/plugins/openbsd/kernel_spec.rb
+++ b/spec/unit/plugins/openbsd/kernel_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "OpenBSD kernel plugin" do
   before(:each) do

--- a/spec/unit/plugins/openbsd/platform_spec.rb
+++ b/spec/unit/plugins/openbsd/platform_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "OpenBSD plugin platform" do
   before(:each) do

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -16,10 +16,9 @@
 # limitations under the License.
 #
 
-require "spec_helper"
-require "ohai/plugins/openstack"
+require_relative "../../spec_helper.rb"
 
-describe "OpenStack Plugin" do
+describe Ohai::System, "plugin openstack" do
 
   let(:plugin) { get_plugin("openstack") }
 

--- a/spec/unit/plugins/os_spec.rb
+++ b/spec/unit/plugins/os_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 ORIGINAL_CONFIG_HOST_OS = ::RbConfig::CONFIG["host_os"]
 

--- a/spec/unit/plugins/packages_spec.rb
+++ b/spec/unit/plugins/packages_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin packages" do
   context "on debian" do

--- a/spec/unit/plugins/passwd_spec.rb
+++ b/spec/unit/plugins/passwd_spec.rb
@@ -1,4 +1,20 @@
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin etc", :unix_only do
   before(:each) do

--- a/spec/unit/plugins/perl_spec.rb
+++ b/spec/unit/plugins/perl_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin perl" do
   let(:plugin) { get_plugin("perl") }

--- a/spec/unit/plugins/php_spec.rb
+++ b/spec/unit/plugins/php_spec.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin php" do
   let(:plugin) { get_plugin("php") }

--- a/spec/unit/plugins/platform_spec.rb
+++ b/spec/unit/plugins/platform_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin platform" do
   before(:each) do

--- a/spec/unit/plugins/powershell_spec.rb
+++ b/spec/unit/plugins/powershell_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin powershell" do
   let(:plugin) { get_plugin("powershell") }

--- a/spec/unit/plugins/python_spec.rb
+++ b/spec/unit/plugins/python_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin python" do
   let(:stdout) { "2.5.2 (r252:60911, Jan  4 2009, 17:40:26)\n[GCC 4.3.2]\n" }

--- a/spec/unit/plugins/rackspace_spec.rb
+++ b/spec/unit/plugins/rackspace_spec.rb
@@ -16,8 +16,7 @@
 #
 
 require "resolv"
-
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin rackspace" do
   let(:plugin) { get_plugin("rackspace") }

--- a/spec/unit/plugins/root_group_spec.rb
+++ b/spec/unit/plugins/root_group_spec.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
-require File.expand_path(File.dirname(__FILE__) + "/../../../lib/ohai/util/win32/group_helper.rb")
+require_relative "../../spec_helper.rb"
+require "ohai/util/win32/group_helper"
 
 describe Ohai::System, "root_group" do
   before(:each) do

--- a/spec/unit/plugins/ruby_spec.rb
+++ b/spec/unit/plugins/ruby_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 ruby_bin = File.join(::RbConfig::CONFIG["bindir"], ::RbConfig::CONFIG["ruby_install_name"])
 

--- a/spec/unit/plugins/rust_spec.rb
+++ b/spec/unit/plugins/rust_spec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin rust" do
   let(:stdout) { "rustc 1.0.0-nightly (29bd9a06e 2015-01-20 23:03:09 +0000)" }

--- a/spec/unit/plugins/scala_spec.rb
+++ b/spec/unit/plugins/scala_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin scala" do
 

--- a/spec/unit/plugins/shard_spec.rb
+++ b/spec/unit/plugins/shard_spec.rb
@@ -17,7 +17,7 @@
 #
 
 require "digest/md5"
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "shard plugin" do
   let(:plugin) { get_plugin("shard") }

--- a/spec/unit/plugins/shells_spec.rb
+++ b/spec/unit/plugins/shells_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin shells" do
   let(:plugin) { get_plugin("shells") }

--- a/spec/unit/plugins/softlayer_spec.rb
+++ b/spec/unit/plugins/softlayer_spec.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin softlayer" do
   let(:plugin) { get_plugin("softlayer") }

--- a/spec/unit/plugins/solaris2/cpu_spec.rb
+++ b/spec/unit/plugins/solaris2/cpu_spec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Solaris2.X cpu plugin" do
   before(:each) do

--- a/spec/unit/plugins/solaris2/dmi_spec.rb
+++ b/spec/unit/plugins/solaris2/dmi_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 SOLARIS_DMI_OUT = <<-EOS
 ID    SIZE TYPE

--- a/spec/unit/plugins/solaris2/hostname_spec.rb
+++ b/spec/unit/plugins/solaris2/hostname_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Solaris2.X hostname plugin" do
   before(:each) do

--- a/spec/unit/plugins/solaris2/kernel_spec.rb
+++ b/spec/unit/plugins/solaris2/kernel_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Solaris2.X kernel plugin" do
   # NOTE: Solaris will report the same module loaded multiple times

--- a/spec/unit/plugins/solaris2/memory_spec.rb
+++ b/spec/unit/plugins/solaris2/memory_spec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Solaris2.X memory plugin" do
   before(:each) do

--- a/spec/unit/plugins/solaris2/network_spec.rb
+++ b/spec/unit/plugins/solaris2/network_spec.rb
@@ -16,7 +16,7 @@
 #  limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Solaris2.X network plugin" do
 

--- a/spec/unit/plugins/solaris2/platform_spec.rb
+++ b/spec/unit/plugins/solaris2/platform_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Solaris plugin platform" do
   before(:each) do

--- a/spec/unit/plugins/solaris2/virtualization_spec.rb
+++ b/spec/unit/plugins/solaris2/virtualization_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Solaris virtualization platform" do
   before(:each) do

--- a/spec/unit/plugins/solaris2/zpools_spec.rb
+++ b/spec/unit/plugins/solaris2/zpools_spec.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Solaris 2.x zpool plugin" do
   before(:each) do

--- a/spec/unit/plugins/ssh_host_keys_spec.rb
+++ b/spec/unit/plugins/ssh_host_keys_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "ssh_host_key plugin" do
 

--- a/spec/unit/plugins/sysconf_spec.rb
+++ b/spec/unit/plugins/sysconf_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "sysconf plugin", :unix_only do
   let(:plugin) { get_plugin("sysconf") }

--- a/spec/unit/plugins/timezone_spec.rb
+++ b/spec/unit/plugins/timezone_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "timezone plugin" do
   before(:each) do

--- a/spec/unit/plugins/virtualbox_spec.rb
+++ b/spec/unit/plugins/virtualbox_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "/spec_helper.rb"))
+require_relative "../../spec_helper.rb"
 
 vbox_output = <<EOF
 Oracle VM VirtualBox Guest Additions Command Line Management Interface Version 5.0.2

--- a/spec/unit/plugins/vmware_spec.rb
+++ b/spec/unit/plugins/vmware_spec.rb
@@ -14,7 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-require "spec_helper"
+
+require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "plugin vmware" do
   let(:plugin) { get_plugin("vmware") }

--- a/spec/unit/plugins/windows/cpu_spec.rb
+++ b/spec/unit/plugins/windows/cpu_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 shared_examples "a cpu" do |cpu_no|
   describe "cpu #{cpu_no}" do

--- a/spec/unit/plugins/windows/fips_spec.rb
+++ b/spec/unit/plugins/windows/fips_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "plugin fips", :windows_only do
   let(:enabled) { 0 }

--- a/spec/unit/plugins/windows/memory_spec.rb
+++ b/spec/unit/plugins/windows/memory_spec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Windows memory plugin", :windows_only do
   before do

--- a/spec/unit/plugins/windows/uptime_spec.rb
+++ b/spec/unit/plugins/windows/uptime_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Windows plugin uptime" do
 

--- a/spec/unit/plugins/windows/virtualization_spec.rb
+++ b/spec/unit/plugins/windows/virtualization_spec.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Windows virtualization platform" do
   let(:plugin) { get_plugin("windows/virtualization") }

--- a/spec/unit/provides_map_spec.rb
+++ b/spec/unit/provides_map_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper.rb"
 
 describe Ohai::ProvidesMap do
 

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper.rb"
 
 describe Ohai::Runner, "run_plugin" do
   let(:safe_run) { true }

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper.rb"
 require "ohai/mixin/os"
 
 describe "Ohai::System" do

--- a/spec/unit/util/file_helper_spec.rb
+++ b/spec/unit/util/file_helper_spec.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "spec_helper"
+require_relative "../../spec_helper.rb"
 require "ohai/util/file_helper"
 
 class FileHelperMock

--- a/spec/unit/util/ip_helper_spec.rb
+++ b/spec/unit/util/ip_helper_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 require "ipaddress"
-require "spec_helper"
+require_relative "../../spec_helper.rb"
 require "ohai/util/ip_helper"
 
 class IpHelperMock


### PR DESCRIPTION
- Use require_relative in all the specs vs. expanding on the current file
path.
- Add missing license headers
- Don't silently swallow ipaddr_extensions not being installed. Make it
  a development dep instead
- Remove a rescue on ipaddress as we only do this in one place and it's
  a required gem
- Make the Openstack plugin spec setup the same way as every other spec

Signed-off-by: Tim Smith <tsmith@chef.io>