### PR TITLE
[mdadm] Handle journal and spare devices properly

### DIFF
--- a/spec/unit/plugins/linux/mdadm_spec.rb
+++ b/spec/unit/plugins/linux/mdadm_spec.rb
@@ -142,8 +142,29 @@ MD
       allow(File).to receive(:open).with("/proc/mdstat").and_return(new_mdstat)
 
       @plugin.run
-      expect(@plugin[:mdadm][:md0][:members].sort).to eq(%w{nvme2n1p3})
+      expect(@plugin[:mdadm][:md0][:spares]).to eq(%w{nvme2n1p3})
+    end
+
+    it "should report journal devices" do
+      new_mdstat = double("/proc/mdstat_journal")
+      allow(new_mdstat).to receive(:each).
+        and_yield("Personalies : [raid6]").
+        and_yield("md0 : active (somecraphere) <morestuff raid6 sdbc1[7] sdd1[6] sde1[5] sdd1[4] sde1[3] sdf1[2] sdg1[1] nvme2n1p3[0](J)")
+      allow(File).to receive(:open).with("/proc/mdstat").and_return(new_mdstat)
+
+      @plugin.run
+      expect(@plugin[:mdadm][:md0][:journal]).to eq("nvme2n1p3")
+    end
+
+    it "should report spare devices" do
+      new_mdstat = double("/proc/mdstat_spare")
+      allow(new_mdstat).to receive(:each).
+        and_yield("Personalies : [raid6]").
+        and_yield("md0 : active (somecraphere) <morestuff raid6 sdbc1[7] sdd1[6] sde1[5] sdd1[4] sde1[3] sdf1[2] sdg1[1] sdh1[0](S)")
+      allow(File).to receive(:open).with("/proc/mdstat").and_return(new_mdstat)
+
+      @plugin.run
+      expect(@plugin[:mdadm][:md0][:spares]).to eq(%w{sdh1})
     end
   end
-
 end


### PR DESCRIPTION
### Description

Journal and spare devices are important to report clearly. This puts
them in their own arrays.

I'd like to backport this to 12.x - but it's unclear here what
backwards compat here is.

I *could* put *all* devices into `members` and then also specify special
members in their own list... but prior to me fixing this plugin a few
months, ago, spares and journal wouldn't have been reported anyway...
and it is probably incorrect to report them as normal members... so this
feels like a further fix on a previous fix, so I've opted for just
fixing it. However, let me know how you guys feel.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

### Issues Resolved

Failing to be able to handle journal or spare devices properly - especially bad for journal devices.

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
