### PR TITLE
Fix the route support for IPV6 routes ending in ::

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -104,7 +104,8 @@ Ohai.plugin(:Network) do
         route_entry = Mash.new(:destination => route_dest,
                                :family => family[:name])
         %w{via scope metric proto src}.each do |k|
-          route_entry[k] = $1 if route_ending =~ /\b#{k}\s+([^\s]+)\b/
+          # http://rubular.com/r/pwTNp65VFf
+          route_entry[k] = $1 if route_ending =~ /\b#{k}\s+([^\s]+)/
         end
 
         # a sanity check, especially for Linux-VServer, OpenVZ and LXC:


### PR DESCRIPTION
Removing the ending word boundary in the regex allows is to capture the
:: endings while still properly parsing other routes. I added a rubular
comment as well so we know what this regex is actually trying to
capture.

Signed-off-by: Tim Smith <tsmith@chef.io>