### PR TITLE
Require Ruby 2.3+ to match Chef itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
   - bundle --version
   - rm -f .bundle/config
 rvm:
-  - 2.2.7
   - 2.3.4
   - 2.4.1
   - ruby-head

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "22"
     - ruby_version: "23"
 
 clone_folder: c:\projects\ohai

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://docs.chef.io/ohai.html"
 
-  s.required_ruby_version = ">= 2.2.0"
+  s.required_ruby_version = ">= 2.3"
 
   s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "ffi-yajl", "~> 2.2"


### PR DESCRIPTION
2.2 just went into security only support mode. Ohai 13 would be the
opportune time to drop support.

Signed-off-by: Tim Smith <tsmith@chef.io>