### PR TITLE
Remove sbt version detect as it's not possible in the current sbt

### DIFF
--- a/lib/ohai/plugins/scala.rb
+++ b/lib/ohai/plugins/scala.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 Ohai.plugin(:Scala) do
-  provides "languages/scala", "languages/scala/sbt"
+  provides "languages/scala"
   depends "languages"
 
   collect_data(:default) do
@@ -30,18 +30,6 @@ Ohai.plugin(:Scala) do
       end
     rescue Ohai::Exceptions::Exec
       Ohai::Log.debug('Plugin Scala: Could not shell_out "scala -version". Skipping data')
-    end
-
-    # Check for sbt
-    begin
-      # sbt launcher version 0.13.7
-      so = shell_out("sbt --version", timeout: 5)
-      if so.exitstatus == 0
-        scala[:sbt] = Mash.new
-        scala[:sbt][:version] = so.stdout.split[3]
-      end
-    rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Scala: Could not shell_out "sbt --version". Skipping data')
     end
 
     languages[:scala] = scala unless scala.empty?

--- a/spec/unit/plugins/scala_spec.rb
+++ b/spec/unit/plugins/scala_spec.rb
@@ -26,15 +26,11 @@ describe Ohai::System, "plugin scala" do
   end
 
   let(:scala_out) { "Scala code runner version 2.11.6 -- Copyright 2002-2013, LAMP/EPFL" }
-  let(:sbt_out) { "sbt launcher version 0.13.8" }
 
   def setup_plugin
     allow(plugin).to receive(:shell_out)
       .with("scala -version")
       .and_return(mock_shell_out(0, "", scala_out))
-    allow(plugin).to receive(:shell_out)
-      .with("sbt --version", { :timeout => 5 })
-      .and_return(mock_shell_out(0, sbt_out, ""))
   end
 
   context "if scala is installed" do
@@ -48,45 +44,15 @@ describe Ohai::System, "plugin scala" do
     end
   end
 
-  context "if sbt is installed" do
-
-    before(:each) do
-      setup_plugin
-      plugin.run
-    end
-
-    it "sets languages[:scala][:sbt][:version]" do
-      expect(plugin[:languages][:scala][:sbt][:version]).to eql("0.13.8")
-    end
-  end
-
-  context "if scala/sbt are not installed" do
-
+  context "if scala is not installed" do
     before(:each) do
       allow(plugin).to receive(:shell_out)
         .and_raise( Ohai::Exceptions::Exec )
       plugin.run
     end
 
-    it "does NOT set the languages[:scala] if scala/sbts commands fails" do
+    it "does NOT set the languages[:scala] if scala commands fails" do
       expect(plugin[:languages]).not_to have_key(:scala)
-    end
-  end
-
-  context "if sbt is not installed" do
-    before(:each) do
-      allow(plugin).to receive(:shell_out)
-        .with("scala -version")
-        .and_return(mock_shell_out(0, "", scala_out))
-
-      allow(plugin).to receive(:shell_out)
-        .with("sbt --version", { :timeout => 5 })
-        .and_raise( Ohai::Exceptions::Exec )
-      plugin.run
-    end
-
-    it "does NOT set the languages[:scala][:sbt] if sbt command fails" do
-      expect(plugin[:languages][:scala]).not_to have_key(:sbt)
     end
   end
 end


### PR DESCRIPTION
sbt --version isn't a command anymore and sbt about tries to initialize
a project which downloads files and times out during detection.

Signed-off-by: Tim Smith <tsmith@chef.io>