### PR TITLE
fix AIX rpm data

### DIFF
--- a/lib/ohai/plugins/packages.rb
+++ b/lib/ohai/plugins/packages.rb
@@ -94,8 +94,14 @@ Ohai.plugin(:Packages) do
     # Package Name:Fileset:Level
     # On aix, filesets are packages and levels are versions
     pkgs.each do |pkg|
-      _, name, version = pkg.split(":")
-      packages[name] = { "version" => version }
+      name, fileset, version, _, _, _, pkg_type = pkg.split(":")
+      if pkg_type == 'R'
+        # RPM
+        packages[name] = { "version" => version }
+      else
+        # LPP
+        packages[fileset] = { "version" => version }
+      end
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Mike Sgarbossa michael.sgarbossa@cvshealth.com

### Description

Uses package type field from lslpp command to determine the correct field to use for the package name.  The 1st field needs to be used for RPM packages listed with lslpp -Lqc.

### Issues Resolved
#1015
