### PR TITLE
Freeze all string values coming out of Ohai.

### DIFF
--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -107,6 +107,9 @@ module Ohai
         Ohai::Log.error("Encountered error while running plugins: #{e.inspect}")
         raise
       end
+
+      # Freeze all strings.
+      freeze_strings!
     end
 
     def have_v6_plugin?(name)
@@ -230,6 +233,26 @@ module Ohai
       else
         Ohai::Log.level = Ohai.config[:log_level]
       end
+    end
+
+    # Freeze all string values in @data. This makes them immutable and saves
+    # a bit of RAM.
+    #
+    # @api private
+    # @return [void]
+    def freeze_strings!
+      # Recursive visitor pattern helper.
+      visitor = lambda do |val|
+        case val
+        when Hash
+          val.each_value {|v| visitor.call(v) }
+        when Array
+          val.each {|v| visitor.call(v) }
+        when String
+          val.freeze
+        end
+      end
+      visitor.call(@data)
     end
   end
 end

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -245,9 +245,9 @@ module Ohai
       visitor = lambda do |val|
         case val
         when Hash
-          val.each_value {|v| visitor.call(v) }
+          val.each_value { |v| visitor.call(v) }
         when Array
-          val.each {|v| visitor.call(v) }
+          val.each { |v| visitor.call(v) }
         when String
           val.freeze
         end

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -166,6 +166,8 @@ EOF
         ohai.all_plugins
         expect(ohai.data[:zoo]).to eq("animals")
         expect(ohai.data[:park]).to eq("plants")
+        expect(ohai.data[:zoo]).to be_frozen
+        expect(ohai.data[:park]).to be_frozen
       end
 
       describe "when using :disabled_plugins" do
@@ -312,6 +314,8 @@ EOF
         ohai.all_plugins
         expect(ohai.data[:zoo]).to eq("animals")
         expect(ohai.data[:park]).to eq("plants")
+        expect(ohai.data[:zoo]).to be_frozen
+        expect(ohai.data[:park]).to be_frozen
       end
 
       it "should write an error to Ohai::Log" do


### PR DESCRIPTION
This both helps avoid weird mutation bugs and saves a bit of RAM. This does not freeze the hashes or arrays so replacement and whatnot should all work the same. Anyone doing in-place mutation of Ohai strings on purpose is getting what they deserve IMO.

Refs https://github.com/chef/chef/issues/4930 for original discussion.