### PR TITLE
Added Devuan Compatibility

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -177,6 +177,9 @@ Ohai.plugin(:Platform) do
         end
         platform_version debian_platform_version
       end
+    elsif File.exist?("/etc/devuan_version")
+      platform "debian"
+      platform_version File.read("/etc/devuan_version").chomp
     elsif File.exist?("/etc/parallels-release")
       contents = File.read("/etc/parallels-release").chomp
       platform get_redhatish_platform(contents)

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -118,7 +118,7 @@ Ohai.plugin(:Platform) do
   #
   def determine_platform_family
     case platform
-    when /debian/, /ubuntu/, /linuxmint/, /raspbian/, /cumulus/
+    when /debian/, /ubuntu/, /linuxmint/, /raspbian/, /cumulus/ 
       "debian"
     when /oracle/, /centos/, /redhat/, /scientific/, /enterpriseenterprise/, /xenserver/, /cloudlinux/, /ibm_powerkvm/, /parallels/, /nexus_centos/, /clearos/, /bigip/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
       "rhel"


### PR DESCRIPTION
### Description
Added compatibility for Devuan distribution 

### Issues Resolved
Devuan is debian without systemd. As a complete fork of Debiain, the version is inside /etc/devuan_version rather than /etc/debian_version 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
