### PR TITLE
Add Chakra Linux support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@ The packages plugin now correctly parses RPM package name / version information 
 
 ### Additional Platform Support
 
-Ohai now properly detects the [Clear](https://clearlinux.org/) and [ClearOS](https://www.clearos.com/) Linux distributions.
+Ohai now properly detects the [Clear](https://clearlinux.org/), [ClearOS](https://www.clearos.com/) and [Chakra](https://chakralinux.org/) Linux distributions.
 
 #### Clear Linux
 
@@ -33,6 +33,11 @@ Ohai now properly detects the [Clear](https://clearlinux.org/) and [ClearOS](htt
 
 - platform: clearos
 - platform_family: rhel
+
+#### Chakra Linux
+
+- platform: chakra
+- platform_family: arch
 
 ## New Deprecations
 

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -121,7 +121,7 @@ Ohai.plugin(:Platform) do
       "gentoo"
     when /slackware/
       "slackware"
-    when /arch/
+    when /arch/, /chakra/
       "arch"
     when /exherbo/
       "exherbo"
@@ -225,6 +225,11 @@ Ohai.plugin(:Platform) do
       platform "arch"
       # no way to determine platform_version in a rolling release distribution
       # kernel release will be used - ex. 2.6.32-ARCH
+      platform_version `uname -r`.strip
+    elsif File.exist?("/etc/chakra-release")
+      platform "chakra"
+      # no way to determine platform_version in a rolling release distribution
+      # kernel release will be used - ex. 2.6.32-CHAKRA
       platform_version `uname -r`.strip
     elsif File.exist?("/etc/exherbo-release")
       platform "exherbo"

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -28,6 +28,7 @@ describe Ohai::System, "Linux plugin platform" do
   let(:have_eos_release) { false }
   let(:have_suse_release) { false }
   let(:have_arch_release) { false }
+  let(:have_chakra_release) { false }
   let(:have_system_release) { false }
   let(:have_slackware_version) { false }
   let(:have_enterprise_release) { false }
@@ -51,6 +52,7 @@ describe Ohai::System, "Linux plugin platform" do
     allow(File).to receive(:exist?).with("/etc/Eos-release").and_return(have_eos_release)
     allow(File).to receive(:exist?).with("/etc/SuSE-release").and_return(have_suse_release)
     allow(File).to receive(:exist?).with("/etc/arch-release").and_return(have_arch_release)
+    allow(File).to receive(:exist?).with("/etc/chakra-release").and_return(have_chakra_release)
     allow(File).to receive(:exist?).with("/etc/system-release").and_return(have_system_release)
     allow(File).to receive(:exist?).with("/etc/slackware-version").and_return(have_slackware_version)
     allow(File).to receive(:exist?).with("/etc/enterprise-release").and_return(have_enterprise_release)
@@ -251,6 +253,26 @@ OS_RELEASE
       expect(@plugin).to receive(:`).with("uname -r").and_return("3.18.2-2-ARCH")
       @plugin.run
       expect(@plugin[:platform_version]).to eq("3.18.2-2-ARCH")
+    end
+  end
+
+  describe "on chakra" do
+    let(:have_chakra_release) { true }
+
+    before(:each) do
+      @plugin.lsb = nil
+    end
+
+    it "should set platform to chakra and platform_family to arch" do
+      @plugin.run
+      expect(@plugin[:platform]).to eq("chakra")
+      expect(@plugin[:platform_family]).to eq("arch")
+    end
+
+    it "should set platform_version to kernel release" do
+      expect(@plugin).to receive(:`).with("uname -r").and_return("4.8.6-1-CHAKRA")
+      @plugin.run
+      expect(@plugin[:platform_version]).to eq("4.8.6-1-CHAKRA")
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Lionel Félicité <deogracia@free.fr>

### Description

I add [Chakra Linux](https://chakralinux.org/) support

### Issues Resolved

When I tried to build chef-dk from source, it fails with
```
[Software: chef-dk] W | 2017-06-29T00:08:58+02:00 | Version local_source for software chef-dk was not parseable. Comparison methods such as #satisfies? will not be available for this version.
bundler: failed to load command: omnibus (/home/lfelicite/Travail/projects/perso/chakra/chakraos-ccr-my-contrib/chef-dk/src/chef-dk-1.5.0/omnibus/vendor/ruby/2.4.0/bin/omnibus)
NoMethodError: undefined method `[]' for nil:NilClass
  /home/lfelicite/Travail/projects/perso/chakra/chakraos-ccr-my-contrib/chef-dk/src/chef-dk-1.5.0/omnibus/files/chef-dk-gem/build-chef-dk-gem.rb:24:in `platform_family_family'
  /home/lfelicite/Travail/projects/perso/chakra/chakraos-ccr-my-contrib/chef-dk/src/chef-dk-1.5.0/omnibus/files/chef-dk-gem/build-chef-dk-gem.rb:49:in `without_groups'
  /home/lfelicite/Travail/projects/perso/chakra/chakraos-ccr-my-contrib/chef-dk/src/chef-dk-1.5.0/omnibus/files/chef-dk/build-chef-dk.rb:11:in `create_bundle_config'
  /home/lfelicite/Travail/projects/perso/chakra/chakraos-ccr-my-contrib/chef-dk/src/chef-dk-1.5.0/omnibus/config/software/chef-dk.rb:84:in `block in evaluate'

```

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
