### PR TITLE
Detect new Amazon hypervisor used by the C5 instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
     - 8-stable
 
 before_install:
-  - gem update --system
+  #  - gem update --system
   - gem --version
   - rvm @global do gem uninstall bundler -a -x -I || true
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
     - 8-stable
 
 before_install:
-  #  - gem update --system
   - gem --version
   - rvm @global do gem uninstall bundler -a -x -I || true
   - gem install bundler

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%
   - ruby --version
-    #  - gem update --system
   - gem --version
   - gem uninstall bundler -a -x -I
   - gem install bundler --quiet --no-ri --no-rdoc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ platform:
 environment:
   matrix:
     - ruby_version: "23"
+    - ruby_version: "24"  
 
 clone_folder: c:\projects\ohai
 clone_depth: 1
@@ -19,7 +20,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%
   - ruby --version
-  - gem update --system
+    #  - gem update --system
   - gem --version
   - gem uninstall bundler -a -x -I
   - gem install bundler --quiet --no-ri --no-rdoc

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -28,6 +28,8 @@ describe Ohai::System, "plugin ec2" do
   before(:each) do
     allow(plugin).to receive(:hint?).with("ec2").and_return(false)
     allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(false)
+    allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_vendor").and_return(false)
+    allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_version").and_return(false)
   end
 
   shared_examples_for "!ec2" do
@@ -332,11 +334,39 @@ describe Ohai::System, "plugin ec2" do
     end
   end # shared examples for ec2
 
-  describe "with ec2 dmi data" do
+  describe "with amazon dmi bios version data" do
     it_behaves_like "ec2"
 
     before(:each) do
-      plugin[:dmi] = { :bios => { :all_records => [ { :Version => "4.2.amazon" } ] } }
+      allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_version").and_return(true)
+      allow(File).to receive(:read).with("/sys/class/dmi/id/bios_version").and_return("4.2.amazon\n")
+    end
+  end
+
+  describe "with non-amazon dmi bios version data" do
+    it_behaves_like "!ec2"
+
+    before(:each) do
+      allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_version").and_return(true)
+      allow(File).to receive(:read).with("/sys/class/dmi/id/bios_version").and_return("1.0\n")
+    end
+  end
+
+  describe "with amazon dmi bios vendor data" do
+    it_behaves_like "ec2"
+
+    before(:each) do
+      allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_vendor").and_return(true)
+      allow(File).to receive(:read).with("/sys/class/dmi/id/bios_vendor").and_return("Amazon EC2\n")
+    end
+  end
+
+  describe "with non-amazon dmi bios vendor data" do
+    it_behaves_like "!ec2"
+
+    before(:each) do
+      allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_vendor").and_return(true)
+      allow(File).to receive(:read).with("/sys/class/dmi/id/bios_vendor").and_return("Xen\n")
     end
   end
 
@@ -345,7 +375,7 @@ describe Ohai::System, "plugin ec2" do
 
     before(:each) do
       allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(true)
-      allow(File).to receive(:read).with("/sys/hypervisor/uuid").and_return("ec2a0561-e4d6-8e15-d9c8-2e0e03adcde8")
+      allow(File).to receive(:read).with("/sys/hypervisor/uuid").and_return("ec2a0561-e4d6-8e15-d9c8-2e0e03adcde8\n")
     end
   end
 
@@ -354,7 +384,7 @@ describe Ohai::System, "plugin ec2" do
 
     before(:each) do
       allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(true)
-      allow(File).to receive(:read).with("/sys/hypervisor/uuid").and_return("123a0561-e4d6-8e15-d9c8-2e0e03adcde8")
+      allow(File).to receive(:read).with("/sys/hypervisor/uuid").and_return("123a0561-e4d6-8e15-d9c8-2e0e03adcde8\n")
     end
   end
 


### PR DESCRIPTION
C5 instances are not Xen based. They use Amazon's own hypervisor so our existing detection methods fail. I suspect we could probably get rid of the old DMI detection, but I get nervous removing detection logic. This checks the bios vendor DMI data. I also removed the depedency on  the DMI plugin since a lot of systems don't have dmidecode. This will catch far more systems.

Signed-off-by: Tim Smith <tsmith@chef.io>