### PR TITLE
Only shellout to sw_vers in darwin hardware once

### DIFF
--- a/lib/ohai/plugins/darwin/hardware.rb
+++ b/lib/ohai/plugins/darwin/hardware.rb
@@ -46,15 +46,21 @@ Ohai.plugin(:Hardware) do
     hw_hash[0]["_items"][0].delete("_name")
     hardware.merge!(hw_hash[0]["_items"][0])
 
-    {
-      "operating_system" => "sw_vers -productName",
-      "operating_system_version" => "sw_vers -productVersion",
-      "build_version" => "sw_vers -buildVersion",
-      "architecture" => "uname -m",
-    }.each do |var, cmd|
-      os_info = shell_out(cmd).stdout
-      hardware[var] = os_info.strip unless os_info.nil?
+    # ProductName:	Mac OS X
+    # ProductVersion:	10.12.5
+    # BuildVersion:	16F73
+    shell_out("sw_vers").stdout.lines.each do |line|
+      case line
+      when /^ProductName:\s*(.*)$/
+        hardware["operating_system"] = Regexp.last_match[1].strip
+      when /^ProductVersion:\s*(.*)$/
+        hardware["operating_system_version"] = Regexp.last_match[1].strip
+      when /^BuildVersion:\s*(.*)$/
+        hardware["build_version"] = Regexp.last_match[1].strip
+      end
     end
+
+    hardware["architecture"] = shell_out("uname -m").stdout.strip
 
     # Storage queries
     storage = []

--- a/spec/unit/plugins/darwin/hardware_spec.rb
+++ b/spec/unit/plugins/darwin/hardware_spec.rb
@@ -31,21 +31,9 @@ describe Ohai::System, "Darwin hardware plugin", :unix_only do
     )
 
     allow(plugin).to receive(:shell_out).with(
-      "sw_vers -productName"
+      "sw_vers"
     ).and_return(
-      mock_shell_out(0, "Mac OS X", "")
-    )
-
-    allow(plugin).to receive(:shell_out).with(
-      "sw_vers -productVersion"
-    ).and_return(
-      mock_shell_out(0, "10.12", "")
-    )
-
-    allow(plugin).to receive(:shell_out).with(
-      "sw_vers -buildVersion"
-    ).and_return(
-      mock_shell_out(0, "16A239j", "")
+      mock_shell_out(0, "ProductName:	Mac OS X\nProductVersion:	10.12\nBuildVersion:	16A239j", "")
     )
 
     allow(plugin).to receive(:shell_out).with(


### PR DESCRIPTION
Avoid 2 extra shell_outs by just parsing the fields. This makes the plugin 6% faster

Signed-off-by: Tim Smith <tsmith@chef.io>