### PR TITLE
fix logger issues

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -88,7 +88,8 @@ class Ohai::Application
   end
 
   def run_application
-    ohai = Ohai::System.new(config, cli: true)
+    config[:invoked_from_cli] = true
+    ohai = Ohai::System.new(config)
     ohai.all_plugins(@attributes)
 
     if @attributes

--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -88,7 +88,7 @@ class Ohai::Application
   end
 
   def run_application
-    ohai = Ohai::System.new(config)
+    ohai = Ohai::System.new(config, cli: true)
     ohai.all_plugins(@attributes)
 
     if @attributes

--- a/lib/ohai/log.rb
+++ b/lib/ohai/log.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/ohai/log.rb
+++ b/lib/ohai/log.rb
@@ -22,6 +22,8 @@ module Ohai
   class Log
     extend Mixlib::Log
 
+    # this class loading initalization is so that we don't lose early logger
+    # messages when run from the CLI?
     init(STDERR)
     level = :info
 

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -39,6 +39,10 @@ module Ohai
     attr_reader :provides_map
     attr_reader :v6_dependency_solver
 
+    # the cli flag is used to determine if we're being constructed by
+    # something like chef-client (which doesn't not set this flag) and
+    # which sets up its own loggers, or if we're coming from Ohai::Application
+    # and therefore need to configure Ohai's own logger.
     def initialize(config = {}, cli: false)
       @cli = cli
       @plugin_path = ""

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -43,8 +43,8 @@ module Ohai
     # something like chef-client (which doesn't not set this flag) and
     # which sets up its own loggers, or if we're coming from Ohai::Application
     # and therefore need to configure Ohai's own logger.
-    def initialize(config = {}, cli: false)
-      @cli = cli
+    def initialize(config = {})
+      @cli = config[:invoked_from_cli]
       @plugin_path = ""
       @config = config
       reset_system

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,8 @@ module Ohai
     attr_reader :provides_map
     attr_reader :v6_dependency_solver
 
-    def initialize(config = {})
+    def initialize(config = {}, cli: false)
+      @cli = cli
       @plugin_path = ""
       @config = config
       reset_system
@@ -51,7 +52,7 @@ module Ohai
       @v6_dependency_solver = Hash.new
 
       configure_ohai
-      configure_logging
+      configure_logging if @cli
 
       @loader = Ohai::Loader.new(self)
       @runner = Ohai::Runner.new(self, true)


### PR DESCRIPTION
    fix ohai logger problems.

    i believe this gets the logic correct in that we want to configure the
    logger when we're coming from the command line but want to skip it when
    we're coming from chef or from other APIs that directly construct an
    Ohai::System object.

    i suspect this is what thom was trying to do by moving the
    Ohai::Log.init call into the Ohai::Application class (which avoids it
    being called entirely when Chef creates its Ohai::System object) here:

    https://github.com/chef/ohai/pull/942/files

    but that change broke the behavior where we were also supposed to skip
    the rest of the configure_logging method in Ohai::System when run under
    chef client.

    I tried going down the route of having the Ohai::Application class
    construct the Ohai::System object and then having it be the
    responsibility of that caller to do configure_logging work.  However,
    I suspect that the initializer in Ohai::System does way too much and
    that the purpose of configuring the logger where it is, is that it
    must be initialized in the middle of object creation before it goes on
    and creates the Loader, the Runner, creates Hints and removes constants.

    So, I went the route of threading a flag through the initializer so that
    Ohai::System can know if its coming from the cli or not and behave
    appropriately.

    There's also quite a mess with the Ohai::Log class being passed around
    to the workstation loader, and it initializes itself at class loading
    time and Chef::Application will inject state into Ohai::Log.  I think
    the eager initialization at class loading time is to not lose early
    messages when run from the cli, but it means the Ohai::Log object is always
    initialized, so that isn't useful for determining if we have come from the
    cli or not.