### PR TITLE
Fix lua detection on new versions of lua

### DIFF
--- a/lib/ohai/plugins/lua.rb
+++ b/lib/ohai/plugins/lua.rb
@@ -27,7 +27,9 @@ Ohai.plugin(:Lua) do
       # Lua 5.2.4  Copyright (C) 1994-2015 Lua.org, PUC-Rio
       if so.exitstatus == 0
         lua = Mash.new
-        lua[:version] = so.stderr.split[1]
+        # at some point in lua's history they went from outputting the version
+        # on stderr to doing it on stdout. This handles old / new versions
+        lua[:version] = so.stdout.empty? ? so.stderr.split[1] : so.stdout.split[1]
         languages[:lua] = lua if lua[:version]
       end
     rescue Ohai::Exceptions::Exec

--- a/spec/unit/plugins/lua_spec.rb
+++ b/spec/unit/plugins/lua_spec.rb
@@ -26,8 +26,8 @@ describe Ohai::System, "plugin lua" do
 
   before(:each) do
     plugin[:languages] = Mash.new
-    @stderr = "Lua 5.1.2  Copyright (C) 1994-2008 Lua.org, PUC-Rio\n"
-    allow(plugin).to receive(:shell_out).with("lua -v").and_return(mock_shell_out(0, "", @stderr))
+    @message = "Lua 5.1.2  Copyright (C) 1994-2008 Lua.org, PUC-Rio\n"
+    allow(plugin).to receive(:shell_out).with("lua -v").and_return(mock_shell_out(0, "", @message))
   end
 
   it "gets the lua version from running lua -v" do
@@ -50,5 +50,11 @@ describe Ohai::System, "plugin lua" do
     allow(plugin).to receive(:shell_out).and_raise(Ohai::Exceptions::Exec)
     plugin.run
     expect(plugin.languages).not_to have_key(:lua)
+  end
+
+  it "sets languages[:lua][:version] when 'lua -v' returns output on stdout not stderr" do
+    allow(plugin).to receive(:shell_out).with("lua -v").and_return(mock_shell_out(0, @message, ""))
+    plugin.run
+    expect(plugin.languages[:lua][:version]).to eql("5.1.2")
   end
 end


### PR DESCRIPTION
Newer versions of lua output lua -v on stdout while older versions use
stderr. This update will handle both and ensure that we continue to
detect the installed lua version.

Signed-off-by: Tim Smith <tsmith@chef.io>