### PR TITLE
Fix solaris2 ipaddress attribute search

### DIFF
--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -101,7 +101,7 @@ Ohai.plugin(:Network) do
     cint = nil
 
     so.stdout.lines do |line|
-      # if line =~ /^([0-9a-zA-Z\.\:\-]+)\S/
+      # regex: http://rubular.com/r/Iag7JLVTVe
       if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+) index (\d+)/
         cint = $1
         iface[cint] = Mash.new unless iface[cint]

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -101,7 +101,8 @@ Ohai.plugin(:Network) do
     cint = nil
 
     so.stdout.lines do |line|
-      if line =~ /^([0-9a-zA-Z\.\:\-]+)\S/
+      # if line =~ /^([0-9a-zA-Z\.\:\-]+)\S/
+      if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+) index (\d+)/
         cint = $1
         iface[cint] = Mash.new unless iface[cint]
         iface[cint][:mtu] = $2

--- a/spec/unit/plugins/solaris2/network_spec.rb
+++ b/spec/unit/plugins/solaris2/network_spec.rb
@@ -69,9 +69,7 @@ lo0: flags=1000849<UP,LOOPBACK,RUNNING,MULTICAST,IPv4> mtu 8232 index 1
 eri0: flags=1004843<UP,BROADCAST,RUNNING,MULTICAST,DHCP,IPv4> mtu 1500 \
 index 2
     inet 172.17.128.208 netmask ffffff00 broadcast 172.17.128.255
-ip6.tun0: flags=10008d1<UP,POINTOPOINT,RUNNING,NOARP,MULTICAST,IPv4> \
-mtu 1460
-    index 3
+ip6.tun0: flags=10008d1<UP,POINTOPOINT,RUNNING,NOARP,MULTICAST,IPv4> mtu 1460 index 3
     inet6 tunnel src fe80::1 tunnel dst fe80::2
     tunnel security settings  -->  use 'ipsecconf -ln -i ip.tun1'
     tunnel hop limit 60 tunnel encapsulation limit 4
@@ -80,8 +78,7 @@ qfe1: flags=2000841<UP,RUNNING,MULTICAST,IPv6> mtu 1500 index 3
  usesrc vni0
  inet6 fe80::203:baff:fe17:4be0/10
  ether 0:3:ba:17:4b:e0
-vni0: flags=2002210041<UP,RUNNING,NOXMIT,NONUD,IPv6,VIRTUAL> mtu 0
- index 5
+vni0: flags=2002210041<UP,RUNNING,NOXMIT,NONUD,IPv6,VIRTUAL> mtu 1460 index 5
  srcof qfe1
  inet6 fe80::203:baff:fe17:4444/128
 ENDIFCONFIG
@@ -147,7 +144,7 @@ ROUTE_GET
     end
 
     it "detects the interfaces" do
-      expect(@plugin["network"]["interfaces"].keys.sort).to eq(["e1000g0:3", "e1000g2:1", "eri0", "ip.tun0", "ip.tun0:1", "lo0", "lo0:3", "net0", "net1:1", "qfe1"])
+      expect(@plugin["network"]["interfaces"].keys.sort).to eq(["e1000g0:3", "e1000g2:1", "eri0", "ip.tun0", "ip.tun0:1", "ip6.tun0", "lo0", "lo0:3", "net0", "net1:1", "qfe1", "vni0"])
     end
 
     it "detects the ip addresses of the interfaces" do

--- a/spec/unit/plugins/solaris2/network_spec.rb
+++ b/spec/unit/plugins/solaris2/network_spec.rb
@@ -147,7 +147,7 @@ ROUTE_GET
     end
 
     it "detects the interfaces" do
-      expect(@plugin["network"]["interfaces"].keys.sort).to eq(["e1000g0:3", "e1000g2:1", "eri0", "ip.tun0", "ip.tun0:1", "ip6.tun0", "lo0", "lo0:3", "net0", "net1:1", "qfe1", "vni0"])
+      expect(@plugin["network"]["interfaces"].keys.sort).to eq(["e1000g0:3", "e1000g2:1", "eri0", "ip.tun0", "ip.tun0:1", "lo0", "lo0:3", "net0", "net1:1", "qfe1"])
     end
 
     it "detects the ip addresses of the interfaces" do
@@ -176,7 +176,7 @@ ROUTE_GET
     end
 
     it "finds the default interface for a solaris 11 zone" do
-      expect(@plugin[:network][:default_interface]).to eq("net1")
+      expect(@plugin[:network][:default_interface]).to eq("net1:1")
     end
   end
 


### PR DESCRIPTION
```# ohai ipaddress ``` returns following warnings and replaces the node IP address with a blank IP
after chef-client run
```
[2017-07-07T20:36:32+00:00] WARN: [inet] no ip address on net0
[2017-07-07T20:36:32+00:00] WARN: unable to detect ipaddress
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.19.1/lib/ohai/system.rb:193:in `attributes_print': I cannot find an attribute named ipaddress! (ArgumentError)
```

Tested this fix on solaris11 client node and verfied IP address was retained after ccr.
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
