### PR TITLE
fix mdadm plugin when arrays are in interesting states.

### DIFF
--- a/lib/ohai/plugins/linux/mdadm.rb
+++ b/lib/ohai/plugins/linux/mdadm.rb
@@ -59,7 +59,12 @@ Ohai.plugin(:Mdadm) do
         if line =~ /(md[0-9]+)/
           device = Regexp.last_match[1]
           pieces = line.split(/\s+/)
-          devices[device] = pieces[4..-1].map { |s| s.match(/(.+)\[\d\]/)[1] }
+          # there are variable numbers of fields until you hit the raid level
+          # everything after that is members
+          members = pieces.drop_while { |x| !x.start_with?("raid") }
+          # drop the 'raid' too
+          members.shift unless members.empty?
+          devices[device] = members.map { |s| s.match(/(.+)\[\d\]/)[1] }
         end
       end
 

--- a/spec/unit/plugins/linux/mdadm_spec.rb
+++ b/spec/unit/plugins/linux/mdadm_spec.rb
@@ -99,7 +99,21 @@ MD
       end
     end
 
-    it "should detect member devies" do
+    it "should detect member devices" do
+      @plugin.run
+      expect(@plugin[:mdadm][:md0][:members].sort).to eq(
+        %w{sdc sdd sde sdf sdg sdh}
+      )
+    end
+
+    it "should detect member devices even if mdstat has extra entries" do
+      new_mdstat = double("/proc/mdstat2")
+      allow(new_mdstat).to receive(:each).
+        and_yield("Personalities : [raid1] [raid6] [raid5] [raid4] [linear] [multipath] [raid0] [raid10]").
+        and_yield("md0 : active (somecraphere) <morestuff> raid10 sdh[5] sdg[4] sdf[3] sde[2] sdd[1] sdc[0]").
+        and_yield("      2929893888 blocks super 1.2 256K chunks 2 near-copies [6/6] [UUUUUU]")
+      allow(File).to receive(:open).with("/proc/mdstat").and_return(new_mdstat)
+
       @plugin.run
       expect(@plugin[:mdadm][:md0][:members].sort).to eq(
         %w{sdc sdd sde sdf sdg sdh}


### PR DESCRIPTION
### Description

Read-only and other things can change the output. Be more careful.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

### Issues Resolved

The plugin used to crash in a variety of cases and it now does not.

### Check List

- [X ] New functionality includes tests
- [ X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
