### PR TITLE
Resolve rubygems failures + update ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,9 @@ rvm:
   - 2.4.2
   - ruby-head
 
-allow_failures:
-  - rvm: ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 
 script:
   - bundle exec chefstyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
     - 8-stable
 
 before_install:
-  - gem update --system
   - gem --version
   - rvm @global do gem uninstall bundler -a -x -I
   - gem install bundler -v 1.14.6 # bundler 1.15 times out resolving deps on Ruby 2.1
@@ -18,9 +17,9 @@ before_install:
   - rm -f .bundle/config
 rvm:
   - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
   - ruby-head
 
 allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
 
 before_install:
   - gem --version
-  - rvm @global do gem uninstall bundler -a -x -I
+  - rvm @global do gem uninstall bundler -a -x -I || true
   - gem install bundler -v 1.14.6 # bundler 1.15 times out resolving deps on Ruby 2.1
   - bundle --version
   - rm -f .bundle/config

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
     - ruby_version: "21"
     - ruby_version: "22"
     - ruby_version: "23"
+    - ruby_version: "24"
 
 clone_folder: c:\projects\ohai
 clone_depth: 1
@@ -21,7 +22,6 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%
   - ruby --version
-  - gem update --system
   - gem --version
   - gem uninstall bundler -a -x -I
   - gem install bundler --quiet --no-ri --no-rdoc


### PR DESCRIPTION
Test on Ruby 2.4 in appveyor
Use the latest ruby releases in Travis
Don't update rubygems since 2.7.2 is busted

Signed-off-by: Tim Smith <tsmith@chef.io>