### PR TITLE
Deprecate the IPScopes Plugin

### DIFF
--- a/lib/ohai/plugins/ip_scopes.rb
+++ b/lib/ohai/plugins/ip_scopes.rb
@@ -24,6 +24,8 @@ Ohai.plugin(:IpScopes) do
     begin
       require "ipaddr_extensions"
 
+      Ohai::Log.warn("The IpScopes Ohai plugin has been deprecated and will be removed from Ohai 14 (April 2018).")
+
       network["interfaces"].keys.sort.each do |if_name|
         next if network["interfaces"][if_name]["addresses"].nil?
 


### PR DESCRIPTION
2 reasons:

1) It requires a gem we're not installing so no one is actually using this. It's just failing to load during every Ohai run
2) If they do install the gem what they end up if fairly duplicate information to what we already provide in a few of the networking plugins

Signed-off-by: Tim Smith <tsmith@chef.io>