### PR TITLE
Add clearos platform to RHEL platform_family

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -107,7 +107,7 @@ Ohai.plugin(:Platform) do
     case platform
     when /debian/, /ubuntu/, /linuxmint/, /raspbian/, /cumulus/
       "debian"
-    when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /xenserver/, /cloudlinux/, /ibm_powerkvm/, /parallels/, /nexus_centos/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
+    when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /xenserver/, /cloudlinux/, /ibm_powerkvm/, /parallels/, /nexus_centos/, /clearos/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
       "rhel"
     when /amazon/
       "amazon"

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -429,6 +429,14 @@ OS_RELEASE
         expect(@plugin[:platform_version].to_i).to eq(13)
       end
 
+      it "should read the platform as clearos and version as 7.3" do
+        expect(File).to receive(:read).with("/etc/redhat-release").and_return("ClearOS release 7.3.0 (Final)")
+        @plugin.run
+        expect(@plugin[:platform]).to eq("clearos")
+        expect(@plugin[:platform_family]).to eq("rhel")
+        expect(@plugin[:platform_version].to_f).to eq(7.3)
+      end
+
       # https://github.com/chef/ohai/issues/560
       # Issue is seen on EL7, so that's what we're testing.
       context "on versions that have /etc/os-release" do


### PR DESCRIPTION


### Description

as of 6.1.0 clearos is RHEL family-ish. 

### Issues Resolved

https://github.com/chef-cookbooks/chef-client/issues/494

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
