### PR TITLE
Fix 8-stable build

### DIFF
--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -105,13 +105,8 @@ module Ohai
       end
       critical_failed = Ohai::Config.ohai[:critical_plugins] & @runner.failed_plugins
       unless critical_failed.empty?
-        msg = "The following Ohai plugins marked as critical failed: #{critical_failed}"
-        if @cli
-          Ohai::Log.error(msg)
-          exit(true)
-        else
-          fail Ohai::Exceptions::CriticalPluginFailure, "#{msg}. Failing Chef run."
-        end
+        msg = "The following Ohai plugins marked as critical failed: #{critical_failed}. Exiting."
+        raise Ohai::Exceptions::CriticalPluginFailure, msg
       end
     end
 

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -340,7 +340,7 @@ Ohai.plugin(:Park) do
 end
 EOF
 
-        with_plugin("fails.rb", <<EOF)
+      with_plugin("fails.rb", <<EOF)
 Ohai.plugin(:Fails) do
   provides 'fails'
   collect_data(:default) do
@@ -392,8 +392,7 @@ EOF
 
         it "should fail when critical plugins fail" do
           Ohai.config[:plugin_path] = [ path_to(".") ]
-          expect(Ohai::Log).to receive(:error).with(/marked as critical/)
-          ohai.all_plugins
+          expect { ohai.all_plugins }.to raise_error(Ohai::Exceptions::CriticalPluginFailure)
         end
 
       end


### PR DESCRIPTION
### Description

PR #1065 broke the 8-stable build... though Travis claimed it passed. There is
no @cli mode in 8.x, so of course that code behaves differently. Cleaning up to
fix tests.

Also, chefstyle

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
