### PR TITLE
Add DMI type 40,41, and 42 from the latest man page

### DIFF
--- a/lib/ohai/common/dmi.rb
+++ b/lib/ohai/common/dmi.rb
@@ -65,6 +65,9 @@ module Ohai
         37 =>  "memory_channel",
         38 =>  "ipmi_device",
         39 =>  "power_supply",
+        40 =>  "additional_information",
+        41 =>  "onboard_devices_extended_information",
+        42 =>  "management_controller_host_interfaces",
         126 => "disabled_entries",
         127 => "end_of_table_marker",
       }


### PR DESCRIPTION
These have been added in the last few years it appears

Signed-off-by: Tim Smith <tsmith@chef.io>