### PR TITLE
[linux/network] Tunnel info

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -212,6 +212,31 @@ Ohai.plugin(:Network) do
         net_counters[tmp_int] = Mash.new unless net_counters[tmp_int]
       end
 
+      if line =~ /^\s+(ip6tnl|ipip)/
+        iface[tmp_int][:tunnel_info] = {}
+        words = line.split
+        words.each_with_index do |word, index|
+          case word
+          when "external"
+            iface[tmp_int][:tunnel_info][word] = true
+          when "any", "ipip6", "ip6ip6"
+            iface[tmp_int][:tunnel_info][:proto] = word
+          when "remote",
+               "local",
+               "encaplimit",
+               "hoplimit",
+               "tclass",
+               "flowlabel",
+               "addrgenmode",
+               "numtxqueues",
+               "numrxqueues",
+               "gso_max_size",
+               "gso_max_segs"
+            iface[tmp_int][:tunnel_info][word] = words[index + 1]
+          end
+        end
+      end
+
       if line =~ /(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)/
         int = on_rx ? :rx : :tx
         net_counters[tmp_int][int] = Mash.new unless net_counters[tmp_int][int]


### PR DESCRIPTION
### Description

This gathers extra information on tunnel devices. Unfortunately iproute2 is a
little inconsistent as to how it prints these out, some are booleans some are
key values, but there's no way to tell them apart other than to know, so I parse
the ones I know about (from reading the source), and ignore anything else.

Note that I didn't add any ifconfig support to the tests. This is for a few
reasons:

1. the output in the tests from ifconfig is ancient, ifconfig on linux doesn't
look like that anymore, it looks like this:

```
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.1.1.2  netmask 255.255.255.0  broadcast 10.1.1.255
        inet6 2601:645:c001:56bb::2  prefixlen 64  scopeid 0x0<global>
        inet6 fe80::52e5:49ff:fe38:d761  prefixlen 64  scopeid 0x20<link>
        ether 50:e5:49:38:d7:61  txqueuelen 1000  (Ethernet)
        RX packets 203501353  bytes 98738916585 (91.9 GiB)
        RX errors 0  dropped 559  overruns 0  frame 0
        TX packets 1035989265  bytes 1458478887585 (1.3 TiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

And I couldn't find a machine old enough to generate the type of output in the
tests *and* have modern ip6tunnel drivers on it. So don't ask. :)

2. Only iproute2 shows the extra tunnel info anyway, so it's not really useful
to do have the interface in the ifconfig output.

Note I will backport this to Ohai 8 after this is merged.

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
