### PR TITLE
cpu: add support for arm64 cpuinfo fields

### DIFF
--- a/lib/ohai/plugins/linux/cpu.rb
+++ b/lib/ohai/plugins/linux/cpu.rb
@@ -59,6 +59,10 @@ Ohai.plugin(:CPU) do
         cpuinfo[current_cpu]["cache_size"] = $1
       when /flags\s+:\s(.+)/
         cpuinfo[current_cpu]["flags"] = $1.split(" ")
+      when /BogoMIPS\s+:\s(.+)/
+        cpuinfo[current_cpu]["bogomips"] = $1
+      when /Features\s+:\s(.+)/
+        cpuinfo[current_cpu]["features"] = $1.split(" ")
       when /bogomips per cpu:\s(.+)/
         cpuinfo["bogomips_per_cpu"] = $1
       when /features\s+:\s(.+)/


### PR DESCRIPTION
Signed-off-by: Davide Cavalca <dcavalca@fb.com>

### Description

On arm64 the format of `/proc/cpuinfo` is different. This change adds basic support to expose `features` and `bogomips`, which are the most useful fields. Note that these fields are per-processor, while on S390 they're only set once, so we can't really reuse that logic.

### Issues Resolved

None that I could find, though I can file one if needed

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
