### PR TITLE
Bump up to chefstyle 0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development do
   gem "sigar", :platform => "ruby"
 
-  gem "chefstyle", "0.4.0"
+  gem "chefstyle", "0.5.0"
   gem "overcommit", ">= 0.34.1"
   gem "pry-byebug"
   gem "pry-stack_explorer"
@@ -16,6 +16,6 @@ group :development do
   gem "rspec-mocks", "~> 3.0"
   gem "rspec-collection_matchers", "~> 1.0"
   gem "rspec_junit_formatter"
-  gem "github_changelog_generator", git: "https://github.com/tduffield/github-changelog-generator", branch: "adjust-tag-section-mapping"
+  gem "github_changelog_generator", git: "https://github.com/chef/github-changelog-generator"
   gem "activesupport", "< 5.0" if RUBY_VERSION <= "2.2.2" # github_changelog_generator dep
 end

--- a/lib/ohai/common/dmi.rb
+++ b/lib/ohai/common/dmi.rb
@@ -118,7 +118,7 @@ module Ohai
             end
           end
           in_common.each do |field, value|
-            next if value == nil
+            next if value.nil?
             dmi[type][field] = value.strip
           end
         end

--- a/lib/ohai/plugins/darwin/platform.rb
+++ b/lib/ohai/plugins/darwin/platform.rb
@@ -20,7 +20,7 @@ Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_build", "platform_family"
 
   collect_data(:darwin) do
-    so = shell_out("#{ Ohai.abs_path( "/usr/bin/sw_vers" )}")
+    so = shell_out("#{Ohai.abs_path( "/usr/bin/sw_vers" )}")
     so.stdout.lines do |line|
       case line
       when /^ProductName:\s+(.+)$/

--- a/lib/ohai/plugins/dmi.rb
+++ b/lib/ohai/plugins/dmi.rb
@@ -91,14 +91,14 @@ Ohai.plugin(:DMI) do
         field = nil
 
       elsif type = type_line.match(line)
-        if dmi_record == nil
+        if dmi_record.nil?
           Ohai::Log.debug("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
           next
         end
         dmi[dmi_record[:type]][:all_records][dmi_record[:position]][:application_identifier] = type[1]
 
       elsif data = data_line.match(line)
-        if dmi_record == nil
+        if dmi_record.nil?
           Ohai::Log.debug("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
           next
         end
@@ -106,11 +106,11 @@ Ohai.plugin(:DMI) do
         field = data[1]
 
       elsif extended_data = extended_data_line.match(line)
-        if dmi_record == nil
+        if dmi_record.nil?
           Ohai::Log.debug("Plugin DMI: unexpected extended data line found before header; discarding:\n#{line}")
           next
         end
-        if field == nil
+        if field.nil?
           Ohai::Log.debug("Plugin DMI: unexpected extended data line found outside data section; discarding:\n#{line}")
           next
         end

--- a/lib/ohai/plugins/dragonflybsd/network.rb
+++ b/lib/ohai/plugins/dragonflybsd/network.rb
@@ -39,7 +39,7 @@ Ohai.plugin(:Network) do
     end
 
     iface = Mash.new
-    so = shell_out("#{ Ohai.abs_path( "/sbin/ifconfig" )} -a")
+    so = shell_out("#{Ohai.abs_path( "/sbin/ifconfig" )} -a")
     cint = nil
     so.stdout.lines do |line|
       if line =~ /^([0-9a-zA-Z\.]+):\s+/

--- a/lib/ohai/plugins/freebsd/network.rb
+++ b/lib/ohai/plugins/freebsd/network.rb
@@ -39,7 +39,7 @@ Ohai.plugin(:Network) do
     end
 
     iface = Mash.new
-    so = shell_out("#{ Ohai.abs_path( "/sbin/ifconfig" )} -a")
+    so = shell_out("#{Ohai.abs_path( "/sbin/ifconfig" )} -a")
     cint = nil
     so.stdout.lines do |line|
       if line =~ /^([0-9a-zA-Z\.]+):\s+/

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -141,9 +141,11 @@ Ohai.plugin(:Network) do
   # using a temporary var to hold routes and their interface name
   def parse_routes(family, iface)
     iface.collect do |i, iv|
-      iv[:routes].collect do |r|
-        r.merge(:dev => i) if r[:family] == family[:name]
-      end.compact if iv[:routes]
+      if iv[:routes]
+        iv[:routes].collect do |r|
+          r.merge(:dev => i) if r[:family] == family[:name]
+        end.compact
+      end
     end.compact.flatten
   end
 
@@ -380,7 +382,7 @@ Ohai.plugin(:Network) do
   end
 
   def interface_address_not_link_level?(iface, address)
-    !iface[:addresses][address][:scope].casecmp("link").zero?
+    !(iface[:addresses][address][:scope].casecmp("link") == 0)
   end
 
   def interface_valid_for_route?(iface, address, family)
@@ -478,12 +480,14 @@ Ohai.plugin(:Network) do
                     :neighbour_attribute => :arp,
                   }]
 
-      families << {
-                    :name => "inet6",
-                    :default_route => "::/0",
-                    :default_prefix => :default_inet6,
-                    :neighbour_attribute => :neighbour_inet6,
-                  } if ipv6_enabled?
+      if ipv6_enabled?
+        families << {
+                      :name => "inet6",
+                      :default_route => "::/0",
+                      :default_prefix => :default_inet6,
+                      :neighbour_attribute => :neighbour_inet6,
+                    }
+      end
 
       parse_ip_addr(iface)
 

--- a/lib/ohai/plugins/netbsd/network.rb
+++ b/lib/ohai/plugins/netbsd/network.rb
@@ -39,7 +39,7 @@ Ohai.plugin(:Network) do
     end
 
     iface = Mash.new
-    so = shell_out("#{ Ohai.abs_path( "/sbin/ifconfig" )} -a")
+    so = shell_out("#{Ohai.abs_path( "/sbin/ifconfig" )} -a")
     cint = nil
     so.stdout.lines do |line|
       if line =~ /^([0-9a-zA-Z\.]+):\s+/

--- a/lib/ohai/plugins/openbsd/network.rb
+++ b/lib/ohai/plugins/openbsd/network.rb
@@ -39,7 +39,7 @@ Ohai.plugin(:Network) do
     end
 
     iface = Mash.new
-    so = shell_out( "#{ Ohai.abs_path( "/sbin/ifconfig" ) } -a" )
+    so = shell_out( "#{Ohai.abs_path( "/sbin/ifconfig" )} -a" )
     cint = nil
     so.stdout.lines do |line|
       if line =~ /^([0-9a-zA-Z\.]+):\s+/

--- a/lib/ohai/plugins/packages.rb
+++ b/lib/ohai/plugins/packages.rb
@@ -22,11 +22,13 @@ Ohai.plugin(:Packages) do
   provides "packages"
   depends "platform_family"
 
-  WINDOWS_ATTRIBUTE_ALIASES = {
-    "DisplayVersion" => "version",
-    "Publisher" => "publisher",
-    "InstallDate" => "installdate",
-  } unless defined?(WINDOWS_ATTRIBUTE_ALIASES)
+  unless defined?(WINDOWS_ATTRIBUTE_ALIASES)
+    WINDOWS_ATTRIBUTE_ALIASES = {
+      "DisplayVersion" => "version",
+      "Publisher" => "publisher",
+      "InstallDate" => "installdate",
+    }
+  end
 
   collect_data(:linux) do
     packages Mash.new

--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -38,7 +38,7 @@ Ohai.plugin(:Rackspace) do
   def has_rackspace_metadata?
     so = shell_out("xenstore-read vm-data/provider_data/provider")
     if so.exitstatus == 0
-      so.stdout.strip.casecmp("rackspace").zero?
+      so.stdout.strip.casecmp("rackspace") == 0
     end
   rescue Ohai::Exceptions::Exec
     false
@@ -84,7 +84,7 @@ Ohai.plugin(:Rackspace) do
 
   # Get the rackspace region
   #
-  def get_region()
+  def get_region
     so = shell_out("xenstore-ls vm-data/provider_data")
     if so.exitstatus == 0
       so.stdout.split("\n").each do |line|
@@ -98,7 +98,7 @@ Ohai.plugin(:Rackspace) do
 
   # Get the rackspace instance_id
   #
-  def get_instance_id()
+  def get_instance_id
     so = shell_out("xenstore-read name")
     if so.exitstatus == 0
       rackspace[:instance_id] = so.stdout.gsub(/instance-/, "")
@@ -110,7 +110,7 @@ Ohai.plugin(:Rackspace) do
 
   # Get the rackspace private networks
   #
-  def get_private_networks()
+  def get_private_networks
     so = shell_out("xenstore-ls vm-data/networking")
     if so.exitstatus == 0
       networks = []

--- a/lib/ohai/plugins/solaris2/dmi.rb
+++ b/lib/ohai/plugins/solaris2/dmi.rb
@@ -152,7 +152,7 @@ Ohai.plugin(:DMI) do
         field = nil
 
       elsif data = data_key_value_line.match(line)
-        if dmi_record == nil
+        if dmi_record.nil?
           Ohai::Log.debug("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
           next
         end
@@ -160,7 +160,7 @@ Ohai.plugin(:DMI) do
         field = data[1]
 
       elsif data = data_key_only_line.match(line)
-        if dmi_record == nil
+        if dmi_record.nil?
           Ohai::Log.debug("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
           next
         end
@@ -168,11 +168,11 @@ Ohai.plugin(:DMI) do
         field = data[1]
 
       elsif extended_data = extended_data_line.match(line)
-        if dmi_record == nil
+        if dmi_record.nil?
           Ohai::Log.debug("Plugin DMI: unexpected extended data line found before header; discarding:\n#{line}")
           next
         end
-        if field == nil
+        if field.nil?
           Ohai::Log.debug("Plugin DMI: unexpected extended data line found outside data section; discarding:\n#{line}")
           next
         end

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -54,11 +54,13 @@
 # inet6 fe80::203:baff:fe17:4444/128
 
 # Extracted from http://illumos.org/hcl/
-ETHERNET_ENCAPS = %w{ afe amd8111s arn atge ath bfe bge bnx bnxe ce cxgbe
-                      dmfe e1000g efe elxl emlxs eri hermon hme hxge igb
-                      iprb ipw iwh iwi iwk iwp ixgb ixgbe mwl mxfe myri10ge
-                      nge ntxn nxge pcn platform qfe qlc ral rge rtls rtw rwd
-                      rwn sfe tavor vr wpi xge yge aggr} unless defined?(ETHERNET_ENCAPS)
+unless defined?(ETHERNET_ENCAPS)
+  ETHERNET_ENCAPS = %w{ afe amd8111s arn atge ath bfe bge bnx bnxe ce cxgbe
+                        dmfe e1000g efe elxl emlxs eri hermon hme hxge igb
+                        iprb ipw iwh iwi iwk iwp ixgb ixgbe mwl mxfe myri10ge
+                        nge ntxn nxge pcn platform qfe qlc ral rge rtls rtw rwd
+                        rwn sfe tavor vr wpi xge yge aggr}
+end
 
 Ohai.plugin(:Network) do
   provides "network", "network/interfaces"

--- a/lib/ohai/plugins/uptime.rb
+++ b/lib/ohai/plugins/uptime.rb
@@ -74,7 +74,7 @@ Ohai.plugin(:Uptime) do
 
   collect_data(:openbsd) do
     # kern.boottime=Tue Nov  1 14:45:52 2011
-    so = shell_out("#{ Ohai.abs_path( "/sbin/sysctl" )} #kern.boottime")
+    so = shell_out("#{Ohai.abs_path( "/sbin/sysctl" )} #kern.boottime")
     so.stdout.lines do |line|
       if line =~ /kern.boottime=(.+)/
         uptime_seconds Time.new.to_i - Time.parse($1).to_i

--- a/lib/ohai/plugins/windows/filesystem.rb
+++ b/lib/ohai/plugins/windows/filesystem.rb
@@ -44,7 +44,7 @@ Ohai.plugin(:Filesystem) do
       fs[filesystem][:kb_used] = fs[filesystem][:kb_size].to_i - fs[filesystem][:kb_available].to_i
       fs[filesystem][:percent_used] = (fs[filesystem][:kb_size].to_i != 0 ? fs[filesystem][:kb_used].to_i * 100 / fs[filesystem][:kb_size].to_i : 0)
       fs[filesystem][:mount] = ld_info[filesystem][:name]
-      fs[filesystem][:fs_type] = ld_info[filesystem][:file_system].downcase unless ld_info[filesystem][:file_system] == nil
+      fs[filesystem][:fs_type] = ld_info[filesystem][:file_system].downcase unless ld_info[filesystem][:file_system].nil?
       fs[filesystem][:volume_name] = ld_info[filesystem][:volume_name]
     end
 

--- a/lib/ohai/plugins/windows/network.rb
+++ b/lib/ohai/plugins/windows/network.rb
@@ -39,7 +39,7 @@ Ohai.plugin(:Network) do
       # If we are running on windows nano or anothe roperating system from the future
       # that does not populate the deprecated win32_* WMI classes, then we should
       # grab data from the newer MSFT_* classes
-      return msft_adapter_data if data[:addresses].count.zero?
+      return msft_adapter_data if data[:addresses].count == 0
       data[:adapters] = wmi.instances_of("Win32_NetworkAdapter")
       data
     end
@@ -125,7 +125,7 @@ Ohai.plugin(:Network) do
         iface[cint][:type] = iface[cint][:instance][:adapter_type] if iface[cint][:instance][:adapter_type]
         iface[cint][:arp] = {}
         iface[cint][:encapsulation] = windows_encaps_lookup(iface[cint][:instance][:adapter_type]) if iface[cint][:instance][:adapter_type]
-        if iface[cint][:configuration][:default_ip_gateway] != nil && iface[cint][:configuration][:default_ip_gateway].size > 0
+        if !iface[cint][:configuration][:default_ip_gateway].nil? && iface[cint][:configuration][:default_ip_gateway].size > 0
           network[:default_gateway] = iface[cint][:configuration][:default_ip_gateway].first
           network[:default_interface] = cint
         end

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -69,7 +69,7 @@ module Ohai
         next if next_plugin.has_run?
 
         if visited.include?(next_plugin)
-          raise Ohai::Exceptions::DependencyCycle, "Dependency cycle detected. Please refer to the following plugins: #{get_cycle(visited, plugin).join(", ") }"
+          raise Ohai::Exceptions::DependencyCycle, "Dependency cycle detected. Please refer to the following plugins: #{get_cycle(visited, plugin).join(", ")}"
         end
 
         dependency_providers = fetch_plugins(next_plugin.dependencies)

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -193,7 +193,7 @@ module Ohai
       end
       raise ArgumentError, "I cannot find an attribute named #{a}!" if data.nil?
       case data
-      when Hash, Mash, Array, Fixnum
+      when Hash, Mash, Array, Integer
         json_pretty_print(data)
       when String
         if data.respond_to?(:lines)

--- a/platform_simulation_specs/common/ohai_plugin_common.rb
+++ b/platform_simulation_specs/common/ohai_plugin_common.rb
@@ -170,7 +170,7 @@ eof
   def clean_path( path, regex )
     Dir.glob( File.join( path, "*" )).
       reject { |e| e =~ regex }.
-      each { |e| Mixlib::ShellOut.new( "rm -rf #{ e }" ).run_command }
+      each { |e| Mixlib::ShellOut.new( "rm -rf #{e}" ).run_command }
   end
 
   module_function( :fake_command, :data_path, :get_path, :read_output, :clean_path,

--- a/spec/unit/plugins/bsd/virtualization_spec.rb
+++ b/spec/unit/plugins/bsd/virtualization_spec.rb
@@ -23,7 +23,7 @@ describe Ohai::System, "BSD virtualization plugin" do
     @plugin = get_plugin("bsd/virtualization")
     allow(@plugin).to receive(:collect_os).and_return(:freebsd)
     allow(@plugin).to receive(:shell_out).with("sysctl -n security.jail.jailed").and_return(mock_shell_out(0, "0", ""))
-    allow(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path( "/sbin/kldstat" )}").and_return(mock_shell_out(0, "", ""))
+    allow(@plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/sbin/kldstat" )}").and_return(mock_shell_out(0, "", ""))
     allow(@plugin).to receive(:shell_out).with("jls -nd").and_return(mock_shell_out(0, "", ""))
     allow(@plugin).to receive(:shell_out).with("sysctl -n hw.model").and_return(mock_shell_out(0, "", ""))
     allow(@plugin).to receive(:shell_out).with("sysctl -n kern.vm_guest").and_return(mock_shell_out(0, "", ""))
@@ -77,7 +77,7 @@ Id Refs Address Size Name
 1 40 0xffffffff80100000 d20428 kernel
 7 3 0xffffffff81055000 41e88 vboxguest.ko
 OUT
-      allow(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path("/sbin/kldstat")}").and_return(mock_shell_out(0, @vbox_guest, ""))
+      allow(@plugin).to receive(:shell_out).with("#{Ohai.abs_path("/sbin/kldstat")}").and_return(mock_shell_out(0, @vbox_guest, ""))
     end
 
     it "detects we are a guest" do

--- a/spec/unit/plugins/netbsd/kernel_spec.rb
+++ b/spec/unit/plugins/netbsd/kernel_spec.rb
@@ -25,7 +25,7 @@ describe Ohai::System, "NetBSD kernel plugin" do
     allow(@plugin).to receive(:init_kernel).and_return({})
     allow(@plugin).to receive(:shell_out).with("uname -i").and_return(mock_shell_out(0, "foo", ""))
     allow(@plugin).to receive(:shell_out).with("sysctl kern.securelevel").and_return(mock_shell_out(0, "kern.securelevel: 1\n", ""))
-    allow(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path( "/usr/bin/modstat" )}").and_return(mock_shell_out(0, "  1    7 0xc0400000 97f830   kernel", ""))
+    allow(@plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/bin/modstat" )}").and_return(mock_shell_out(0, "  1    7 0xc0400000 97f830   kernel", ""))
   end
 
   it "should set the kernel_os to the kernel_name value" do

--- a/spec/unit/plugins/solaris2/virtualization_spec.rb
+++ b/spec/unit/plugins/solaris2/virtualization_spec.rb
@@ -34,7 +34,7 @@ PSRINFO_PV
     allow(File).to receive(:exist?).with("/usr/sbin/smbios").and_return(false)
     allow(File).to receive(:exist?).with("/usr/sbin/zoneadm").and_return(false)
     allow(@plugin).to receive(:shell_out).with("/usr/sbin/smbios").and_return(mock_shell_out(0, "", ""))
-    allow(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, "", ""))
+    allow(@plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, "", ""))
   end
 
   describe "when we are checking for kvm" do
@@ -43,12 +43,12 @@ PSRINFO_PV
     end
 
     it "should run psrinfo -pv" do
-      expect(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv")
+      expect(@plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv")
       @plugin.run
     end
 
     it "Should set kvm guest if psrinfo -pv contains QEMU Virtual CPU" do
-      allow(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, "QEMU Virtual CPU", ""))
+      allow(@plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, "QEMU Virtual CPU", ""))
       @plugin.run
       expect(@plugin[:virtualization][:system]).to eq("kvm")
       expect(@plugin[:virtualization][:role]).to eq("guest")
@@ -56,7 +56,7 @@ PSRINFO_PV
     end
 
     it "should not set virtualization if kvm isn't there" do
-      expect(@plugin).to receive(:shell_out).with("#{ Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, @psrinfo_pv, ""))
+      expect(@plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, @psrinfo_pv, ""))
       @plugin.run
       expect(@plugin[:virtualization][:systems]).to eq({})
     end


### PR DESCRIPTION
This allows us to continue to include recent versions of chef and ohai
in ChefDK 1.x releases, permitting security updates and features.