### PR TITLE
Fix Eucalyptus plugin to use the HttpHelper mixin

### DIFF
--- a/lib/ohai/plugins/eucalyptus.rb
+++ b/lib/ohai/plugins/eucalyptus.rb
@@ -19,9 +19,11 @@
 
 # eucalyptus metadata service is compatible with the ec2 service calls
 require "ohai/mixin/ec2_metadata"
+require "ohai/mixin/http_helper"
 
 Ohai.plugin(:Eucalyptus) do
   include Ohai::Mixin::Ec2Metadata
+  include Ohai::Mixin::HttpHelper
 
   provides "eucalyptus"
   depends "network/interfaces"
@@ -53,7 +55,7 @@ Ohai.plugin(:Eucalyptus) do
   def looks_like_euca?
     # Try non-blocking connect so we don't "block" if
     # the metadata service doesn't respond
-    hint?("eucalyptus") || has_euca_mac? && can_metadata_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
+    hint?("eucalyptus") || has_euca_mac? && can_socket_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
   end
 
   collect_data do


### PR DESCRIPTION
### Description

"can_metadata_connect?" has been renamed to "can_socket_connect?" and
moved into the HttpHelper mixin. (#951)

See also: #986

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
