### PR TITLE
clean up and prune dev gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.sw?
 Gemfile.lock
+Gemfile.local
 pkg/
 tmp/
 coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,4 @@ instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
 
 # If you want to load debugging tools into the bundle exec sandbox,
 # add these additional dependencies into chef/Gemfile.local
-eval(IO.read(__FILE__ + ".local"), binding) if File.exist?(__FILE__ + ".local")
+eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")

--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,5 @@ end
 instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
 
 # If you want to load debugging tools into the bundle exec sandbox,
-# add these additional dependencies into chef/Gemfile.local
+# add these additional dependencies into Gemfile.local
 eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")

--- a/Gemfile
+++ b/Gemfile
@@ -4,16 +4,24 @@ gemspec
 
 group :development do
   gem "chefstyle"
-  gem "overcommit", ">= 0.34.1"
-  gem "pry-byebug"
-  gem "pry-stack_explorer"
-  gem "rb-readline"
-  gem "rake", ">= 10.1.0", "< 12.0.0"
+  gem "rake", ">= 10.1.0"
   gem "rspec-core", "~> 3.0"
   gem "rspec-expectations", "~> 3.0"
   gem "rspec-mocks", "~> 3.0"
   gem "rspec-collection_matchers", "~> 1.0"
-  gem "rspec_junit_formatter"
-  gem "github_changelog_generator", git: "https://github.com/chef/github-changelog-generator"
   gem "ipaddr_extensions"
 end
+
+group :ci do
+  gem "rspec_junit_formatter"
+end
+
+group :changelog do
+  gem "github_changelog_generator", git: "https://github.com/chef/github-changelog-generator"
+end
+
+instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
+
+# If you want to load debugging tools into the bundle exec sandbox,
+# add these additional dependencies into chef/Gemfile.local
+eval(IO.read(__FILE__ + ".local"), binding) if File.exist?(__FILE__ + ".local")

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+# NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
   gem "chefstyle"
   gem "rake", ">= 10.1.0"


### PR DESCRIPTION
people that want pry need to explicitly include it in their own Gemfile.local now.

also creates groups so that we can exclude gems that we don't necessarily need to test