### PR TITLE
Add a plugin to provide PCI bus information using `lspci`.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### LsPci Plugin
+
+The new LsPci plugin provides a `node[:pci]` hash with information about the PCI bus based on `lspci`. Only runs on Linux.
+
 # Ohai Release Notes 13.7
 
 ### EC2 C5 Detection

--- a/lib/ohai/plugins/linux/lspci.rb
+++ b/lib/ohai/plugins/linux/lspci.rb
@@ -1,0 +1,76 @@
+#
+# Author:: Joerg Herzinger <joerg.herzinger@oiml.at>
+# Author:: Phil Dibowitz <phil@ipom.com>
+# Copyright:: Copyright (c) 2011 GLOBAL 2000/Friends of the Earth Austria
+# Copyright:: Copyright (c) 2017 Facebook, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Ohai.plugin(:Lspci) do
+  depends "platform"
+  provides "pci"
+
+  collect_data(:linux) do
+    devices = Mash.new
+    lspci = shell_out("lspci -vnnmk")
+
+    h = /[0-9a-fA-F]/ #any hex digit
+    hh = /#{h}#{h}/ #any 2 hex digits
+    hhhh = /#{h}#{h}#{h}#{h}/ #any 4 hex digits
+
+    d_id = String.new #This identifies our pci devices
+
+    def standard_form(devices, d_id, hhhh, tag, line)
+      tmp = line.scan(/(.*)\s\[(#{hhhh})\]/)[0]
+      devices[d_id]["#{tag}_name"] = tmp[0]
+      devices[d_id]["#{tag}_id"] = tmp[1]
+    end
+
+    def standard_array(devices, d_id, tag, line)
+      if !devices[d_id][tag].kind_of?(Array)
+        devices[d_id][tag] = [line]
+      else
+        devices[d_id][tag].push(line)
+      end
+    end
+
+    lspci.stdout.split("\n").each do |line|
+      dev = line.scan(/^(.*):\s(.*)$/)[0]
+      next if dev.nil?
+      case dev[0]
+      when "Device" # There are two different Device tags
+        if tmp = dev[1].match(/(#{hh}:#{hh}.#{h})/)
+          # We have a device id
+          d_id = tmp[0] # From now on we will need this id
+          devices[d_id] = Mash.new
+        else
+          standard_form(devices, d_id, hhhh, "device", dev[1])
+        end
+      when "Class"
+        standard_form(devices, d_id, hhhh, "class", dev[1])
+      when "Vendor"
+        standard_form(devices, d_id, hhhh, "vendor", dev[1])
+      when "Driver"
+        standard_array(devices, d_id, "driver", dev[1])
+      when "Module"
+        standard_array(devices, d_id, "module", dev[1])
+      when "SDevice"
+        standard_form(devices, d_id, hhhh, "sdevice", dev[1])
+      else
+      end
+    end
+
+    pci devices
+  end
+end

--- a/spec/unit/plugins/linux/lspci_spec.rb
+++ b/spec/unit/plugins/linux/lspci_spec.rb
@@ -1,0 +1,131 @@
+#
+# Author:: Phil Dibowitz <phil@ipom.com>
+# Copyright:: Copyright (c) 2017 Facebook, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../spec_helper.rb"
+
+describe Ohai::System, "Linux lspci plugin" do
+  let (:plugin) { get_plugin("linux/lspci") }
+
+  before(:each) do
+    @stdout = <<LSPCI
+Device:	00:1f.3
+Class:	Audio device [0403]
+Vendor:	Intel Corporation [8086]
+Device:	Sunrise Point-LP HD Audio [9d71]
+SVendor:	Lenovo [17aa]
+SDevice:	Sunrise Point-LP HD Audio [224e]
+Rev:	21
+Driver:	snd_hda_intel
+Module:	snd_hda_intel
+Module:	snd_soc_skl
+
+Device:	00:1f.4
+Class:	SMBus [0c05]
+Vendor:	Intel Corporation [8086]
+Device:	Sunrise Point-LP SMBus [9d23]
+SVendor:	Lenovo [17aa]
+SDevice:	Sunrise Point-LP SMBus [224e]
+Rev:	21
+Driver:	i801_smbus
+Module:	i2c_i801
+
+Device:	00:1f.6
+Class:	Ethernet controller [0200]
+Vendor:	Intel Corporation [8086]
+Device:	Ethernet Connection (4) I219-LM [15d7]
+SVendor:	Lenovo [17aa]
+SDevice:	Ethernet Connection (4) I219-LM [224e]
+Rev:	21
+Driver:	e1000e
+Module:	e1000e
+
+Device:	02:00.0
+Class:	Unassigned class [ff00]
+Vendor:	Realtek Semiconductor Co., Ltd. [10ec]
+Device:	RTS525A PCI Express Card Reader [525a]
+SVendor:	Lenovo [17aa]
+SDevice:	RTS525A PCI Express Card Reader [224e]
+Rev:	01
+Driver:	rtsx_pci
+Module:	rtsx_pci
+
+Device:	04:00.0
+Class:	Network controller [0280]
+Vendor:	Intel Corporation [8086]
+Device:	Wireless 8265 / 8275 [24fd]
+SVendor:	Intel Corporation [8086]
+SDevice:	Wireless 8265 / 8275 [0130]
+Rev:	88
+Driver:	iwlwifi
+Module:	iwlwifi
+
+Device:	05:00.0
+Class:	Non-Volatile memory controller [0108]
+Vendor:	Toshiba America Info Systems [1179]
+Device:	Device [0115]
+SVendor:	Toshiba America Info Systems [1179]
+SDevice:	Device [0001]
+Rev:	01
+ProgIf:	02
+Driver:	nvme
+Module:	nvme
+NUMANode:	0
+LSPCI
+    allow(plugin).to receive(:shell_out).with("lspci -vnnmk").and_return(
+      mock_shell_out(0, @stdout, ""))
+  end
+
+  describe "when gathering data from lspci" do
+    it "lists all devices" do
+      plugin.run
+      expect(plugin[:pci].keys).to eq(
+        ["00:1f.3", "00:1f.4", "00:1f.6", "02:00.0", "04:00.0", "05:00.0"]
+      )
+    end
+
+    it "parses out device name vs id" do
+      plugin.run
+      expect(plugin[:pci]["04:00.0"]["device_name"]).to eq("Wireless 8265 / 8275")
+      expect(plugin[:pci]["04:00.0"]["device_id"]).to eq("24fd")
+    end
+
+    it "parses out sdevice name vs id" do
+      plugin.run
+      expect(plugin[:pci]["04:00.0"]["sdevice_name"]).to eq("Wireless 8265 / 8275")
+      expect(plugin[:pci]["04:00.0"]["sdevice_id"]).to eq("0130")
+    end
+
+    it "parses out class name vs id" do
+      plugin.run
+      expect(plugin[:pci]["04:00.0"]["class_name"]).to eq("Network controller")
+      expect(plugin[:pci]["04:00.0"]["class_id"]).to eq("0280")
+    end
+
+    it "parses out vendor name vs id" do
+      plugin.run
+      expect(plugin[:pci]["04:00.0"]["vendor_name"]).to eq("Intel Corporation")
+      expect(plugin[:pci]["04:00.0"]["vendor_id"]).to eq("8086")
+    end
+
+    it "provides drivers and modules" do
+      plugin.run
+      expect(plugin[:pci]["04:00.0"]["driver"]).to eq(["iwlwifi"])
+      expect(plugin[:pci]["04:00.0"]["module"]).to eq(["iwlwifi"])
+    end
+  end
+end


### PR DESCRIPTION
### Description

This is based on an original plugin from:
https://github.com/GLOBAL2000/chef-ohai-plugins/

With modifications from the fork here:
https://github.com/GLOBAL2000/chef-ohai-plugins/

Signed-off-by: Phil Dibowitz <phil@ipom.com>

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
