### PR TITLE
[mdadm] Support arrays more than 10 disks

### DIFF
--- a/lib/ohai/plugins/linux/mdadm.rb
+++ b/lib/ohai/plugins/linux/mdadm.rb
@@ -67,7 +67,7 @@ Ohai.plugin(:Mdadm) do
           # drop the 'raid' too
 
           members.shift unless members.empty?
-          devices[device] = members.map { |s| s.match(/(.+)\[\d\]/)[1] }
+          devices[device] = members.map { |s| s.match(/(.+)\[\d+\]/)[1] }
         end
       end
 

--- a/spec/unit/plugins/linux/mdadm_spec.rb
+++ b/spec/unit/plugins/linux/mdadm_spec.rb
@@ -106,6 +106,20 @@ MD
       )
     end
 
+    it "should detect member devices even if there are multi-digit numbers" do
+      new_mdstat = double("/proc/mdstat2")
+      allow(new_mdstat).to receive(:each).
+        and_yield("Personalities : [raid1] [raid6] [raid5] [raid4] [linear] [multipath] [raid0] [raid10]").
+        and_yield("md0 : active raid10 sdj[2010] sdi[99] sdh[5] sdg[4] sdf[3] sde[2] sdd[1] sdc[0]").
+        and_yield("      2929893888 blocks super 1.2 256K chunks 2 near-copies [6/6] [UUUUUU]")
+      allow(File).to receive(:open).with("/proc/mdstat").and_return(new_mdstat)
+
+      @plugin.run
+      expect(@plugin[:mdadm][:md0][:members].sort).to eq(
+        %w{sdc sdd sde sdf sdg sdh sdi sdj}
+      )
+    end
+
     it "should detect member devices even if mdstat has extra entries" do
       new_mdstat = double("/proc/mdstat2")
       allow(new_mdstat).to receive(:each).


### PR DESCRIPTION
### Description

Fix mdadm not handling arrays with > 10 members

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
