### PR TITLE
Move all requires / strings inside the collect blocks

### DIFF
--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -17,13 +17,12 @@
 # limitations under the License.
 #
 
-require "ohai/mixin/dmi_decode"
-
 Ohai.plugin(:Virtualization) do
-  include Ohai::Mixin::DmiDecode
   provides "virtualization"
 
   collect_data(:freebsd, :openbsd, :netbsd, :dragonflybsd) do
+    require "ohai/mixin/dmi_decode"
+    include Ohai::Mixin::DmiDecode
 
     virtualization Mash.new unless virtualization
     virtualization[:systems] = Mash.new unless virtualization[:systems]

--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -15,12 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "ohai/mixin/do_metadata"
-require "ohai/mixin/http_helper"
-
 Ohai.plugin(:DigitalOcean) do
-  include Ohai::Mixin::DOMetadata
-  include Ohai::Mixin::HttpHelper
 
   provides "digital_ocean"
 
@@ -48,6 +43,11 @@ Ohai.plugin(:DigitalOcean) do
   end
 
   collect_data do
+    require "ohai/mixin/do_metadata"
+    require "ohai/mixin/http_helper"
+    include Ohai::Mixin::DOMetadata
+    include Ohai::Mixin::HttpHelper
+
     if looks_like_digital_ocean?
       Ohai::Log.debug("Plugin Digitalocean: looks_like_digital_ocean? == true")
       digital_ocean Mash.new

--- a/lib/ohai/plugins/dragonflybsd/os.rb
+++ b/lib/ohai/plugins/dragonflybsd/os.rb
@@ -18,12 +18,11 @@
 # limitations under the License.
 #
 
-require "ohai/mixin/os"
-
 Ohai.plugin(:OS) do
   provides "os", "os_version"
 
   collect_data(:dragonflybsd) do
+    require "ohai/mixin/os"
     os collect_os
 
     # This is __DragonFly_version. See sys/param.h

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -24,11 +24,11 @@
 # 3. DMI data mentions amazon. This catches HVM instances in a VPC
 # 4. Kernel data mentioned Amazon. This catches Windows HVM & paravirt instances
 
-require "ohai/mixin/ec2_metadata"
-require "ohai/mixin/http_helper"
-require "base64"
-
 Ohai.plugin(:EC2) do
+  require "ohai/mixin/ec2_metadata"
+  require "ohai/mixin/http_helper"
+  require "base64"
+
   include Ohai::Mixin::Ec2Metadata
   include Ohai::Mixin::HttpHelper
 

--- a/lib/ohai/plugins/eucalyptus.rb
+++ b/lib/ohai/plugins/eucalyptus.rb
@@ -18,12 +18,8 @@
 # limitations under the License.
 
 # eucalyptus metadata service is compatible with the ec2 service calls
-require "ohai/mixin/ec2_metadata"
-require "ohai/mixin/http_helper"
 
 Ohai.plugin(:Eucalyptus) do
-  include Ohai::Mixin::Ec2Metadata
-  include Ohai::Mixin::HttpHelper
 
   provides "eucalyptus"
   depends "network/interfaces"
@@ -59,6 +55,11 @@ Ohai.plugin(:Eucalyptus) do
   end
 
   collect_data do
+    require "ohai/mixin/ec2_metadata"
+    require "ohai/mixin/http_helper"
+    include Ohai::Mixin::Ec2Metadata
+    include Ohai::Mixin::HttpHelper
+
     if looks_like_euca?
       Ohai::Log.debug("Plugin Eucalyptus: looks_like_euca? == true")
       eucalyptus Mash.new

--- a/lib/ohai/plugins/freebsd/os.rb
+++ b/lib/ohai/plugins/freebsd/os.rb
@@ -18,12 +18,11 @@
 # limitations under the License.
 #
 
-require "ohai/mixin/os"
-
 Ohai.plugin(:OS) do
   provides "os", "os_version"
 
   collect_data(:freebsd) do
+    require "ohai/mixin/os"
     os collect_os
 
     # This is __FreeBSD_version. See sys/param.h or

--- a/lib/ohai/plugins/gce.rb
+++ b/lib/ohai/plugins/gce.rb
@@ -14,12 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "ohai/mixin/gce_metadata"
-require "ohai/mixin/http_helper"
-
 Ohai.plugin(:GCE) do
-  include Ohai::Mixin::GCEMetadata
-  include Ohai::Mixin::HttpHelper
 
   provides "gce"
 
@@ -42,6 +37,11 @@ Ohai.plugin(:GCE) do
   end
 
   collect_data do
+    require "ohai/mixin/gce_metadata"
+    require "ohai/mixin/http_helper"
+    include Ohai::Mixin::GCEMetadata
+    include Ohai::Mixin::HttpHelper
+
     if looks_like_gce?
       Ohai::Log.debug("Plugin GCE: looks_like_gce? == true")
       gce Mash.new

--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -25,11 +25,11 @@
 # limitations under the License.
 #
 
-require "socket"
-require "ipaddr"
-
 Ohai.plugin(:Hostname) do
   provides "domain", "hostname", "fqdn", "machinename"
+
+  require "socket"
+  require "ipaddr"
 
   # hostname : short hostname
   # machinename : output of hostname command (might be short on solaris)

--- a/lib/ohai/plugins/linux/systemd_paths.rb
+++ b/lib/ohai/plugins/linux/systemd_paths.rb
@@ -16,14 +16,13 @@
 # limitations under the License.
 #
 
-require "ohai/util/file_helper"
-
-include Ohai::Util::FileHelper
-
 Ohai.plugin(:SystemdPaths) do
   provides "systemd_paths"
 
   collect_data(:linux) do
+    require "ohai/util/file_helper"
+    include Ohai::Util::FileHelper
+
     systemd_path_path = which("systemd-path")
     if systemd_path_path
       systemd_path = shell_out(systemd_path_path)

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -16,10 +16,7 @@
 # limitations under the License.
 #
 
-require "ohai/mixin/dmi_decode"
-
 Ohai.plugin(:Virtualization) do
-  include Ohai::Mixin::DmiDecode
   provides "virtualization"
 
   def lxc_version_exists?
@@ -31,6 +28,9 @@ Ohai.plugin(:Virtualization) do
   end
 
   collect_data(:linux) do
+    require "ohai/mixin/dmi_decode"
+    include Ohai::Mixin::DmiDecode
+
     virtualization Mash.new unless virtualization
     virtualization[:systems] = Mash.new unless virtualization[:systems]
 

--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -16,12 +16,7 @@
 # limitations under the License.
 #
 
-require "ipaddress"
-require "ohai/mixin/network_constants"
-
 Ohai.plugin(:NetworkAddresses) do
-  include Ohai::Mixin::NetworkConstants
-
   provides "ipaddress", "ip6address", "macaddress"
 
   depends "network/interfaces"
@@ -133,6 +128,10 @@ Ohai.plugin(:NetworkAddresses) do
   # time as ipaddress. if ipaddress is set and macaddress is nil, that means
   # the interface ipaddress is bound to has the NOARP flag
   collect_data do
+    require "ipaddress"
+    require "ohai/mixin/network_constants"
+    include Ohai::Mixin::NetworkConstants
+
     results = {}
 
     network Mash.new unless network

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -16,12 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "ohai/mixin/ec2_metadata"
-require "ohai/mixin/http_helper"
-
 Ohai.plugin(:Openstack) do
-  include Ohai::Mixin::Ec2Metadata
-  include Ohai::Mixin::HttpHelper
 
   provides "openstack"
   depends "dmi"
@@ -57,6 +52,11 @@ Ohai.plugin(:Openstack) do
   end
 
   collect_data do
+    require "ohai/mixin/ec2_metadata"
+    require "ohai/mixin/http_helper"
+    include Ohai::Mixin::Ec2Metadata
+    include Ohai::Mixin::HttpHelper
+
     # fetch data if we look like openstack
     if openstack_hint? || openstack_dmi?
       openstack Mash.new

--- a/lib/ohai/plugins/packages.rb
+++ b/lib/ohai/plugins/packages.rb
@@ -22,14 +22,6 @@ Ohai.plugin(:Packages) do
   provides "packages"
   depends "platform_family"
 
-  unless defined?(WINDOWS_ATTRIBUTE_ALIASES)
-    WINDOWS_ATTRIBUTE_ALIASES = {
-      "DisplayVersion" => "version",
-      "Publisher" => "publisher",
-      "InstallDate" => "installdate",
-    }
-  end
-
   collect_data(:linux) do
     packages Mash.new
     if %w{debian}.include? platform_family
@@ -79,6 +71,15 @@ Ohai.plugin(:Packages) do
 
   collect_data(:windows) do
     require "win32/registry"
+
+    unless defined?(WINDOWS_ATTRIBUTE_ALIASES)
+      WINDOWS_ATTRIBUTE_ALIASES = {
+        "DisplayVersion" => "version",
+        "Publisher" => "publisher",
+        "InstallDate" => "installdate",
+      }
+    end
+
     packages Mash.new
     collect_programs_from_registry_key('Software\Microsoft\Windows\CurrentVersion\Uninstall')
     # on 64 bit systems, 32 bit programs are stored here

--- a/lib/ohai/plugins/passwd.rb
+++ b/lib/ohai/plugins/passwd.rb
@@ -1,6 +1,3 @@
-
-require "etc"
-
 Ohai.plugin(:Passwd) do
   provides "etc", "current_user"
 
@@ -10,6 +7,8 @@ Ohai.plugin(:Passwd) do
   end
 
   collect_data do
+    require "etc"
+
     unless etc
       etc Mash.new
 

--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "resolv"
-
 Ohai.plugin(:Rackspace) do
   provides "rackspace"
 
@@ -133,6 +131,8 @@ Ohai.plugin(:Rackspace) do
   end
 
   collect_data do
+    require "resolv"
+
     # Adds rackspace Mash
     if looks_like_rackspace?
       rackspace Mash.new

--- a/lib/ohai/plugins/root_group.rb
+++ b/lib/ohai/plugins/root_group.rb
@@ -18,11 +18,10 @@
 Ohai.plugin(:RootGroup) do
   provides "root_group"
 
-  require "ohai/util/win32/group_helper" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
-
   collect_data do
     case ::RbConfig::CONFIG["host_os"]
     when /mswin|mingw32|windows/
+      require "ohai/util/win32/group_helper"
       group = Ohai::Util::Win32::GroupHelper.windows_root_group_name
       root_group group
     else

--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 
-require "digest/md5"
-
 Ohai.plugin(:ShardSeed) do
   depends "hostname", "dmi", "machine_id", "machinename"
   provides "shard_seed"
@@ -57,6 +55,7 @@ Ohai.plugin(:ShardSeed) do
   end
 
   collect_data(:darwin) do
+    require "digest/md5"
     create_seed do |src|
       case src
       when :serial
@@ -68,6 +67,7 @@ Ohai.plugin(:ShardSeed) do
   end
 
   collect_data(:linux) do
+    require "digest/md5"
     create_seed do |src|
       case src
       when :serial

--- a/lib/ohai/plugins/softlayer.rb
+++ b/lib/ohai/plugins/softlayer.rb
@@ -18,10 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "ohai/mixin/softlayer_metadata"
-
 Ohai.plugin(:Softlayer) do
-  include ::Ohai::Mixin::SoftlayerMetadata
 
   provides "softlayer"
 
@@ -35,6 +32,9 @@ Ohai.plugin(:Softlayer) do
   end
 
   collect_data do
+    require "ohai/mixin/softlayer_metadata"
+    include ::Ohai::Mixin::SoftlayerMetadata
+
     # Adds softlayer Mash
     if looks_like_softlayer?
       Ohai::Log.debug("Plugin Softlayer: looks_like_softlayer? == true")

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -53,15 +53,6 @@
 # srcof qfe1
 # inet6 fe80::203:baff:fe17:4444/128
 
-# Extracted from http://illumos.org/hcl/
-unless defined?(ETHERNET_ENCAPS)
-  ETHERNET_ENCAPS = %w{ afe amd8111s arn atge ath bfe bge bnx bnxe ce cxgbe
-                        dmfe e1000g efe elxl emlxs eri hermon hme hxge igb
-                        iprb ipw iwh iwi iwk iwp ixgb ixgbe mwl mxfe myri10ge
-                        nge ntxn nxge pcn platform qfe qlc ral rge rtls rtw rwd
-                        rwn sfe tavor vr wpi xge yge aggr}
-end
-
 Ohai.plugin(:Network) do
   provides "network", "network/interfaces"
   provides "counters/network", "counters/network/interfaces"
@@ -92,6 +83,15 @@ Ohai.plugin(:Network) do
 
   collect_data(:solaris2) do
     require "scanf"
+
+    # Extracted from http://illumos.org/hcl/
+    unless defined?(ETHERNET_ENCAPS)
+      ETHERNET_ENCAPS = %w{ afe amd8111s arn atge ath bfe bge bnx bnxe ce cxgbe
+                            dmfe e1000g efe elxl emlxs eri hermon hme hxge igb
+                            iprb ipw iwh iwi iwk iwp ixgb ixgbe mwl mxfe myri10ge
+                            nge ntxn nxge pcn platform qfe qlc ral rge rtls rtw rwd
+                            rwn sfe tavor vr wpi xge yge aggr}
+    end
 
     iface = Mash.new
     network Mash.new unless network

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -18,10 +18,7 @@
 # limitations under the License.
 #
 
-require "ohai/mixin/dmi_decode"
-
 Ohai.plugin(:Virtualization) do
-  include Ohai::Mixin::DmiDecode
   provides "virtualization"
 
   def collect_solaris_guestid
@@ -31,6 +28,9 @@ Ohai.plugin(:Virtualization) do
   end
 
   collect_data(:solaris2) do
+    require "ohai/mixin/dmi_decode"
+    include Ohai::Mixin::DmiDecode
+
     virtualization Mash.new
     virtualization[:systems] = Mash.new
 

--- a/lib/ohai/plugins/uptime.rb
+++ b/lib/ohai/plugins/uptime.rb
@@ -24,12 +24,11 @@
 # limitations under the License.
 #
 
-require "ohai/mixin/seconds_to_human"
-
 Ohai.plugin(:Uptime) do
   provides "uptime", "uptime_seconds"
   provides "idletime", "idletime_seconds" # linux only
   depends "platform_version"
+  require "ohai/mixin/seconds_to_human"
 
   def collect_uptime(path)
     # kern.boottime: { sec = 1232765114, usec = 823118 } Fri Jan 23 18:45:14 2009


### PR DESCRIPTION
We shouldn't require things outside the collect block because this
always runs regardless of which plugins actually run. In theory this
speeds things up a little bit

Signed-off-by: Tim Smith <tsmith@chef.io>