### PR TITLE
Handle situations where /proc/cpuinfo lacks core data

### DIFF
--- a/lib/ohai/plugins/linux/cpu.rb
+++ b/lib/ohai/plugins/linux/cpu.rb
@@ -86,7 +86,7 @@ Ohai.plugin(:CPU) do
     cpu[:total] = cpu_number
 
     # use data we collected unless cpuinfo is lacking core information
-    # which is the case on older linux distros (specifically SLES <= 12 SP1)
+    # which is the case on older linux distros
     if !real_cpu.empty? && cpu["0"]["cores"]
       cpu[:real] = real_cpu.keys.length
       cpu[:cores] = real_cpu.keys.length * cpu["0"]["cores"].to_i
@@ -94,22 +94,26 @@ Ohai.plugin(:CPU) do
       begin
         Ohai::Log.debug("Plugin CPU: Falling back to aggregate data from lscpu as real cpu & core data is missing in /proc/cpuinfo")
         so = shell_out("lscpu")
-        lscpu_data = Mash.new
-        so.stdout.each_line do |line|
-          case line
-          when /^Thread\(s\) per core:\s(.+)/ # http://rubular.com/r/lOw2pRrw1q
-            lscpu_data[:threads] = $1.to_i
-          when /^Core\(s\) per socket:\s(.+)/ # http://rubular.com/r/lOw2pRrw1q
-            lscpu_data[:cores] = $1.to_i
-          when /^Socket\(s\):\s(.+)/ # http://rubular.com/r/DIzmPtJFvK
-            lscpu_data[:sockets] = $1.to_i
+        if so.exitstatus == 0
+          lscpu_data = Mash.new
+          so.stdout.each_line do |line|
+            case line
+            when /^Thread\(s\) per core:\s(.+)/ # http://rubular.com/r/lOw2pRrw1q
+              lscpu_data[:threads] = $1.to_i
+            when /^Core\(s\) per socket:\s(.+)/ # http://rubular.com/r/lOw2pRrw1q
+              lscpu_data[:cores] = $1.to_i
+            when /^Socket\(s\):\s(.+)/ # http://rubular.com/r/DIzmPtJFvK
+              lscpu_data[:sockets] = $1.to_i
+            end
           end
+          cpu[:total] = lscpu_data[:sockets] * lscpu_data[:cores] * lscpu_data[:threads]
+          cpu[:real] = lscpu_data[:sockets]
+          cpu[:cores] = lscpu_data[:sockets] * lscpu_data[:cores]
+        else
+          Ohai::Log.debug("Plugin CPU: Error executing lscpu. CPU data may not be available.")
         end
-        cpu[:total] = lscpu_data[:sockets] * lscpu_data[:cores] * lscpu_data[:threads]
-        cpu[:real] = lscpu_data[:sockets]
-        cpu[:cores] = lscpu_data[:sockets] * lscpu_data[:cores]
       rescue Ohai::Exceptions::Exec # util-linux isn't installed most likely
-        Ohai::Log.debug("Plugin CPU: Error executing lshw. util-linux may not be installed")
+        Ohai::Log.debug("Plugin CPU: Error executing lscpu. util-linux may not be installed.")
       end
     end
   end


### PR DESCRIPTION
This works around failures to collect core data on SLES <= 12 SP1. We need to support SLES and core counts are used in several of our product cookbooks.

Signed-off-by: Tim Smith <tsmith@chef.io>