### PR TITLE
add amazon platform_family

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,8 +107,10 @@ Ohai.plugin(:Platform) do
     case platform
     when /debian/, /ubuntu/, /linuxmint/, /raspbian/, /cumulus/
       "debian"
-    when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /amazon/, /xenserver/, /cloudlinux/, /ibm_powerkvm/, /parallels/, /nexus_centos/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
+    when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /xenserver/, /cloudlinux/, /ibm_powerkvm/, /parallels/, /nexus_centos/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
       "rhel"
+    when /amazon/
+      "amazon"
     when /suse/
       "suse"
     when /fedora/, /pidora/, /arista_eos/

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -113,7 +113,7 @@ describe Ohai::System, "Linux plugin platform" do
       @plugin[:lsb][:release] = "2011.09"
       @plugin.run
       expect(@plugin[:platform]).to eq("amazon")
-      expect(@plugin[:platform_family]).to eq("rhel")
+      expect(@plugin[:platform_family]).to eq("amazon")
     end
 
     it "should set platform to scientific when [:lsb][:id] contains ScientificSL" do
@@ -358,7 +358,7 @@ OS_RELEASE
       it "should set the platform_family to rhel if the LSB name is amazon-ish" do
         @plugin[:lsb][:id] = "Amazon"
         @plugin.run
-        expect(@plugin[:platform_family]).to eq("rhel")
+        expect(@plugin[:platform_family]).to eq("amazon")
       end
 
       it "should set the platform_family to fedora if the LSB name is fedora-ish" do


### PR DESCRIPTION
i think we've finally decided not to move amazon to fedora in #960

i still think everyone is wrong, but i got my `fedora_derived?`
chef-sugar helper so its a mute point now...

https://github.com/chef/chef-rfc/pull/252

