### PR TITLE
changing method to gather AIX uptime

### DIFF
--- a/lib/ohai/plugins/aix/uptime.rb
+++ b/lib/ohai/plugins/aix/uptime.rb
@@ -28,7 +28,7 @@ Ohai.plugin(:Uptime) do
     # This reads as 1148 days, 20 hours, 54 minutes, 50 seconds since the process was started (elapsed)
     # who -b does not return the YEAR, so we need something more concrete
     so = shell_out("LC_ALL=POSIX ps -o etime= -p 1").stdout
-    
+ 
     # Here we'll check our shell_out for a dash, which indicates there is a # of days involved
     # We'll chunk off the days, hours (where applicable), minutes, seconds into seperate vars
     # We also need to do this because ps -o etime= will not display days if the machine has been up for less than 24 hours
@@ -45,9 +45,8 @@ Ohai.plugin(:Uptime) do
       (m, s) = so.split(/[:]/)
     end
     elapsed_seconds = ((d.to_i * 86400) + (h.to_i * 3600) + (m.to_i * 60) + s.to_i)
-    
-    uptime_seconds Time.now.to_i - elapsed_seconds 
+ 
+    uptime_seconds Time.now.to_i - elapsed_seconds
     uptime seconds_to_human(elapsed_seconds)
-  
   end
 end

--- a/lib/ohai/plugins/aix/uptime.rb
+++ b/lib/ohai/plugins/aix/uptime.rb
@@ -45,7 +45,7 @@ Ohai.plugin(:Uptime) do
       (m, s) = so.split(/[:]/)
     end
     elapsed_seconds = ((d.to_i * 86400) + (h.to_i * 3600) + (m.to_i * 60) + s.to_i)
-    
+
     uptime_seconds Time.now.to_i - elapsed_seconds
     uptime seconds_to_human(elapsed_seconds)
   end

--- a/lib/ohai/plugins/aix/uptime.rb
+++ b/lib/ohai/plugins/aix/uptime.rb
@@ -28,7 +28,7 @@ Ohai.plugin(:Uptime) do
     # This reads as 1148 days, 20 hours, 54 minutes, 50 seconds since the process was started (elapsed)
     # who -b does not return the YEAR, so we need something more concrete
     so = shell_out("LC_ALL=POSIX ps -o etime= -p 1").stdout
- 
+
     # Here we'll check our shell_out for a dash, which indicates there is a # of days involved
     # We'll chunk off the days, hours (where applicable), minutes, seconds into seperate vars
     # We also need to do this because ps -o etime= will not display days if the machine has been up for less than 24 hours
@@ -45,7 +45,7 @@ Ohai.plugin(:Uptime) do
       (m, s) = so.split(/[:]/)
     end
     elapsed_seconds = ((d.to_i * 86400) + (h.to_i * 3600) + (m.to_i * 60) + s.to_i)
- 
+    
     uptime_seconds Time.now.to_i - elapsed_seconds
     uptime seconds_to_human(elapsed_seconds)
   end

--- a/lib/ohai/plugins/aix/uptime.rb
+++ b/lib/ohai/plugins/aix/uptime.rb
@@ -22,16 +22,32 @@ Ohai.plugin(:Uptime) do
 
   collect_data(:aix) do
     require "date"
-    # Example output:
-    # $ who -b
-    #   .       system boot  Jul  9 17:51
-    so = shell_out("who -b")
-    so.stdout.lines.each do |line|
-      if line =~ /.* boot (.+)/
-        uptime_seconds Time.now.to_i - DateTime.parse($1 + " #{Time.now.zone}").strftime("%s").to_i
-        uptime seconds_to_human(uptime_seconds)
-        break
-      end
+    # below we're going to assume that PID 1 is init (this is true 99.99999% of the time)
+    # output will look like this
+    # 1148-20:54:50
+    # This reads as 1148 days, 20 hours, 54 minutes, 50 seconds since the process was started (elapsed)
+    # who -b does not return the YEAR, so we need something more concrete
+    so = shell_out("LC_ALL=POSIX ps -o etime= -p 1").stdout
+    
+    # Here we'll check our shell_out for a dash, which indicates there is a # of days involved
+    # We'll chunk off the days, hours (where applicable), minutes, seconds into seperate vars
+    # We also need to do this because ps -o etime= will not display days if the machine has been up for less than 24 hours
+    # If the machine has been up for less than one hour, the shell_out will not output hours hence our else
+    # see here: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/com.ibm.aix.cmds4/ps.htm#ps__row-d3e109655
+    d = nil
+    h = nil
+    case so
+    when /^\d+-\d/
+      (d, h, m, s) = so.split(/[-:]/)
+    when /^\d+:\d+:\d/
+      (h, m, s) = so.split(/[:]/)
+    else
+      (m, s) = so.split(/[:]/)
     end
+    elapsed_seconds = ((d.to_i * 86400) + (h.to_i * 3600) + (m.to_i * 60) + s.to_i)
+    
+    uptime_seconds Time.now.to_i - elapsed_seconds 
+    uptime seconds_to_human(elapsed_seconds)
+  
   end
 end

--- a/spec/unit/plugins/aix/uptime_spec.rb
+++ b/spec/unit/plugins/aix/uptime_spec.rb
@@ -23,19 +23,18 @@ describe Ohai::System, "Aix plugin uptime" do
   before(:each) do
     @plugin = get_plugin("aix/uptime")
     allow(@plugin).to receive(:collect_os).and_return(:aix)
-    allow(Time).to receive_message_chain(:now, :to_i).and_return(1412072511)
-    allow(Time).to receive_message_chain(:now, :zone).and_return("IST")
-    allow(DateTime).to receive_message_chain(:parse, :strftime, :to_i).and_return(1411561320)
-    allow(@plugin).to receive(:shell_out).with("who -b").and_return(mock_shell_out(0, "   .        system boot Sep 24 17:52", nil))
-
+    allow(@plugin).to receive(:shell_out).and_call_original
+    allow(Time).to receive_message_chain(:now, :to_i).and_return(1504287957)
+    allow(@plugin).to receive(:shell_out).with("LC_ALL=POSIX ps -o etime= -p 1").and_return(mock_shell_out(0,"1148-20:54:50", nil))
+    
     @plugin.run
   end
 
-  it "should set uptime_seconds to uptime" do
-    expect(@plugin[:uptime_seconds]).to eq(511191)
+  it "should set uptime_seconds to uptime with days" do
+    expect(@plugin[:uptime_seconds]).to eq(1405025467)
   end
 
-  it "should set uptime to a human readable date" do
-    expect(@plugin[:uptime]).to eq("5 days 21 hours 59 minutes 51 seconds")
+  it "should set uptime to a human readable date with days" do
+    expect(@plugin[:uptime]).to eq("1148 days 20 hours 54 minutes 50 seconds")
   end
 end

--- a/spec/unit/plugins/aix/uptime_spec.rb
+++ b/spec/unit/plugins/aix/uptime_spec.rb
@@ -25,8 +25,7 @@ describe Ohai::System, "Aix plugin uptime" do
     allow(@plugin).to receive(:collect_os).and_return(:aix)
     allow(@plugin).to receive(:shell_out).and_call_original
     allow(Time).to receive_message_chain(:now, :to_i).and_return(1504287957)
-    allow(@plugin).to receive(:shell_out).with("LC_ALL=POSIX ps -o etime= -p 1").and_return(mock_shell_out(0,"1148-20:54:50", nil))
-    
+    allow(@plugin).to receive(:shell_out).with("LC_ALL=POSIX ps -o etime= -p 1").and_return(mock_shell_out(0, "1148-20:54:50", nil))
     @plugin.run
   end
 


### PR DESCRIPTION
### Description

The existing Ohai plugin for returning uptime on AIX machines doesn't account for the year in which the box was booted leading to false positives and negative values

### Issues Resolved
Sample of existing issue
```

Ohai:
--
"uptime_seconds": -4845099,
"uptime": "22 hours 08 minutes 21 seconds",
 
s178 # uptime
09:16AM   up 308 days,  22:10,  4 users,  load average: 7.60, 9.58, 11.85
s178 # who -b
.        system boot Oct 27 11:07
```


### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
