### PR TITLE
Fix OpenStack plugin to use the HttpHelper mixin

### DIFF
--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -17,9 +17,11 @@
 # limitations under the License.
 
 require "ohai/mixin/ec2_metadata"
+require "ohai/mixin/http_helper"
 
 Ohai.plugin(:Openstack) do
   include Ohai::Mixin::Ec2Metadata
+  include Ohai::Mixin::HttpHelper
 
   provides "openstack"
   depends "dmi"
@@ -61,7 +63,7 @@ Ohai.plugin(:Openstack) do
       openstack[:provider] = openstack_provider
 
       # fetch the metadata if we can do a simple socket connect first
-      if can_metadata_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
+      if can_socket_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
         fetch_metadata.each do |k, v|
           openstack[k] = v
         end

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -37,7 +37,7 @@ describe Ohai::System, "plugin openstack" do
   context "when DMI data is Openstack" do
     context "and the metadata service is not available" do
       before do
-        allow(plugin).to receive(:can_metadata_connect?).
+        allow(plugin).to receive(:can_socket_connect?).
           with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80).
           and_return(false)
         plugin[:dmi] = { :system => { :all_records => [ { :Manufacturer => "OpenStack Foundation" } ] } }
@@ -57,7 +57,7 @@ describe Ohai::System, "plugin openstack" do
   context "when running on dreamhost" do
     it "sets openstack provider attribute to dreamhost" do
       plugin["etc"] = { "passwd" => { "dhc-user" => {} } }
-      allow(plugin).to receive(:can_metadata_connect?).
+      allow(plugin).to receive(:can_socket_connect?).
         with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80).
         and_return(false)
       plugin[:dmi] = { :system => { :all_records => [ { :Manufacturer => "OpenStack Foundation" } ] } }
@@ -69,7 +69,7 @@ describe Ohai::System, "plugin openstack" do
   context "when the hint is present" do
     context "and the metadata service is not available" do
       before do
-        allow(plugin).to receive(:can_metadata_connect?).
+        allow(plugin).to receive(:can_socket_connect?).
           with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80).
           and_return(false)
         allow(plugin).to receive(:hint?).with("openstack").and_return(true)
@@ -176,7 +176,7 @@ EOM
 
       before do
         allow(plugin).to receive(:hint?).with("openstack").and_return(true)
-        allow(plugin).to receive(:can_metadata_connect?).
+        allow(plugin).to receive(:can_socket_connect?).
           with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80).
           and_return(true)
 


### PR DESCRIPTION
### Description

"can_metadata_connect?" has been renamed to "can_socket_connect?" and
moved into the HttpHelper mixin. (#951)

This patch fixes OpenStack plugin to use the HttpHelper mixin.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
