### PR TITLE
Inject sane paths into shell_out

### DIFF
--- a/lib/ohai/mixin/command.rb
+++ b/lib/ohai/mixin/command.rb
@@ -27,8 +27,13 @@ module Ohai
       # DISCLAIMER: Logging only works in the context of a plugin!!
       # accept a command and any of the mixlib-shellout options
       def shell_out(cmd, **options)
+        options = options.dup
         # unless specified by the caller timeout after 30 seconds
         options[:timeout] ||= 30
+        unless RUBY_PLATFORM =~ /mswin|mingw32|windows/
+          options[:env] = options.key?(:env) ? options[:env].dup : {}
+          options[:env]["PATH"] ||= ((ENV["PATH"] || "").split(":") + %w{/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin}).join(":")
+        end
         so = Mixlib::ShellOut.new(cmd, options)
         begin
           so.run_command

--- a/spec/unit/mixin/command_spec.rb
+++ b/spec/unit/mixin/command_spec.rb
@@ -26,15 +26,24 @@ describe Ohai::Mixin::Command, "shell_out" do
 
   let(:plugin_name) { :OSSparkleDream }
 
+  let(:options) { windows? ? { timeout: 30 } : { timeout: 30, env: { "PATH" => "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" } } }
+
   before(:each) do
     allow(Ohai::Mixin::Command).to receive(:name).and_return(plugin_name)
+    @original_env = ENV.to_hash
+    ENV.clear
+  end
+
+  after(:each) do
+    ENV.clear
+    ENV.update(@original_env)
   end
 
   describe "when the command runs" do
     it "logs the command and exitstatus" do
       expect(Mixlib::ShellOut).
         to receive(:new).
-        with(cmd, { timeout: 30 }).
+        with(cmd, options).
         and_return(shell_out)
 
       expect(shell_out).
@@ -55,7 +64,7 @@ describe Ohai::Mixin::Command, "shell_out" do
     it "logs the command and error message" do
       expect(Mixlib::ShellOut).
         to receive(:new).
-        with(cmd, { timeout: 30 }).
+        with(cmd, options).
         and_return(shell_out)
 
       expect(shell_out).
@@ -76,7 +85,7 @@ describe Ohai::Mixin::Command, "shell_out" do
     it "logs the command an timeout error message" do
       expect(Mixlib::ShellOut).
         to receive(:new).
-        with(cmd, { timeout: 30 }).
+        with(cmd, options).
         and_return(shell_out)
 
       expect(shell_out).
@@ -94,7 +103,7 @@ describe Ohai::Mixin::Command, "shell_out" do
   end
 
   describe "when a timeout option is provided" do
-    let(:options) { { timeout: 10 } }
+    let(:options) { windows? ? { timeout: 10 } : { timeout: 10, env: { "PATH" => "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" } } }
 
     it "runs the command with the provided timeout" do
       expect(Mixlib::ShellOut).


### PR DESCRIPTION
### Description

Ohai network plugin for Linux fails to collect network related attributes
when networking commands like ip, route, ifconfig and arp are not in the $PATH.

### Issues Resolved

#990

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
