### PR TITLE
Remove rescue loading plist in the specs as this is a dep

### DIFF
--- a/spec/unit/plugins/darwin/system_profiler_spec.rb
+++ b/spec/unit/plugins/darwin/system_profiler_spec.rb
@@ -19,13 +19,6 @@
 require_relative "../../../spec_helper.rb"
 require_relative "system_profiler_output.rb"
 
-begin
-  require "plist"
-rescue LoadError => e
-  puts "The darwin systemprofile plugin spec tests will fail without the 'plist' library/gem.\n\n"
-  raise e
-end
-
 describe Ohai::System, "Darwin system_profiler plugin", :unix_only do
   before(:each) do
     @plugin = get_plugin("darwin/system_profiler")


### PR DESCRIPTION
There’s no need for this and we’re not doing this in the dozen other places we load deps.

Signed-off-by: Tim Smith <tsmith@chef.io>