### PR TITLE
[mdadm] Fill in member devices

### DIFF
--- a/spec/unit/plugins/linux/mdadm_spec.rb
+++ b/spec/unit/plugins/linux/mdadm_spec.rb
@@ -99,6 +99,12 @@ MD
       end
     end
 
+    it "should detect member devies" do
+      @plugin.run
+      expect(@plugin[:mdadm][:md0][:members].sort).to eq(
+        %w{sdc sdd sde sdf sdg sdh}
+      )
+    end
   end
 
 end


### PR DESCRIPTION
It's useful to actually know the setup of the array.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

### Description

the mdadm plugin doesn't report member devices... but it should.

### Issues Resolved

Now it does.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
