### PR TITLE
Remove the rubygems require in the main app

### DIFF
--- a/bin/ohai
+++ b/bin/ohai
@@ -19,17 +19,8 @@
 # limitations under the License.
 #
 
-begin
-  # if we're in a source code checkout, we want to run the code from that.
-  # have to do this *after* rubygems is loaded.
-  $:.unshift File.expand_path("../../lib", __FILE__)
-  require "ohai/application"
-rescue LoadError
-  if missing_rubygems
-    STDERR.puts "rubygems previously failed to load - is it installed?"
-  end
-
-  raise
-end
+# if we're in a source code checkout, we want to run the code from that.
+$:.unshift File.expand_path("../../lib", __FILE__)
+require "ohai/application"
 
 Ohai::Application.new.run

--- a/bin/ohai
+++ b/bin/ohai
@@ -20,12 +20,6 @@
 #
 
 begin
-  require "rubygems"
-rescue LoadError
-  # must be debian! ;)
-  missing_rubygems = true
-end
-begin
   # if we're in a source code checkout, we want to run the code from that.
   # have to do this *after* rubygems is loaded.
   $:.unshift File.expand_path("../../lib", __FILE__)


### PR DESCRIPTION
This is Ruby 1.8 code and also pretty heavily assumes the the user is installing into a system (debian) ruby install. There's no need for any of this with modern ruby releases.

Signed-off-by: Tim Smith <tsmith@chef.io>