### PR TITLE
Fix regression in #1047

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,12 @@ Users can now specify a list of plugins which are `critical`. Critical plugins w
 ohai.critical_plugins << :Filesystem
 ```
 
+### Filesystem now has a `allow_partial_data` configuration option
+
+The Filesystem plugin now has a `allow_partial_data` configuration option. If
+set, the filesystem will return whatever data it can even if some commands it
+ran failed.
+
 # Ohai Release Notes 13.5
 
 ### Correctly detect IPv6 routes ending in ::

--- a/lib/ohai/plugins/linux/filesystem.rb
+++ b/lib/ohai/plugins/linux/filesystem.rb
@@ -130,7 +130,10 @@ Ohai.plugin(:Filesystem) do
           fs[key][:mount] = $6
         end
       end
-    rescue Ohai::Exceptions::Exec
+    rescue Ohai::Exceptions::Exec => e
+      unless Ohai.config[:plugin][:filesystem][:allow_partial_data]
+        raise e
+      end
       Ohai::Log.warn("Plugin Filesystem: df binary is not available. Some data will not be available.")
     end
 
@@ -148,6 +151,9 @@ Ohai.plugin(:Filesystem) do
         end
       end
     rescue Ohai::Exceptions::Exec
+      unless Ohai.config[:plugin][:filesystem][:allow_partial_data]
+        raise e
+      end
       Ohai::Log.warn("Plugin Filesystem: mount binary is not available. Some data will not be available.")
     end
 

--- a/spec/unit/plugins/linux/filesystem_spec.rb
+++ b/spec/unit/plugins/linux/filesystem_spec.rb
@@ -533,8 +533,17 @@ BLKID_TYPE
   end
 
   %w{df mount}.each do |command|
-    describe "when #{command} does not exist" do
+    describe "when :allow_partial_data set, #{command} does not exist" do
+      before do
+        Ohai.config[:plugin][:filesystem][:allow_partial_data] = true
+      end
+
+      after do
+        Ohai.config[:plugin][:filesystem][:allow_partial_data] = false
+      end
+
       it "logs warning about #{command} missing" do
+        Ohai.config[:plugin][:filesystem][:allow_partial_data] = true
         allow(plugin).to receive(:shell_out).with(/#{command}/).and_raise(Ohai::Exceptions::Exec)
         expect(Ohai::Log).to receive(:warn).with("Plugin Filesystem: #{command} binary is not available. Some data will not be available.")
         plugin.run


### PR DESCRIPTION
### Description

PR #1047 allows a plugin to return partial data which may be incredibly
dangerous. It's a totally reasonable thing to want, however, so we gate
it behind a plugin config. However, the default behavior reverts to
where it was.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

### Issues Resolved

Don't lie to people about their filesystems

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
