### PR TITLE
[mdadm] Handle journal and spare devices properly - Ohai 8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,6 @@ install:
   - echo %PATH%
   - ruby --version
   - gem --version
-  - gem uninstall bundler -a -x -I
-  - gem install bundler --quiet --no-ri --no-rdoc
   - bundler --version
 
 build_script:

--- a/spec/unit/plugins/linux/mdadm_spec.rb
+++ b/spec/unit/plugins/linux/mdadm_spec.rb
@@ -142,8 +142,29 @@ MD
       allow(File).to receive(:open).with("/proc/mdstat").and_return(new_mdstat)
 
       @plugin.run
-      expect(@plugin[:mdadm][:md0][:members].sort).to eq(%w{nvme2n1p3})
+      expect(@plugin[:mdadm][:md0][:spares]).to eq(%w{nvme2n1p3})
+    end
+
+    it "should report journal devices" do
+      new_mdstat = double("/proc/mdstat_journal")
+      allow(new_mdstat).to receive(:each).
+        and_yield("Personalies : [raid6]").
+        and_yield("md0 : active (somecraphere) <morestuff raid6 sdbc1[7] sdd1[6] sde1[5] sdd1[4] sde1[3] sdf1[2] sdg1[1] nvme2n1p3[0](J)")
+      allow(File).to receive(:open).with("/proc/mdstat").and_return(new_mdstat)
+
+      @plugin.run
+      expect(@plugin[:mdadm][:md0][:journal]).to eq("nvme2n1p3")
+    end
+
+    it "should report spare devices" do
+      new_mdstat = double("/proc/mdstat_spare")
+      allow(new_mdstat).to receive(:each).
+        and_yield("Personalies : [raid6]").
+        and_yield("md0 : active (somecraphere) <morestuff raid6 sdbc1[7] sdd1[6] sde1[5] sdd1[4] sde1[3] sdf1[2] sdg1[1] sdh1[0](S)")
+      allow(File).to receive(:open).with("/proc/mdstat").and_return(new_mdstat)
+
+      @plugin.run
+      expect(@plugin[:mdadm][:md0][:spares]).to eq(%w{sdh1})
     end
   end
-
 end


### PR DESCRIPTION
### Description

This is a backport of #1094.

Journal and spare devices are important to report clearly. This puts
them in their own arrays.

See #1094 for discussion of this being backported.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

### Issues Resolved

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
