### PR TITLE
Remove cloud_v2 and filesystem2 attributes

### DIFF
--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 Ohai.plugin(:Cloud) do
-  provides "cloud_v2"
   provides "cloud"
 
   depends "ec2"
@@ -309,8 +308,6 @@ Ohai.plugin(:Cloud) do
     get_azure_values if on_azure?
     get_digital_ocean_values if on_digital_ocean?
 
-    # set node[:cloud] and node[:cloud_v2] hash here
-    cloud_v2 @cloud_attr_obj.cloud_mash
     cloud @cloud_attr_obj.cloud_mash
   end
 end

--- a/lib/ohai/plugins/darwin/filesystem.rb
+++ b/lib/ohai/plugins/darwin/filesystem.rb
@@ -20,7 +20,6 @@
 
 Ohai.plugin(:Filesystem) do
   provides "filesystem"
-  provides "filesystem2"
 
   def generate_device_view(fs)
     view = {}
@@ -104,6 +103,5 @@ Ohai.plugin(:Filesystem) do
     fs_data["by_pair"] = by_pair
 
     filesystem fs_data
-    filesystem2 fs_data
   end
 end

--- a/lib/ohai/plugins/linux/filesystem.rb
+++ b/lib/ohai/plugins/linux/filesystem.rb
@@ -20,7 +20,6 @@
 
 Ohai.plugin(:Filesystem) do
   provides "filesystem"
-  provides "filesystem2"
 
   def find_device(name)
     %w{/dev /dev/mapper}.each do |dir|
@@ -250,6 +249,5 @@ Ohai.plugin(:Filesystem) do
 
     # Set the filesystem data
     filesystem fs_data
-    filesystem2 fs_data
   end
 end

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -88,18 +88,6 @@ describe Ohai::System, "plugin cloud" do
       @plugin[:digital_ocean] = nil
       @plugin.run
       expect(@plugin[:cloud]).to be_nil
-      expect(@plugin[:cloud_v2]).to be_nil
-    end
-  end
-
-  describe "with a cloud mash" do
-    before do
-      @plugin[:ec2] = Mash.new
-    end
-
-    it "populates cloud public ip" do
-      @plugin.run
-      expect(@plugin[:cloud]).to eq(@plugin[:cloud_v2])
     end
   end
 

--- a/spec/unit/plugins/darwin/filesystem_spec.rb
+++ b/spec/unit/plugins/darwin/filesystem_spec.rb
@@ -27,11 +27,6 @@ describe Ohai::System, "darwin filesystem plugin" do
     allow(plugin).to receive(:shell_out).with("mount").and_return(mock_shell_out(0, "", ""))
   end
 
-  it "sets both filesystem and filesystem2 attributes" do
-    plugin.run
-    expect(plugin[:filesystem]).to eq(plugin[:filesystem2])
-  end
-
   describe "when gathering filesystem usage data from df" do
     before(:each) do
       @stdout = <<-DF

--- a/spec/unit/plugins/linux/filesystem_spec.rb
+++ b/spec/unit/plugins/linux/filesystem_spec.rb
@@ -55,11 +55,6 @@ describe Ohai::System, "Linux filesystem plugin" do
     end
   end
 
-  it "sets both filesystem and filesystem2 attributes" do
-    plugin.run
-    expect(plugin[:filesystem]).to eq(plugin[:filesystem2])
-  end
-
   describe "when gathering filesystem usage data from df" do
     before(:each) do
       @stdout = <<-DF


### PR DESCRIPTION
We made cloud_v2 and filesystem2 the default cloud and filesystem
plugins in Chef 13. For backwards compatibility we wrote the data out to
both locations, which bloated the node object size significantly. We've
deprecated the legacy attributes and this removes them. Chef servers
everywhere will thank us.

Signed-off-by: Tim Smith <tsmith@chef.io>