### PR TITLE
Update zpools plugin to work on Linux/BSD

### DIFF
--- a/lib/ohai/plugins/zpools.rb
+++ b/lib/ohai/plugins/zpools.rb
@@ -47,7 +47,7 @@ Ohai.plugin(:Zpools) do
     pools
   end
 
-  collect_data(:solaris2, :linux) do
+  collect_data(:solaris2, :linux, :freebsd, :openbsd, :netbsd, :dragonflybsd) do
     pools = gather_pool_info
 
     # Grab individual health for devices in the zpools
@@ -68,7 +68,8 @@ Ohai.plugin(:Zpools) do
         case line
         # linux: http://rubular.com/r/J3wQC6E2lH
         # solaris: http://rubular.com/r/FqOBzUQQ4p
-        when /^\s+((sd|c)[-_a-zA-Z0-9]+)\s+([-_a-zA-Z0-9]+)\s+(\d+)\s+(\d+)\s+(\d+)$/
+        # freebsd: http://rubular.com/r/RYkMNlytXl
+        when /^\s+((sd|c|ad|da)[-_a-zA-Z0-9]+)\s+([-_a-zA-Z0-9]+)\s+(\d+)\s+(\d+)\s+(\d+)$/
           Ohai::Log.debug("Plugin Zpools: Parsing zpool status line: #{line.chomp}")
           pools[pool][:devices][$1] = Mash.new
           pools[pool][:devices][$1][:state] = $3

--- a/spec/unit/plugins/zpools_spec.rb
+++ b/spec/unit/plugins/zpools_spec.rb
@@ -13,12 +13,14 @@
 # limitations under the License.
 #
 
-require_relative "../../../spec_helper.rb"
+require_relative "../../spec_helper.rb"
 
-describe Ohai::System, "Solaris 2.x zpool plugin" do
+describe Ohai::System, "zpools plugin" do
+  let(:plugin) { get_plugin("zpools") }
+
   before(:each) do
-    @plugin = get_plugin("solaris2/zpools")
-    allow(@plugin).to receive(:collect_os).and_return(:solaris2)
+    allow(plugin).to receive(:platform_family).and_return('solaris2')
+    allow(plugin).to receive(:collect_os).and_return(:solaris2)
 
     @zpool_status_rpool = <<-EOSR
 pool: rpool
@@ -62,58 +64,58 @@ EOST
 rpool   109G    66.2G   42.8G   60%     1.00x   ONLINE  34
 tank    130T    4.91M   130T    0%      1.00x   ONLINE  34
 EOZO
-    allow(@plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, @zpool_out, ""))
-    allow(@plugin).to receive(:shell_out).with("su adm -c \"zpool status rpool\"").and_return(mock_shell_out(0, @zpool_status_rpool, ""))
-    allow(@plugin).to receive(:shell_out).with("su adm -c \"zpool status tank\"").and_return(mock_shell_out(0, @zpool_status_tank, ""))
+    allow(plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, @zpool_out, ""))
+    allow(plugin).to receive(:shell_out).with("su adm -c \"zpool status rpool\"").and_return(mock_shell_out(0, @zpool_status_rpool, ""))
+    allow(plugin).to receive(:shell_out).with("su adm -c \"zpool status tank\"").and_return(mock_shell_out(0, @zpool_status_tank, ""))
   end
 
   describe "On Solaris2 Common" do
     it "Should have entries for both zpools" do
-      @plugin.run
-      expect(@plugin[:zpools][:rpool]).to be
-      expect(@plugin[:zpools][:tank]).to be
+      plugin.run
+      expect(plugin[:zpools][:rpool]).to be
+      expect(plugin[:zpools][:tank]).to be
     end
 
     it "Should have the correct pool size" do
-      @plugin.run
-      expect(@plugin[:zpools][:rpool][:pool_size]).to match("109G")
-      expect(@plugin[:zpools][:tank][:pool_size]).to match("130T")
+      plugin.run
+      expect(plugin[:zpools][:rpool][:pool_size]).to match("109G")
+      expect(plugin[:zpools][:tank][:pool_size]).to match("130T")
     end
 
     it "Should have the correct pool allocated size" do
-      @plugin.run
-      expect(@plugin[:zpools][:rpool][:pool_allocated]).to match("66.2G")
-      expect(@plugin[:zpools][:tank][:pool_allocated]).to match("4.91M")
+      plugin.run
+      expect(plugin[:zpools][:rpool][:pool_allocated]).to match("66.2G")
+      expect(plugin[:zpools][:tank][:pool_allocated]).to match("4.91M")
     end
 
     it "Should have the correct pool free size" do
-      @plugin.run
-      expect(@plugin[:zpools][:rpool][:pool_free]).to match("42.8G")
-      expect(@plugin[:zpools][:tank][:pool_free]).to match("130T")
+      plugin.run
+      expect(plugin[:zpools][:rpool][:pool_free]).to match("42.8G")
+      expect(plugin[:zpools][:tank][:pool_free]).to match("130T")
     end
 
     it "Should have the correct capacity_used" do
-      @plugin.run
-      expect(@plugin[:zpools][:rpool][:capacity_used]).to match("60%")
-      expect(@plugin[:zpools][:tank][:capacity_used]).to match("0%")
+      plugin.run
+      expect(plugin[:zpools][:rpool][:capacity_used]).to match("60%")
+      expect(plugin[:zpools][:tank][:capacity_used]).to match("0%")
     end
 
     it "Should have the correct dedup_factor" do
-      @plugin.run
-      expect(@plugin[:zpools][:rpool][:dedup_factor]).to match("1.00x")
-      expect(@plugin[:zpools][:tank][:dedup_factor]).to match("1.00x")
+      plugin.run
+      expect(plugin[:zpools][:rpool][:dedup_factor]).to match("1.00x")
+      expect(plugin[:zpools][:tank][:dedup_factor]).to match("1.00x")
     end
 
     it "Should have the correct health" do
-      @plugin.run
-      expect(@plugin[:zpools][:rpool][:health]).to match("ONLINE")
-      expect(@plugin[:zpools][:tank][:health]).to match("ONLINE")
+      plugin.run
+      expect(plugin[:zpools][:rpool][:health]).to match("ONLINE")
+      expect(plugin[:zpools][:tank][:health]).to match("ONLINE")
     end
 
     it "Should have the correct number of devices" do
-      @plugin.run
-      expect(@plugin[:zpools][:rpool][:devices].keys.size).to match(2)
-      expect(@plugin[:zpools][:tank][:devices].keys.size).to match(12)
+      plugin.run
+      expect(plugin[:zpools][:rpool][:devices].keys.size).to match(2)
+      expect(plugin[:zpools][:tank][:devices].keys.size).to match(12)
     end
   end
 
@@ -123,13 +125,13 @@ EOZO
 rpool   109G    66.2G   42.8G   60%     1.00x   ONLINE  -
 tank    130T    4.91M   130T    0%      1.00x   ONLINE  -
 EOZO
-      allow(@plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, @zpool_out, ""))
+      allow(plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, @zpool_out, ""))
     end
 
     it "Won't have a version number" do
-      @plugin.run
-      expect(@plugin[:zpools][:rpool][:zpool_version]).to match("-")
-      expect(@plugin[:zpools][:tank][:zpool_version]).to match("-")
+      plugin.run
+      expect(plugin[:zpools][:rpool][:zpool_version]).to be_nil
+      expect(plugin[:zpools][:tank][:zpool_version]).to be_nil
     end
 
   end
@@ -140,13 +142,13 @@ EOZO
 rpool   109G    66.2G   42.8G   60%     1.00x   ONLINE  34
 tank    130T    4.91M   130T    0%      1.00x   ONLINE  34
 EOZO
-      allow(@plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, @zpool_out, ""))
+      allow(plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, @zpool_out, ""))
     end
 
     it "Should have a version number" do
-      @plugin.run
-      expect(@plugin[:zpools][:rpool][:zpool_version]).to match("34")
-      expect(@plugin[:zpools][:tank][:zpool_version]).to match("34")
+      plugin.run
+      expect(plugin[:zpools][:rpool][:zpool_version]).to match("34")
+      expect(plugin[:zpools][:tank][:zpool_version]).to match("34")
     end
 
   end

--- a/spec/unit/plugins/zpools_spec.rb
+++ b/spec/unit/plugins/zpools_spec.rb
@@ -18,26 +18,120 @@ require_relative "../../spec_helper.rb"
 describe Ohai::System, "zpools plugin" do
   let(:plugin) { get_plugin("zpools") }
 
-  before(:each) do
-    allow(plugin).to receive(:platform_family).and_return('solaris2')
-    allow(plugin).to receive(:collect_os).and_return(:solaris2)
+  context "on Linux" do
+    let(:zpool_status_tank) do
+      <<-EOST
+  pool: tank
+  state: ONLINE
+  scan: scrub repaired 0 in 0h0m with 0 errors on Fri Jun  6 14:43:40 2014
+  config:
 
-    @zpool_status_rpool = <<-EOSR
-pool: rpool
-state: ONLINE
-scan: resilvered 65.6G in 0h8m with 0 errors on Fri Jun  6 14:22:40 2014
-config:
+    NAME                       STATE     READ WRITE CKSUM
+    tank                       ONLINE       0     0     0
+      raidz2-0                 ONLINE       0     0     0
+        sdc                    ONLINE       0     0     0
+        sdd                    ONLINE       0     0     0
+        sde                    ONLINE       0     0     0
+        sdf                    ONLINE       0     0     0
+        sdg                    ONLINE       0     0     0
+        sdh                    ONLINE       0     0     0
+      raidz2-1                 ONLINE       0     0     0
+        sdi                    ONLINE       0     0     0
+        sdj                    ONLINE       0     0     0
+        sdk                    ONLINE       0     0     0
+        sdl                    ONLINE       0     0     0
+        sdm                    ONLINE       0     0     0
+        sdn                    ONLINE       0     0     0
+EOST
+    end
+    let(:zpool_out) do
+      <<-EOZO
+rpool	109G	66.2G	42.8G	60%	1.00x	ONLINE	-
+tank	130T	4.91M	130T	0%	1.00x	ONLINE	-
+EOZO
+    end
+    let(:zpool_status_rpool) do
+      <<-EOSR
+  pool: rpool
+  state: ONLINE
+  scan: none requested
+  config:
 
-      NAME          STATE     READ WRITE CKSUM
-      rpool         ONLINE       0     0     0
-        mirror-0    ONLINE       0     0     0
-          c3t5d0s0  ONLINE       0     0     0
-          c3t4d0s0  ONLINE       0     0     0
+    NAME          STATE     READ WRITE CKSUM
+    rpool         ONLINE       0     0     0
+      mirror-0    ONLINE       0     0     0
+        sda       ONLINE       0     0     0
+        sdb       ONLINE       0     0     0
 
-errors: No known data errors
+  errors: No known data errors
 EOSR
+    end
+    before do
+      allow(plugin).to receive(:platform_family).and_return("rhel")
+      allow(plugin).to receive(:collect_os).and_return(:linux)
+      allow(plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, zpool_out, ""))
+      allow(plugin).to receive(:shell_out).with("zpool status rpool").and_return(mock_shell_out(0, zpool_status_rpool, ""))
+      allow(plugin).to receive(:shell_out).with("zpool status tank").and_return(mock_shell_out(0, zpool_status_tank, ""))
+    end
 
-    @zpool_status_tank = <<-EOST
+    it "Has entries for both zpools" do
+      plugin.run
+      expect(plugin[:zpools][:rpool]).to be
+      expect(plugin[:zpools][:tank]).to be
+    end
+
+    it "Has the correct pool size" do
+      plugin.run
+      expect(plugin[:zpools][:rpool][:pool_size]).to match("109G")
+      expect(plugin[:zpools][:tank][:pool_size]).to match("130T")
+    end
+
+    it "Has the correct pool allocated size" do
+      plugin.run
+      expect(plugin[:zpools][:rpool][:pool_allocated]).to match("66.2G")
+      expect(plugin[:zpools][:tank][:pool_allocated]).to match("4.91M")
+    end
+
+    it "Has the correct pool free size" do
+      plugin.run
+      expect(plugin[:zpools][:rpool][:pool_free]).to match("42.8G")
+      expect(plugin[:zpools][:tank][:pool_free]).to match("130T")
+    end
+
+    it "Has the correct capacity_used" do
+      plugin.run
+      expect(plugin[:zpools][:rpool][:capacity_used]).to match("60%")
+      expect(plugin[:zpools][:tank][:capacity_used]).to match("0%")
+    end
+
+    it "Has the correct dedup_factor" do
+      plugin.run
+      expect(plugin[:zpools][:rpool][:dedup_factor]).to match("1.00x")
+      expect(plugin[:zpools][:tank][:dedup_factor]).to match("1.00x")
+    end
+
+    it "Has the correct health" do
+      plugin.run
+      expect(plugin[:zpools][:rpool][:health]).to match("ONLINE")
+      expect(plugin[:zpools][:tank][:health]).to match("ONLINE")
+    end
+
+    it "Has the correct number of devices" do
+      plugin.run
+      expect(plugin[:zpools][:rpool][:devices].keys.size).to match(2)
+      expect(plugin[:zpools][:tank][:devices].keys.size).to match(12)
+    end
+
+    it "Won't have a version number" do
+      plugin.run
+      expect(plugin[:zpools][:rpool][:zpool_version]).to be_nil
+      expect(plugin[:zpools][:tank][:zpool_version]).to be_nil
+    end
+  end
+
+  context "on Solaris2" do
+    let(:zpool_status_tank) do
+      <<-EOST
 pool: tank
 state: ONLINE
 scan: scrub repaired 0 in 0h0m with 0 errors on Fri Jun  6 14:43:40 2014
@@ -60,96 +154,89 @@ config:
           c1t50014EE25F698BECd0  ONLINE       0     0     0
           c1t50014EE25F6998DAd0  ONLINE       0     0     0
 EOST
-    @zpool_out = <<-EOZO
+    end
+    let(:zpool_out) do
+      <<-EOZO
 rpool   109G    66.2G   42.8G   60%     1.00x   ONLINE  34
 tank    130T    4.91M   130T    0%      1.00x   ONLINE  34
 EOZO
-    allow(plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, @zpool_out, ""))
-    allow(plugin).to receive(:shell_out).with("su adm -c \"zpool status rpool\"").and_return(mock_shell_out(0, @zpool_status_rpool, ""))
-    allow(plugin).to receive(:shell_out).with("su adm -c \"zpool status tank\"").and_return(mock_shell_out(0, @zpool_status_tank, ""))
-  end
+    end
+    let(:zpool_status_rpool) do
+      <<-EOSR
+pool: rpool
+state: ONLINE
+scan: resilvered 65.6G in 0h8m with 0 errors on Fri Jun  6 14:22:40 2014
+config:
 
-  describe "On Solaris2 Common" do
-    it "Should have entries for both zpools" do
+      NAME          STATE     READ WRITE CKSUM
+      rpool         ONLINE       0     0     0
+        mirror-0    ONLINE       0     0     0
+          c3t5d0s0  ONLINE       0     0     0
+          c3t4d0s0  ONLINE       0     0     0
+
+errors: No known data errors
+EOSR
+    end
+    before do
+      allow(plugin).to receive(:platform_family).and_return("solaris2")
+      allow(plugin).to receive(:collect_os).and_return(:solaris2)
+      allow(plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, zpool_out, ""))
+      allow(plugin).to receive(:shell_out).with("su adm -c \"zpool status rpool\"").and_return(mock_shell_out(0, zpool_status_rpool, ""))
+      allow(plugin).to receive(:shell_out).with("su adm -c \"zpool status tank\"").and_return(mock_shell_out(0, zpool_status_tank, ""))
+    end
+
+    it "Has entries for both zpools" do
       plugin.run
       expect(plugin[:zpools][:rpool]).to be
       expect(plugin[:zpools][:tank]).to be
     end
 
-    it "Should have the correct pool size" do
+    it "Has the correct pool size" do
       plugin.run
       expect(plugin[:zpools][:rpool][:pool_size]).to match("109G")
       expect(plugin[:zpools][:tank][:pool_size]).to match("130T")
     end
 
-    it "Should have the correct pool allocated size" do
+    it "Has the correct pool allocated size" do
       plugin.run
       expect(plugin[:zpools][:rpool][:pool_allocated]).to match("66.2G")
       expect(plugin[:zpools][:tank][:pool_allocated]).to match("4.91M")
     end
 
-    it "Should have the correct pool free size" do
+    it "Has the correct pool free size" do
       plugin.run
       expect(plugin[:zpools][:rpool][:pool_free]).to match("42.8G")
       expect(plugin[:zpools][:tank][:pool_free]).to match("130T")
     end
 
-    it "Should have the correct capacity_used" do
+    it "Has the correct capacity_used" do
       plugin.run
       expect(plugin[:zpools][:rpool][:capacity_used]).to match("60%")
       expect(plugin[:zpools][:tank][:capacity_used]).to match("0%")
     end
 
-    it "Should have the correct dedup_factor" do
+    it "Has the correct dedup_factor" do
       plugin.run
       expect(plugin[:zpools][:rpool][:dedup_factor]).to match("1.00x")
       expect(plugin[:zpools][:tank][:dedup_factor]).to match("1.00x")
     end
 
-    it "Should have the correct health" do
+    it "Has the correct health" do
       plugin.run
       expect(plugin[:zpools][:rpool][:health]).to match("ONLINE")
       expect(plugin[:zpools][:tank][:health]).to match("ONLINE")
     end
 
-    it "Should have the correct number of devices" do
+    it "Has the correct number of devices" do
       plugin.run
       expect(plugin[:zpools][:rpool][:devices].keys.size).to match(2)
       expect(plugin[:zpools][:tank][:devices].keys.size).to match(12)
     end
-  end
 
-  describe "On OmniOS_151006" do
-    before(:each) do
-      @zpool_out = <<-EOZO
-rpool   109G    66.2G   42.8G   60%     1.00x   ONLINE  -
-tank    130T    4.91M   130T    0%      1.00x   ONLINE  -
-EOZO
-      allow(plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, @zpool_out, ""))
-    end
-
-    it "Won't have a version number" do
-      plugin.run
-      expect(plugin[:zpools][:rpool][:zpool_version]).to be_nil
-      expect(plugin[:zpools][:tank][:zpool_version]).to be_nil
-    end
-
-  end
-
-  describe "On Solaris_11.1" do
-    before(:each) do
-      @zpool_out = <<-EOZO
-rpool   109G    66.2G   42.8G   60%     1.00x   ONLINE  34
-tank    130T    4.91M   130T    0%      1.00x   ONLINE  34
-EOZO
-      allow(plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, @zpool_out, ""))
-    end
-
-    it "Should have a version number" do
+    it "Has a version number" do
       plugin.run
       expect(plugin[:zpools][:rpool][:zpool_version]).to match("34")
       expect(plugin[:zpools][:tank][:zpool_version]).to match("34")
     end
-
   end
 end


### PR DESCRIPTION
This plugin works on Linux/BSD for the most part. Let's do the extra work to get there.

Caveats:

The regex is still less than ideal here. Since zpool status for a zpool lists the zlevel and the volume itself along with the drives it's a bit tricky to extract just the drive information. We're relying on the starting characters to identify drives. So we're saying a line that starts with C is a drive on solaris, SD on Linux, and DA/AD on BSD. What happens if my volume is called "crap"? Well that would show up as a drive. That bug has always existed and this doesn't change that. We can use -P on Linux to get the full path which fixes this for Linux, but that doesn't exist on Solaris/BSD (of course).