### PR TITLE
Improvements to EC2 metadata handling

### DIFF
--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -71,7 +71,10 @@ module Ohai
       end
 
       def http_client
-        Net::HTTP.start(EC2_METADATA_ADDR).tap { |h| h.read_timeout = 30 }
+        @conn ||= Net::HTTP.start(EC2_METADATA_ADDR).tap do |h|
+          h.read_timeout = 10
+          h.keep_alive_timeout = 10
+        end
       end
 
       # Get metadata for a given path and API version

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -62,7 +62,7 @@ module Ohai
         versions = response.body.split("\n").sort
         until versions.empty? || EC2_SUPPORTED_VERSIONS.include?(versions.last)
           pv = versions.pop
-          Ohai::Log.debug("ec2 metadata mixin: EC2 shows unsupported metadata version: #{pv}") unless pv == "latest"
+          Ohai::Log.debug("ec2 metadata mixin: EC2 lists metadata version: #{pv} not yet supported by Ohai") unless pv == "latest"
         end
         Ohai::Log.debug("ec2 metadata mixin: EC2 metadata version: #{versions.last}")
         if versions.empty?

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -49,6 +49,7 @@ module Ohai
 
       def best_api_version
         @api_version ||= begin
+          Ohai::Log.debug("ec2 metadata mixin: Fetching http://#{EC2_METADATA_ADDR}/ to determine the latest supported metadata release")
           response = http_client.get("/")
           if response.code == "404"
             Ohai::Log.debug("ec2 metadata mixin: Received HTTP 404 from metadata server while determining API version, assuming 'latest'")
@@ -63,7 +64,7 @@ module Ohai
             pv = versions.pop
             Ohai::Log.debug("ec2 metadata mixin: EC2 lists metadata version: #{pv} not yet supported by Ohai") unless pv == "latest"
           end
-          Ohai::Log.debug("ec2 metadata mixin: EC2 metadata version: #{versions.last}")
+          Ohai::Log.debug("ec2 metadata mixin: Latest supported EC2 metadata version: #{versions.last}")
           if versions.empty?
             raise "Unable to determine EC2 metadata version (no supported entries found)"
           end
@@ -87,6 +88,7 @@ module Ohai
       #   `nil` and continue the run instead of failing it.
       def metadata_get(id, api_version)
         path = "/#{api_version}/meta-data/#{id}"
+        Ohai::Log.debug("ec2 metadata mixin: Fetching http://#{EC2_METADATA_ADDR}#{path}")
         response = http_client.get(path)
         case response.code
         when "200"
@@ -167,6 +169,7 @@ module Ohai
       end
 
       def fetch_userdata
+        Ohai::Log.debug("ec2 metadata mixin: Fetching http://#{EC2_METADATA_ADDR}/#{best_api_version}/user-data/")
         response = http_client.get("/#{best_api_version}/user-data/")
         response.code == "200" ? response.body : nil
       end

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -58,7 +58,6 @@ module Ohai
         end
         # Note: Sorting the list of versions may have unintended consequences in
         # non-EC2 environments. It appears to be safe in EC2 as of 2013-04-12.
-        versions = response.body.split("\n")
         versions = response.body.split("\n").sort
         until versions.empty? || EC2_SUPPORTED_VERSIONS.include?(versions.last)
           pv = versions.pop

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -42,8 +42,7 @@ module Ohai
       EC2_METADATA_ADDR = "169.254.169.254" unless defined?(EC2_METADATA_ADDR)
       EC2_SUPPORTED_VERSIONS = %w{ 1.0 2007-01-19 2007-03-01 2007-08-29 2007-10-10 2007-12-15
                                    2008-02-01 2008-09-01 2009-04-04 2011-01-01 2011-05-01 2012-01-12
-                                   2014-11-05 2014-02-25 2016-04-19 2016-06-30 2016-09-02}
-
+                                   2014-02-25 2014-11-05 2015-10-20 2016-04-19 2016-06-30 2016-09-02 }
       EC2_ARRAY_VALUES = %w{security-groups}
       EC2_ARRAY_DIR    = %w{network/interfaces/macs}
       EC2_JSON_DIR     = %w{iam}

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -49,7 +49,7 @@ describe Ohai::System, "plugin ec2" do
       allow(t).to receive(:connect_nonblock).and_raise(Errno::EINPROGRESS)
       allow(Socket).to receive(:new).and_return(t)
       expect(@http_client).to receive(:get).
-        with("/").exactly(3).times.
+        with("/").
         and_return(double("Net::HTTP Response", :body => "2012-01-12", :code => "200"))
     end
 

--- a/spec/unit/plugins/eucalyptus_spec.rb
+++ b/spec/unit/plugins/eucalyptus_spec.rb
@@ -36,7 +36,7 @@ describe Ohai::System, "plugin eucalyptus" do
       allow(plugin).to receive(:http_client).and_return(@http_client)
 
       expect(@http_client).to receive(:get).
-        with("/").twice.
+        with("/").
         and_return(double("Net::HTTP Response", :body => "2012-01-12", :code => "200"))
       expect(@http_client).to receive(:get).
         with("/2012-01-12/meta-data/").

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -160,7 +160,7 @@ EOM
         }'
       end
 
-      let(:http_client) { double("Net::HTTP", :read_timeout= => nil) }
+      let(:http_client) { double("Net::HTTP", { :read_timeout= => nil, :keep_alive_timeout= => nil } ) }
 
       def allow_get(url, response_body)
         allow(http_client).to receive(:get).


### PR DESCRIPTION
There's a few changes here so far.

Better logging when we reject a version that Amazon says they support
Drop our timeouts to a more reasonable time. These APIs are crazy fast there's no need to wait 30 seconds
Only setup the http client object once and use methods that allow connection reuse
Don't parse the best API version 3 times
Add all current EC2 metadata versions