### PR TITLE
Ohai 14: Use SHA256 for the shard seed for FIPS compliance

### DIFF
--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -17,7 +17,7 @@
 #
 
 Ohai.plugin(:ShardSeed) do
-  require "digest/md5"
+  require "digest/sha2"
   depends "hostname", "dmi", "machine_id", "machinename"
   provides "shard_seed"
 
@@ -52,7 +52,7 @@ Ohai.plugin(:ShardSeed) do
                 yield(src)
               end
     end
-    shard_seed Digest::MD5.hexdigest(data)[0...7].to_i(16)
+    shard_seed Digest::SHA256.hexdigest(data)[0...7].to_i(16)
   end
 
   collect_data(:darwin) do

--- a/spec/unit/plugins/shard_spec.rb
+++ b/spec/unit/plugins/shard_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "digest/md5"
+require "digest/sha2"
 require_relative "../../spec_helper.rb"
 
 describe Ohai::System, "shard plugin" do
@@ -40,7 +40,7 @@ describe Ohai::System, "shard plugin" do
 
   it "should provide a shard with a default-safe set of sources" do
     plugin.run
-    result = Digest::MD5.hexdigest(
+    result = Digest::SHA256.hexdigest(
       "#{machinename}#{serial}#{uuid}"
     )[0...7].to_i(16)
     expect(plugin[:shard_seed]).to eq(result)
@@ -49,7 +49,7 @@ describe Ohai::System, "shard plugin" do
   it "should provide a shard with a configured source" do
     Ohai.config[:plugin][:shard_seed][:sources] = [:fqdn]
     plugin.run
-    result = Digest::MD5.hexdigest(fqdn)[0...7].to_i(16)
+    result = Digest::SHA256.hexdigest(fqdn)[0...7].to_i(16)
     expect(plugin[:shard_seed]).to eq(result)
   end
 


### PR DESCRIPTION
MD5 is not allowed in FIPS140/180. We can use SHA256 and then this
passes FIPS and all the government users can use this plugin. Yes I
realize we just trim the value anyways. Still can't use it in FIPS.

Signed-off-by: Tim Smith <tsmith@chef.io>