### PR TITLE
Add error handling in Linux filesystem plugin

### DIFF
--- a/lib/ohai/plugins/linux/filesystem.rb
+++ b/lib/ohai/plugins/linux/filesystem.rb
@@ -95,7 +95,7 @@ Ohai.plugin(:Filesystem) do
     fs = Mash.new
 
     # Grab filesystem data from df
-    if which("df")
+    begin
       so = shell_out("df -P")
       so.stdout.each_line do |line|
         case line
@@ -130,12 +130,12 @@ Ohai.plugin(:Filesystem) do
           fs[key][:mount] = $6
         end
       end
-    else
+    rescue Ohai::Exceptions::Exec
       Ohai::Log.warn("df is not available")
     end
 
     # Grab mount information from /bin/mount
-    if which("mount")
+    begin
       so = shell_out("mount")
       so.stdout.each_line do |line|
         if line =~ /^(.+?) on (.+?) type (.+?) \((.+?)\)$/
@@ -147,7 +147,7 @@ Ohai.plugin(:Filesystem) do
           fs[key][:mount_options] = $4.split(",")
         end
       end
-    else
+    rescue Ohai::Exceptions::Exec
       Ohai::Log.warn("mount is not available")
     end
 

--- a/spec/unit/plugins/linux/filesystem_spec.rb
+++ b/spec/unit/plugins/linux/filesystem_spec.rb
@@ -27,6 +27,8 @@ describe Ohai::System, "Linux filesystem plugin" do
     allow(plugin).to receive(:shell_out).with("df -iP").and_return(mock_shell_out(0, "", ""))
     allow(plugin).to receive(:shell_out).with("mount").and_return(mock_shell_out(0, "", ""))
     allow(plugin).to receive(:which).with("lsblk").and_return(nil)
+    allow(plugin).to receive(:which).with("df").and_return("/bin/df")
+    allow(plugin).to receive(:which).with("mount").and_return("/bin/mount")
     allow(plugin).to receive(:which).with("blkid").and_return("/sbin/blkid")
     allow(plugin).to receive(:shell_out).with("/sbin/blkid", timeout: 60).and_return(mock_shell_out(0, "", ""))
 
@@ -527,6 +529,16 @@ BLKID_TYPE
     it "should provide a mounts view with all devices" do
       plugin.run
       expect(plugin[:filesystem]["by_mountpoint"]["/mnt"][:devices]).to eq(["/dev/sdb1", "/dev/sdc1"])
+    end
+  end
+
+  %w{df mount}.each do |command|
+    describe "when #{command} does not exist" do
+      it "logs event" do
+        allow(plugin).to receive(:which).with(command).and_return(nil)
+        expect(Ohai::Log).to receive(:warn).with("#{command} is not available")
+        plugin.run
+      end
     end
   end
 end

--- a/spec/unit/plugins/linux/filesystem_spec.rb
+++ b/spec/unit/plugins/linux/filesystem_spec.rb
@@ -534,7 +534,7 @@ BLKID_TYPE
 
   %w{df mount}.each do |command|
     describe "when #{command} does not exist" do
-      it "logs event" do
+      it "logs warning about #{command} missing" do
         allow(plugin).to receive(:which).with(command).and_return(nil)
         expect(Ohai::Log).to receive(:warn).with("#{command} is not available")
         plugin.run

--- a/spec/unit/plugins/linux/filesystem_spec.rb
+++ b/spec/unit/plugins/linux/filesystem_spec.rb
@@ -535,7 +535,7 @@ BLKID_TYPE
   %w{df mount}.each do |command|
     describe "when #{command} does not exist" do
       it "logs warning about #{command} missing" do
-        allow(plugin).to receive(:which).with(command).and_return(nil)
+        allow(plugin).to receive(:shell_out).with(/#{command}/).and_raise(Ohai::Exceptions::Exec)
         expect(Ohai::Log).to receive(:warn).with("#{command} is not available")
         plugin.run
       end


### PR DESCRIPTION
### Description

Add error handling in Linux filesystem plugin for when a command does not exist. 

### Issues Resolved

https://github.com/chef/ohai/issues/1011

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. 
