### PR TITLE
Additional backports + Release 8.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Change Log
 
-## [8.23.0](https://github.com/chef/ohai/tree/8.23.0) (2017-01-23)
+## [8.24.0](https://github.com/chef/ohai/tree/v8.24.0) (2017-05-08)
+
+[Full Changelog](https://github.com/chef/ohai/compare/v8.23.0...v8.24.0)
+
+- base: Load additional ohai plugins from /etc/chef/ohai/plugins or C:\chef\ohai\plugins\
+- ec2: Poll EC2 metadata from the new 2016 metadata API versions [#992](https://github.com/chef/ohai/pull/992) ([tas50](https://github.com/tas50))
+- mdadm: Add a new 'members' attribute for member devices in the array [#989](https://github.com/chef/ohai/pull/989) ([jaymzh](https://github.com/jaymzh))
+- dmi: Add DMI type 40,41, and 42 from the latest man page [#969](https://github.com/chef/ohai/pull/969) ([tas50](https://github.com/tas50))
+- ec2: Gather availability_zone and region data [#964](https://github.com/chef/ohai/pull/964) ([webframp](https://github.com/webframp))
+- scala: Fix scala detection when version output contains a warning [#959](https://github.com/chef/ohai/pull/959) ([tas50](https://github.com/tas50))
+- lua: Fix lua detection on new versions of lua [#958](https://github.com/chef/ohai/pull/958) ([tas50](https://github.com/tas50))
+- dmi: Rescue exception in DMI plugin to improve debug logs [#952](https://github.com/chef/ohai/pull/952) ([tas50](https://github.com/tas50))
+
+## [v8.23.0](https://github.com/chef/ohai/tree/v8.23.0) (2017-01-24)
 
 [Full Changelog](https://github.com/chef/ohai/compare/v8.22.1...v8.23.0)
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development do
   gem "sigar", :platform => "ruby"
 
-  gem "chefstyle"
+  gem "chefstyle", "0.4.0"
   gem "overcommit", ">= 0.34.1"
   gem "pry-byebug"
   gem "pry-stack_explorer"

--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -47,7 +47,7 @@ module Ohai
       end
 
       def default_plugin_path
-        [ File.expand_path(File.join(File.dirname(__FILE__), "plugins")) ]
+        [ File.expand_path(File.join(File.dirname(__FILE__), "plugins")), ChefConfig::Config.platform_specific_path("/etc/chef/ohai/plugins") ]
       end
     end
 

--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -40,7 +40,7 @@ module Ohai
       # Finds all the *.rb files under the configured paths in :plugin_path
       def self.find_all_in(plugin_dir)
         unless Dir.exist?(plugin_dir)
-          Ohai::Log.warn("The plugin path #{plugin_dir} does not exist. Skipping...")
+          Ohai::Log.info("The plugin path #{plugin_dir} does not exist. Skipping...")
           return []
         end
 

--- a/lib/ohai/version.rb
+++ b/lib/ohai/version.rb
@@ -18,5 +18,5 @@
 
 module Ohai
   OHAI_ROOT = File.expand_path(File.dirname(__FILE__))
-  VERSION = "8.23.0"
+  VERSION = "8.24.0"
 end

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -222,7 +222,7 @@ EOF
 
       describe "when plugin directory does not exist" do
         it "logs an invalid plugin path warning" do
-          expect(Ohai::Log).to receive(:warn).with(/The plugin path.*does not exist/)
+          expect(Ohai::Log).to receive(:info).with(/The plugin path.*does not exist/)
           allow(Dir).to receive(:exist?).with("/bogus/dir").and_return(false)
           Ohai::Loader::PluginFile.find_all_in("/bogus/dir")
         end

--- a/spec/unit/plugins/linux/mdadm_spec.rb
+++ b/spec/unit/plugins/linux/mdadm_spec.rb
@@ -99,6 +99,12 @@ MD
       end
     end
 
+    it "should detect member devies" do
+      @plugin.run
+      expect(@plugin[:mdadm][:md0][:members].sort).to eq(
+        %w{sdc sdd sde sdf sdg sdh}
+      )
+    end
   end
 
 end


### PR DESCRIPTION
This hand backports chefstyle and the plugin path changes and includes a nice artisanal changelog since the generator falls over in a stable branch sort of situation