### PR TITLE
Add Arch Linux support to package plugin

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,10 @@ Ohai now properly detects the [F5 Big-IP](https://www.f5.com/) platform and plat
 - platform: bigip
 - platform_family: rhel
 
+### Package Plugin Supports Arch Linux
+
+The Package plugin has been updated to include package information on Arch Linux systems.
+
 # Ohai Release Notes 13.2:
 
 Ohai 13.2 has been a fantastic release in terms of community involvement with new plugins, platform support, and critical bug fixes coming from community members. A huge thank you to msgarbossa, albertomurillo, jaymzh, and davide125 for their work.

--- a/spec/data/plugins/pacman.output
+++ b/spec/data/plugins/pacman.output
@@ -1,0 +1,51 @@
+Name            : acl
+Version         : 2.2.52-3
+Description     : Access control list utilities, libraries and headers
+Architecture    : x86_64
+URL             : http://savannah.nongnu.org/projects/acl
+Licenses        : LGPL
+Groups          : None
+Provides        : xfsacl
+Depends On      : attr>=2.4.46
+Optional Deps   : None
+Required By     : coreutils  gettext  libarchive  logrotate  sed  shadow  systemd  tar
+Optional For    : None
+Conflicts With  : xfsacl
+Replaces        : xfsacl
+Installed Size  : 290.00 KiB
+Packager        : Bartlomiej Piotrowski <bpiotrowski@archlinux.org>
+Build Date      : Sun Nov  6 14:03:46 2016
+Install Date    : Sun Jul 23 03:25:45 2017
+Install Reason  : Installed as a dependency for another package
+Install Script  : No
+Validated By    : Signature
+
+Name            : abcde
+Version         : 2.8.1-2
+Description     : Frontend command-line utility that grabs tracks off a CD, encodes them to ogg or mp3 format, and tags them, all in one go
+Architecture    : any
+URL             : https://abcde.einval.com/
+Licenses        : GPL
+Groups          : None
+Provides        : None
+Depends On      : bash  cd-discid  wget  vorbis-tools  python2-eyed3
+Optional Deps   : cdparanoia: Paranoia ripping support [installed]
+                  cdrkit: icedax ripping support [installed]
+                  flac: FLAC encoding support [installed]
+                  id3: ID3 v1 tag support
+                  lame: MP3 encoding support [installed]
+                  mp3gain: MP3 normalization support [installed]
+                  perl-musicbrainz-discid: musicbrainz support (AUR)
+                  perl-webservice-musicbrainz: musicbrainz support (AUR)
+                  vorbisgain: Ogg Vorbis normalization support [installed]
+Required By     : None
+Optional For    : None
+Conflicts With  : None
+Replaces        : None
+Installed Size  : 334.00 KiB
+Packager        : Alexander Rødseth <rodseth@gmail.com>
+Build Date      : Wed Apr 26 02:04:21 2017
+Install Date    : Fri May  5 15:36:23 2017
+Install Reason  : Explicitly installed
+Install Script  : No
+Validated By    : Signature

--- a/spec/unit/plugins/packages_spec.rb
+++ b/spec/unit/plugins/packages_spec.rb
@@ -102,6 +102,43 @@ describe Ohai::System, "plugin packages" do
     end
   end
 
+  context "on arch" do
+    let(:plugin) do
+      get_plugin("packages").tap do |plugin|
+        plugin[:platform_family] = "arch"
+      end
+    end
+
+    let(:stdout) do
+      File.read(File.join(SPEC_PLUGIN_PATH, "pacman.output"))
+    end
+
+    before(:each) do
+      allow(plugin).to receive(:collect_os).and_return(:linux)
+      allow(plugin).to receive(:shell_out).with("LANG=C pacman -Qi").and_return(mock_shell_out(0, stdout, ""))
+      plugin.run
+    end
+
+    it "calls LANG=C pacman -Qi" do
+      expect(plugin).to receive(:shell_out)
+        .with("LANG=C pacman -Qi")
+        .and_return(mock_shell_out(0, stdout, ""))
+      plugin.run
+    end
+
+    it "gets packages and versions/release - normal case" do
+      expect(plugin[:packages]["acl"][:version]).to eq("2.2.52-3")
+      expect(plugin[:packages]["acl"][:installdate]).to eq("1500780345")
+      expect(plugin[:packages]["acl"][:arch]).to eq("x86_64")
+    end
+
+    it "gets packages and versions/release - multiline optdeps" do
+      expect(plugin[:packages]["abcde"][:version]).to eq("2.8.1-2")
+      expect(plugin[:packages]["abcde"][:installdate]).to eq("1493998583")
+      expect(plugin[:packages]["abcde"][:arch]).to eq("any")
+    end
+  end
+
   context "on windows", :windows_only do
 
     let(:plugin) do


### PR DESCRIPTION
### Description

This commit adds support for detecting packages on Arch Linux. This is my first time contributing to Ohai or any Chef project, so I'd appreciate any feedback.

### Issues Resolved

I wrote this mainly because I wanted to make some decisions in Chef that involved knowing if one package from a set were already installed. Specifically, I wanted a recipe that installs command line vim, but only if graphical vim isn't already installed.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>