### PR TITLE
uptime_seconds and uptime should match on AIX

### DIFF
--- a/lib/ohai/plugins/aix/uptime.rb
+++ b/lib/ohai/plugins/aix/uptime.rb
@@ -46,7 +46,7 @@ Ohai.plugin(:Uptime) do
     end
     elapsed_seconds = ((d.to_i * 86400) + (h.to_i * 3600) + (m.to_i * 60) + s.to_i)
 
-    uptime_seconds Time.now.to_i - elapsed_seconds
+    uptime_seconds elapsed_seconds
     uptime seconds_to_human(elapsed_seconds)
   end
 end


### PR DESCRIPTION
On a given AIX system, the uptime_seconds and uptime do not match.

uptime_seconds in this case should be 4630366, not 1503190745

uptime_seconds: 1503190745
uptime: 53 days 14 hours 12 minutes 46 seconds

Therefore, our uptime_seconds is actually just the elapsed seconds on AIX, not the current time minus the elapsed seconds.

### Description

uptime_seconds and uptime match, and screens on Manage/Automate that these attributes input to remain accurate.