### PR TITLE
Fix FQDN resolution, scan all IPs associated with host for FQDN

### DIFF
--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -175,7 +175,14 @@ Ohai.plugin(:Hostname) do
     else
       #host is not in dns. optionally use:
       #C:\WINDOWS\system32\drivers\etc\hosts
-      fqdn Socket.gethostbyaddr(info.last).first
+      if info.last.length == 4
+        #If the last ip addr in the list is IPv4 use that
+        fqdn Socket.gethostbyaddr(info.last).first
+      else
+        #If the last ip addr in the list is IPv6 use the one before it
+        #This is a workaround because the underlying winsock calls only return the machine name when given an IPv6 address
+        fqdn Socket.gethostbyaddr(info[info.length - 2]).first
+      end
     end
     domain collect_domain
   end

--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -175,13 +175,17 @@ Ohai.plugin(:Hostname) do
     else
       #host is not in dns. optionally use:
       #C:\WINDOWS\system32\drivers\etc\hosts
-      if info.last.length == 4
-        #If the last ip addr in the list is IPv4 use that
-        fqdn Socket.gethostbyaddr(info.last).first
-      else
-        #If the last ip addr in the list is IPv6 use the one before it
-        #This is a workaround because the underlying winsock calls only return the machine name when given an IPv6 address
-        fqdn Socket.gethostbyaddr(info[info.length - 2]).first
+      found_fqdn = false
+      info[3..info.length].reverse.each do |addr|
+        hostent = Socket.gethostbyaddr(addr)
+        if hostent.first =~ /.+?\.(.*)/
+          fqdn hostent.first
+          found_fqdn = true
+          break
+        end
+      end
+      if !found_fqdn
+        fqdn info.first
       end
     end
     domain collect_domain


### PR DESCRIPTION
### Description

Currently on Windows Server 2016, the FQDN is being set as the machine name instead of the FQDN. This boils down to the underlying winsock library calls which, when given an IPv6 address, return only the machine name instead of the FQDN.

The work around involves calling Socket.gethostbyaddr with the IPv4 address returned in the h_addr_list instead of the IPv6 address.

### Check List

- [ x] New functionality includes tests (no new functionality)
- [x ] All tests pass
- [ x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes) (bugfix)
- [ x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco> 
