### PR TITLE
Added systemd-nspawn virtualization detection

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -159,7 +159,7 @@ Ohai.plugin(:Virtualization) do
       end
     end
 
-    # Detect LXC/Docker
+    # Detect LXC/Docker/Nspawn
     #
     # /proc/self/cgroup will look like this inside a docker container:
     # <index #>:<subsystem>:/lxc/<hexadecimal container id>
@@ -190,6 +190,11 @@ Ohai.plugin(:Virtualization) do
         virtualization[:system] = "lxc"
         virtualization[:role] = "guest"
         virtualization[:systems][:lxc] = "guest"
+      elsif File.read("/proc/1/environ") =~ /container=systemd-nspawn/
+        Ohai::Log.debug("Plugin Virtualization: /proc/1/environ indicates nspawn container. Detecting as nspawn guest")
+        virtualization[:system] = "nspawn"
+        virtualization[:role] = "guest"
+        virtualization[:systems][:nspawn] = "guest"
       elsif lxc_version_exists? && File.read("/proc/self/cgroup") =~ %r{\d:[^:]+:/$}
         # lxc-version shouldn't be installed by default
         # Even so, it is likely we are on an LXC capable host that is not being used as such

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -631,7 +631,6 @@ CGROUP
   describe "when we are checking for systemd-nspawn" do
     it "sets nspawn guest if /proc/1/environ has nspawn string in it" do
       allow(File).to receive(:exist?).with("/proc/self/cgroup").and_return(true)
-      allow(File).to receive(:exist?).with("/proc/1/environ").and_return(false)
       one_environ = "container=systemd-nspawn_ttys=/dev/pts/0 /dev/pts/1 /dev/pts/2 /dev/pts/3".chomp
       allow(File).to receive(:read).with("/proc/1/environ").and_return(one_environ)
       allow(File).to receive(:read).with("/proc/self/cgroup").and_return("")

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -40,6 +40,7 @@ describe Ohai::System, "Linux virtualization platform" do
     allow(File).to receive(:exist?).with("/sys/devices/virtual/misc/kvm").and_return(false)
     allow(File).to receive(:exist?).with("/dev/lxd/sock").and_return(false)
     allow(File).to receive(:exist?).with("/var/lib/lxd/devlxd").and_return(false)
+    allow(File).to receive(:exist?).with("/proc/1/environ").and_return(false)
 
     # default the which wrappers to nil
     allow(plugin).to receive(:which).with("lxc-version").and_return(nil)
@@ -624,6 +625,19 @@ CGROUP
       expect(File).to receive(:exist?).with("/proc/self/cgroup").and_return(false)
       plugin.run
       expect(plugin[:virtualization]).to eq({ "systems" => {} })
+    end
+  end
+
+  describe "when we are checking for systemd-nspawn" do
+    it "sets nspawn guest if /proc/1/environ has nspawn string in it" do
+      allow(File).to receive(:exist?).with("/proc/self/cgroup").and_return(true)
+      allow(File).to receive(:exist?).with("/proc/1/environ").and_return(false)
+      one_environ = "container=systemd-nspawn_ttys=/dev/pts/0 /dev/pts/1 /dev/pts/2 /dev/pts/3".chomp
+      allow(File).to receive(:read).with("/proc/1/environ").and_return(one_environ)
+      allow(File).to receive(:read).with("/proc/self/cgroup").and_return('')
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("nspawn")
+      expect(plugin[:virtualization][:role]).to eq("guest")
     end
   end
 

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -634,7 +634,7 @@ CGROUP
       allow(File).to receive(:exist?).with("/proc/1/environ").and_return(false)
       one_environ = "container=systemd-nspawn_ttys=/dev/pts/0 /dev/pts/1 /dev/pts/2 /dev/pts/3".chomp
       allow(File).to receive(:read).with("/proc/1/environ").and_return(one_environ)
-      allow(File).to receive(:read).with("/proc/self/cgroup").and_return('')
+      allow(File).to receive(:read).with("/proc/self/cgroup").and_return("")
       plugin.run
       expect(plugin[:virtualization][:system]).to eq("nspawn")
       expect(plugin[:virtualization][:role]).to eq("guest")


### PR DESCRIPTION
### Description

`node['virtualization']` should detect when running in a `systemd-nspawn` container.

Previously it would return this, which made it very difficult to tell if running inside an nspawn container:
```
root@archon:~# ohai | jq .virtualization
{
  "systems": {
    "kvm": "host"
  },
  "system": "kvm",
  "role": "host"
}
```

Now it returns this:
```
root@archon:~# /usr/local/bin/ohai | jq .virtualization
[2017-10-29T14:34:20-07:00] INFO: The plugin path /etc/chef/ohai/plugins does not exist. Skipping...
{
  "systems": {
    "kvm": "host",
    "nspawn": "guest"
  },
  "system": "nspawn",
  "role": "guest"
}
```

The behavior on a systemd host is unchanged:
```
zeal@drcid ~/dev/ohai $ sudo ohai | jq .virtualization
[2017-10-29T15:11:09-07:00] INFO: The plugin path /etc/chef/ohai/plugins does not exist. Skipping...
{
  "systems": {
    "kvm": "host"
  },
  "system": "kvm",
  "role": "host"
}
```

I consider this a bug, since it's incorrectly reporting the host/guest status, so I didn't update the release notes. Let me know if you want me to do that as well, however.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
