### PR TITLE
Shorten the sbt shellout timeout period

### DIFF
--- a/lib/ohai/plugins/scala.rb
+++ b/lib/ohai/plugins/scala.rb
@@ -35,7 +35,7 @@ Ohai.plugin(:Scala) do
     # Check for sbt
     begin
       # sbt launcher version 0.13.7
-      so = shell_out("sbt --version")
+      so = shell_out("sbt --version", timeout: 5)
       if so.exitstatus == 0
         scala[:sbt] = Mash.new
         scala[:sbt][:version] = so.stdout.split[3]

--- a/spec/unit/plugins/scala_spec.rb
+++ b/spec/unit/plugins/scala_spec.rb
@@ -33,7 +33,7 @@ describe Ohai::System, "plugin scala" do
       .with("scala -version")
       .and_return(mock_shell_out(0, "", scala_out))
     allow(plugin).to receive(:shell_out)
-      .with("sbt --version")
+      .with("sbt --version", { :timeout => 5 })
       .and_return(mock_shell_out(0, sbt_out, ""))
   end
 
@@ -80,7 +80,7 @@ describe Ohai::System, "plugin scala" do
         .and_return(mock_shell_out(0, "", scala_out))
 
       allow(plugin).to receive(:shell_out)
-        .with("sbt --version")
+        .with("sbt --version", { :timeout => 5 })
         .and_raise( Ohai::Exceptions::Exec )
       plugin.run
     end


### PR DESCRIPTION
30 seconds is way too high here. On my mac the sbt command fails (a whole different issue), but we take 30 seconds to skip the plugin. There’s no reason to wait 30 seconds here for a plugin that doesn’t need that.

Signed-off-by: Tim Smith <tsmith@chef.io>