### PR TITLE
also check for lxc-start

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:Virtualization) do
   provides "virtualization"
 
   def lxc_version_exists?
-    which("lxc-version")
+    which("lxc-version") || which("lxc-start")
   end
 
   def nova_exists?


### PR DESCRIPTION
Signed-off-by: Jose Asuncion <jeunito@gmail.com>

### Description

Adds checking of `lxc-start` to `lxc_version_exists?`

### Issues Resolved

https://github.com/chef/ohai/issues/488

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
