### PR TITLE
Fix sbt version detection in the scala plugin with modern sbt

### DIFF
--- a/lib/ohai/plugins/scala.rb
+++ b/lib/ohai/plugins/scala.rb
@@ -32,16 +32,21 @@ Ohai.plugin(:Scala) do
       Ohai::Log.debug('Plugin Scala: Could not shell_out "scala -version". Skipping data')
     end
 
-    # Check for sbt
+    # Check for sbt in a way that is known compatible with 0.12 and 0.13 releases
     begin
-      # sbt launcher version 0.13.7
-      so = shell_out("sbt --version", timeout: 5)
+      # [info] Set current project to tsmith (in build file:/Users/tsmith/)
+      # [info] This is sbt 0.13.13
+      # [info] The current project is {file:/Users/tsmith/}tsmith 0.1-SNAPSHOT
+      # [info] The current project is built against Scala 2.10.6
+      # [info] Available Plugins: sbt.plugins.IvyPlugin, sbt.plugins.JvmPlugin, sbt.plugins.CorePlugin, sbt.plugins.JUnitXmlReportPlugin, sbt.plugins.Giter8TemplatePlugin
+      # [info] sbt, sbt plugins, and build definitions are using Scala 2.10.6
+      so = shell_out("sbt about", timeout: 10)
       if so.exitstatus == 0
         scala[:sbt] = Mash.new
-        scala[:sbt][:version] = so.stdout.split[3]
+        scala[:sbt][:version] = so.stdout.match(/.*This is sbt ([a-z0-9.]*)/)[1] # necessary to avoid color codes in the output
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Scala: Could not shell_out "sbt --version". Skipping data')
+      Ohai::Log.debug('Plugin Scala: Could not shell_out "sbt about". Skipping data')
     end
 
     languages[:scala] = scala unless scala.empty?

--- a/spec/unit/plugins/scala_spec.rb
+++ b/spec/unit/plugins/scala_spec.rb
@@ -26,14 +26,14 @@ describe Ohai::System, "plugin scala" do
   end
 
   let(:scala_out) { "Scala code runner version 2.11.6 -- Copyright 2002-2013, LAMP/EPFL" }
-  let(:sbt_out) { "sbt launcher version 0.13.8" }
+  let(:sbt_out) { '\e[0m[\e[0minfo\e[0m] \e[0mSet current project to ohai (in build file:/Users/tsmith/dev/work/ohai/)\e[0m\n\e[0m[\e[0minfo\e[0m] \e[0mThis is sbt 0.13.13\e[0m\n\e[0m[\e[0minfo\e[0m] \e[0mThe current project is {file:/Users/tsmith/dev/work/ohai/}ohai 0.1-SNAPSHOT\e[0m\n\e[0m[\e[0minfo\e[0m] \e[0mThe current project is built against Scala 2.10.6\e[0m\n\e[0m[\e[0minfo\e[0m] \e[0mAvailable Plugins: sbt.plugins.IvyPlugin, sbt.plugins.JvmPlugin, sbt.plugins.CorePlugin, sbt.plugins.JUnitXmlReportPlugin, sbt.plugins.Giter8TemplatePlugin\e[0m\n\e[0m[\e[0minfo\e[0m] \e[0msbt, sbt plugins, and build definitions are using Scala 2.10.6\e[0m\n' }
 
   def setup_plugin
     allow(plugin).to receive(:shell_out)
       .with("scala -version")
       .and_return(mock_shell_out(0, "", scala_out))
     allow(plugin).to receive(:shell_out)
-      .with("sbt --version", { :timeout => 5 })
+      .with("sbt about", { :timeout => 10 })
       .and_return(mock_shell_out(0, sbt_out, ""))
   end
 
@@ -56,7 +56,7 @@ describe Ohai::System, "plugin scala" do
     end
 
     it "sets languages[:scala][:sbt][:version]" do
-      expect(plugin[:languages][:scala][:sbt][:version]).to eql("0.13.8")
+      expect(plugin[:languages][:scala][:sbt][:version]).to eql("0.13.13")
     end
   end
 
@@ -80,7 +80,7 @@ describe Ohai::System, "plugin scala" do
         .and_return(mock_shell_out(0, "", scala_out))
 
       allow(plugin).to receive(:shell_out)
-        .with("sbt --version", { :timeout => 5 })
+        .with("sbt about", { :timeout => 10 })
         .and_raise( Ohai::Exceptions::Exec )
       plugin.run
     end


### PR DESCRIPTION
sbt —version isn’t a command anymore. We need to use the slower about, which also includes horrible color codes, which we have to regex around.

Signed-off-by: Tim Smith <tsmith@chef.io>