### PR TITLE
Allow ohai to load a plugin path

### DIFF
--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -70,8 +70,8 @@ module Ohai
 
     # Searches all plugin paths and returns an Array of PluginFile objects
     # representing each plugin file.
-    def plugin_files_by_dir
-      Array(Ohai.config[:plugin_path]).inject([]) do |plugin_files, plugin_path|
+    def plugin_files_by_dir(dir = Ohai.config[:plugin_path])
+      Array(dir).inject([]) do |plugin_files, plugin_path|
         plugin_files + PluginFile.find_all_in(plugin_path)
       end
     end
@@ -83,6 +83,14 @@ module Ohai
 
       collect_v6_plugins
       collect_v7_plugins
+    end
+
+    def load_additional(from)
+      plugin_files_by_dir(from).collect do |plugin_file|
+        Ohai::Log.debug "Loading additional plugin: #{plugin_file}"
+        plugin = load_plugin_class(plugin_file.path, plugin_file.plugin_root)
+        load_v7_plugin(plugin)
+      end
     end
 
     # Load a specified file as an ohai plugin and creates an instance of it.

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -112,6 +112,15 @@ module Ohai
       freeze_strings!
     end
 
+    def run_additional_plugins(plugin_path)
+      @loader.load_additional(plugin_path).each do |plugin|
+        Ohai::Log.debug "Running plugin #{plugin}"
+        @runner.run_plugin(plugin)
+      end
+
+      freeze_strings!
+    end
+
     def have_v6_plugin?(name)
       @v6_dependency_solver.values.any? { |v6plugin| v6plugin.name == name }
     end

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -95,6 +95,31 @@ EOF
     end
   end
 
+  when_plugins_directory "is an additional plugin path" do
+    with_plugin("cookbook_a/alpha.rb", <<EOF)
+Ohai.plugin(:Alpha) do
+  provides "alpha"
+end
+EOF
+
+    with_plugin("cookbook_b/beta.rb", <<EOF)
+Ohai.plugin(:Beta) do
+  provides "beta"
+end
+EOF
+
+    describe "#load_additional" do
+      it "adds the plugins to the map" do
+        loader.load_additional(@plugins_directory)
+        expect(provides_map.map.keys).to eql(%w{alpha beta})
+      end
+
+      it "returns a set of plugins" do
+        expect(loader.load_additional(@plugins_directory)).to include(Ohai::NamedPlugin::Alpha)
+      end
+    end
+  end
+
   when_plugins_directory "contains invalid plugins" do
     with_plugin("extra_s.rb", <<EOF)
 Ohai.plugins(:ExtraS) do

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -711,4 +711,49 @@ EOF
     end
   end
 
+  describe "when loading a specific plugin path" do
+    when_plugins_directory "contains v7 plugins" do
+      with_plugin("my_cookbook/languages.rb", <<-E)
+        Ohai.plugin(:Languages) do
+          provides 'languages'
+
+          collect_data do
+            languages Mash.new
+          end
+        end
+      E
+
+      with_plugin("english/english.rb", <<-E)
+        Ohai.plugin(:English) do
+          provides 'languages/english'
+
+          depends 'languages'
+
+          collect_data do
+            languages[:english] = Mash.new
+            languages[:english][:version] = 2014
+          end
+        end
+      E
+
+      with_plugin("french/french.rb", <<-E)
+        Ohai.plugin(:French) do
+          provides 'languages/french'
+
+          depends 'languages'
+
+          collect_data do
+            languages[:french] = Mash.new
+            languages[:french][:version] = 2012
+          end
+        end
+      E
+
+      it "should run all the plugins" do
+        ohai.run_additional_plugins(@plugins_directory)
+        expect(ohai.data[:languages][:english][:version]).to eq(2014)
+        expect(ohai.data[:languages][:french][:version]).to eq(2012)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is in support of RFC 59, which allows us to add an ohai cookbook
segment and load plugins automatically

cc @chef/maintainers