### PR TITLE
Improve detection of Windows EC2 nodes by using UUID information

### DIFF
--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -39,6 +39,7 @@ Ohai.plugin(:EC2) do
 
   # look for amazon string in dmi bios data
   # this gets us detection of HVM instances that are within a VPC
+  # @return [Boolean] do we have Amazon DMI data?
   def has_ec2_dmi?
     # detect a version of '4.2.amazon'
     if get_attribute(:dmi, :bios, :all_records, 0, :Version) =~ /amazon/
@@ -52,6 +53,7 @@ Ohai.plugin(:EC2) do
 
   # looks for a xen UUID that starts with ec2
   # this gets us detection of Linux HVM and Paravirt hosts
+  # @return [Boolean] do we have a Xen UUID or not?
   def has_ec2_xen_uuid?
     if ::File.exist?("/sys/hypervisor/uuid")
       if ::File.read("/sys/hypervisor/uuid") =~ /^ec2/
@@ -65,6 +67,7 @@ Ohai.plugin(:EC2) do
 
   # looks for the Amazon.com Organization in Windows Kernel data
   # this gets us detection of Windows systems
+  # @return [Boolean] is the Windows organization Amazon?
   def has_amazon_org?
     # detect an Organization of 'Amazon.com'
     if get_attribute(:kernel, :os_info, :organization) =~ /Amazon/
@@ -76,6 +79,8 @@ Ohai.plugin(:EC2) do
     end
   end
 
+  # a single check that combines all the various detection methods for EC2
+  # @return [Boolean] Does the system appear to be on EC2
   def looks_like_ec2?
     return true if hint?("ec2")
 

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -35,7 +35,6 @@ Ohai.plugin(:EC2) do
   provides "ec2"
 
   depends "dmi"
-  depends "kernel"
 
   # look for amazon string in dmi bios data
   # this gets us detection of HVM instances that are within a VPC
@@ -73,27 +72,13 @@ Ohai.plugin(:EC2) do
     false
   end
 
-  # looks for the Amazon.com Organization in Windows Kernel data
-  # this gets us detection of Windows systems
-  # @return [Boolean] is the Windows organization Amazon?
-  def has_amazon_org?
-    # detect an Organization of 'Amazon.com'
-    if get_attribute(:kernel, :os_info, :organization) =~ /Amazon/
-      Ohai::Log.debug("Plugin EC2: has_amazon_org? == true")
-      true
-    else
-      Ohai::Log.debug("Plugin EC2: has_amazon_org? == false")
-      false
-    end
-  end
-
   # a single check that combines all the various detection methods for EC2
   # @return [Boolean] Does the system appear to be on EC2
   def looks_like_ec2?
     return true if hint?("ec2")
 
     # Even if it looks like EC2 try to connect first
-    if has_ec2_xen_uuid? || has_ec2_dmi? || has_amazon_org?
+    if has_ec2_xen_uuid? || has_ec2_dmi?
       return true if can_socket_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
     end
   end

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -33,7 +33,6 @@ Ohai.plugin(:EC2) do
   include Ohai::Mixin::HttpHelper
 
   provides "ec2"
-
   depends "dmi"
 
   # look for amazon string in dmi bios data
@@ -55,14 +54,7 @@ Ohai.plugin(:EC2) do
   # this gets us detection of HVM and Paravirt hosts
   # @return [Boolean] do we have a Xen UUID or not?
   def has_ec2_xen_uuid?
-    if RUBY_PLATFORM =~ /mswin|mingw32|windows/
-      require "wmi-lite/wmi"
-      wmi = WmiLite::Wmi.new
-      if wmi.query("select uuid from Win32_ComputerSystemProduct")[0]["identifyingnumber"] =~ /^ec2/
-        Ohai::Log.debug("Plugin EC2: has_ec2_xen_uuid? == true")
-        return true
-      end
-    elsif ::File.exist?("/sys/hypervisor/uuid")
+    if ::File.exist?("/sys/hypervisor/uuid")
       if ::File.read("/sys/hypervisor/uuid") =~ /^ec2/
         Ohai::Log.debug("Plugin EC2: has_ec2_xen_uuid? == true")
         return true
@@ -72,13 +64,31 @@ Ohai.plugin(:EC2) do
     false
   end
 
+  # looks at the identifying number WMI value to see if it starts with ec2.
+  # this is actually the same value we're looking at in has_ec2_xen_uuid? on
+  # linux hosts
+  # @return [Boolean] do we have a Xen Identifying Number or not?
+  def has_ec2_identifying_number?
+    if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+    #  require "wmi-lite/wmi"
+      wmi = WmiLite::Wmi.new
+      if wmi.first_of("Win32_ComputerSystemProduct")["identifyingnumber"] =~ /^ec2/
+        Ohai::Log.debug("Plugin EC2: has_ec2_identifying_number? == true")
+        return true
+      end
+    else
+      Ohai::Log.debug("Plugin EC2: has_ec2_identifying_number? == false")
+      false
+    end
+  end
+
   # a single check that combines all the various detection methods for EC2
   # @return [Boolean] Does the system appear to be on EC2
   def looks_like_ec2?
     return true if hint?("ec2")
 
     # Even if it looks like EC2 try to connect first
-    if has_ec2_xen_uuid? || has_ec2_dmi?
+    if has_ec2_xen_uuid? || has_ec2_dmi? || has_ec2_identifying_number?
       return true if can_socket_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
     end
   end

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -24,11 +24,11 @@
 # 3. DMI data mentions amazon. This catches HVM instances in a VPC
 # 4. Kernel data mentioned Amazon. This catches Windows HVM & paravirt instances
 
-require "ohai/mixin/ec2_metadata"
-require "ohai/mixin/http_helper"
-require "base64"
-
 Ohai.plugin(:EC2) do
+  require "ohai/mixin/ec2_metadata"
+  require "ohai/mixin/http_helper"
+  require "base64"
+
   include Ohai::Mixin::Ec2Metadata
   include Ohai::Mixin::HttpHelper
 

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -342,15 +342,7 @@ describe Ohai::System, "plugin ec2" do
     end
   end
 
-  describe "with amazon kernel data" do
-    it_behaves_like "ec2"
-
-    before(:each) do
-      plugin[:kernel] = { :os_info => { :organization => "Amazon.com" } }
-    end
-  end
-
-  describe "with EC2 Xen UUID" do
+  describe "with EC2 Xen UUID on Linux" do
     it_behaves_like "ec2"
 
     before(:each) do
@@ -359,7 +351,7 @@ describe Ohai::System, "plugin ec2" do
     end
   end
 
-  describe "with non-EC2 Xen UUID" do
+  describe "with non-EC2 Xen UUID on Linux" do
     it_behaves_like "!ec2"
 
     before(:each) do

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -342,7 +342,7 @@ describe Ohai::System, "plugin ec2" do
     end
   end
 
-  describe "with EC2 Xen UUID on Linux" do
+  describe "with EC2 Xen UUID" do
     it_behaves_like "ec2"
 
     before(:each) do
@@ -351,12 +351,44 @@ describe Ohai::System, "plugin ec2" do
     end
   end
 
-  describe "with non-EC2 Xen UUID on Linux" do
+  describe "with non-EC2 Xen UUID" do
     it_behaves_like "!ec2"
 
     before(:each) do
       allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(true)
       allow(File).to receive(:read).with("/sys/hypervisor/uuid").and_return("123a0561-e4d6-8e15-d9c8-2e0e03adcde8")
+    end
+  end
+
+  describe "with EC2 Identifying Number", :windows_only do
+    it_behaves_like "ec2"
+
+    before do
+      allow_any_instance_of(WmiLite::Wmi).to receive(:first_of).and_return(
+        { "caption" => "Computer System Product",
+          "description" => "Computer System Product",
+          "identifyingnumber" => "ec2a355a-91cd-5fe8-bbfc-cc891d0bf9d6",
+          "name" => "HVM domU",
+          "skunumber" => nil,
+          "uuid" => "5A352AEC-CD91-E85F-BBFC-CC891D0BF9D6",
+          "vendor" => "Xen",
+          "version" => "4.2.amazon" })
+    end
+  end
+
+  describe "without EC2 Identifying Number", :windows_only do
+    it_behaves_like "!ec2"
+
+    before do
+      allow_any_instance_of(WmiLite::Wmi).to receive(:first_of).and_return(
+        { "caption" => "Computer System Product",
+          "description" => "Computer System Product",
+          "identifyingnumber" => "1234",
+          "name" => "HVM domU",
+          "skunumber" => nil,
+          "uuid" => "5A352AEC-CD91-E85F-BBFC-CC891D0BF9D6",
+          "vendor" => "Xen",
+          "version" => "1.2.3" })
     end
   end
 


### PR DESCRIPTION
We're currently relying on "amazon" Organization data being present in the Windows installation. This doesn't work if the VM was migrated from VMware and it doesn't work if the org builds their own AMIs that include their organization. Amazon recommends checking UUID data and we're already doing that on Linux. Lets do that on Windows. 