### PR TITLE
Remove changelog generator from 8-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,5 @@ group :development do
   gem "rspec-mocks", "~> 3.0"
   gem "rspec-collection_matchers", "~> 1.0"
   gem "rspec_junit_formatter"
-  gem "github_changelog_generator", git: "https://github.com/chef/github-changelog-generator"
   gem "activesupport", "< 5.0" if RUBY_VERSION <= "2.2.2" # github_changelog_generator dep
 end

--- a/Rakefile
+++ b/Rakefile
@@ -22,14 +22,3 @@ require "rubocop/rake_task"
 RuboCop::RakeTask.new(:style) do |task|
   task.options += ["--display-cop-names", "--no-color"]
 end
-
-require "github_changelog_generator/task"
-
-GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  config.future_release = Ohai::VERSION
-  config.max_issues = 0
-  config.add_issues_wo_labels = false
-  config.enhancement_labels = "enhancement,Enhancement,New Feature,Feature".split(",")
-  config.bug_labels = "bug,Bug,Improvement,Upstream Bug".split(",")
-  config.exclude_labels = "duplicate,question,invalid,wontfix,no_changelog,Exclude From Changelog,Question,Discussion".split(",")
-end


### PR DESCRIPTION
We're not using this anymore in ohai-8 land.

Signed-off-by: Tim Smith <tsmith@chef.io>