### PR TITLE
Updating AIX uptime_seconds to reflect elapsed seconds from boot rather than epoch

### DIFF
--- a/lib/ohai/plugins/aix/uptime.rb
+++ b/lib/ohai/plugins/aix/uptime.rb
@@ -46,7 +46,7 @@ Ohai.plugin(:Uptime) do
     end
     elapsed_seconds = ((d.to_i * 86400) + (h.to_i * 3600) + (m.to_i * 60) + s.to_i)
 
-    uptime_seconds Time.now.to_i - elapsed_seconds
+    uptime_seconds elapsed_seconds
     uptime seconds_to_human(elapsed_seconds)
   end
 end

--- a/lib/ohai/plugins/aix/uptime.rb
+++ b/lib/ohai/plugins/aix/uptime.rb
@@ -46,6 +46,7 @@ Ohai.plugin(:Uptime) do
     end
     elapsed_seconds = ((d.to_i * 86400) + (h.to_i * 3600) + (m.to_i * 60) + s.to_i)
 
+    # uptime seconds below will return the elapsed time since boot
     uptime_seconds elapsed_seconds
     uptime seconds_to_human(elapsed_seconds)
   end

--- a/spec/unit/plugins/aix/uptime_spec.rb
+++ b/spec/unit/plugins/aix/uptime_spec.rb
@@ -24,13 +24,12 @@ describe Ohai::System, "Aix plugin uptime" do
     @plugin = get_plugin("aix/uptime")
     allow(@plugin).to receive(:collect_os).and_return(:aix)
     allow(@plugin).to receive(:shell_out).and_call_original
-    allow(Time).to receive_message_chain(:now, :to_i).and_return(1504287957)
     allow(@plugin).to receive(:shell_out).with("LC_ALL=POSIX ps -o etime= -p 1").and_return(mock_shell_out(0, "1148-20:54:50", nil))
     @plugin.run
   end
 
   it "should set uptime_seconds to uptime with days" do
-    expect(@plugin[:uptime_seconds]).to eq(1405025467)
+    expect(@plugin[:uptime_seconds]).to eq(99262490)
   end
 
   it "should set uptime to a human readable date with days" do


### PR DESCRIPTION
…er than epoch

Signed-off-by: rmcleod8 <richard.mcleod@gmail.com>

### Description

Updated the value returned for `uptime_seconds` on AIX machines to show elapsed seconds from boot rather than returning the data as epoch

### Issues Resolved

https://github.com/chef/ohai/issues/1074

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
