### PR TITLE
Critical Plugins

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+### Critical Plugins
+
+Users can now specify a list of plugins which are `critical`. Critical plugins will cause Ohai to fail if they do not run successfully (and thus cause a Chef run using Ohai to fail). The syntax for this is:
+
+```
+ohai.critical_plugins << :Filesystem
+```
+
 # Ohai Release Notes 13.5
 
 ### Correctly detect IPv6 routes ending in ::

--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -35,6 +35,7 @@ module Ohai
       default :log_location, STDERR
       default :plugin, Ohai::PluginConfig.new { |h, k| h[k] = Ohai::PluginConfig.new }
       default :plugin_path, [ File.expand_path(File.join(File.dirname(__FILE__), "plugins")), ChefConfig::Config.platform_specific_path("/etc/chef/ohai/plugins") ]
+      default :critical_plugins, []
     end
   end
 

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -85,10 +85,12 @@ module Ohai
       include Ohai::Util::FileHelper
 
       attr_reader :data
+      attr_reader :failed
 
       def initialize(data)
         @data = data
         @has_run = false
+        @failed = false
       end
 
       def run
@@ -182,8 +184,10 @@ module Ohai
       def safe_run
         run
       rescue Ohai::Exceptions::Error => e
+        @failed = true
         raise e
       rescue => e
+        @failed = true
         Ohai::Log.debug("Plugin #{name} threw #{e.inspect}")
         e.backtrace.each { |line| Ohai::Log.debug( line ) }
       end

--- a/lib/ohai/exception.rb
+++ b/lib/ohai/exception.rb
@@ -29,5 +29,6 @@ module Ohai
     class DependencyNotFound < Error; end
     class AttributeSyntaxError < Error; end
     class PluginConfigError < Error; end
+    class CriticalPluginFailure < Error; end
   end
 end

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -23,11 +23,13 @@ require "benchmark"
 module Ohai
   class Runner
 
+    attr_reader :failed_plugins
     # safe_run: set to true if this runner will run plugins in
     # safe-mode. default false.
     def initialize(controller, safe_run = false)
       @provides_map = controller.provides_map
       @safe_run = safe_run
+      @failed_plugins = []
     end
 
     # Runs plugins and any un-run dependencies.
@@ -86,6 +88,9 @@ module Ohai
 
         if dependency_providers.empty?
           @safe_run ? next_plugin.safe_run : next_plugin.run
+          if next_plugin.failed
+            @failed_plugins << next_plugin.name
+          end
         else
           visited << next_plugin << dependency_providers.first
         end


### PR DESCRIPTION
### Description

This adds a new Ohai configuration `critical_plugins` which will cause
Ohai to exit (or `fail` if inside of Chef) if the plugins in the list do
not run successfully.

This feature only supports Ohai 7-style named plugins, not the ancient
Ohai 6-style stuff.

Tests to follow, but:

```
$ cat /home/phild/ohai.rb
ohai.critical_plugins << :Filesystem
$ ./bin/ohai -c /home/phild/ohai.rb
[2017-10-03T13:43:14-07:00] INFO: The plugin path /etc/chef/ohai/plugins does not exist. Skipping...
[2017-10-03T13:43:14-07:00] ERROR: The following plugins marked as critical failed: [:Filesystem]
```

And when I run Chef:
```
[2017-10-03T13:44:11-07:00] FATAL: RuntimeError: The following plugins marked as critical failed: [:Filesystem2]. Failing Chef run.
```

### Issues Resolved

This fixes #879.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
