### PR TITLE
Ohai 14: Require Ruby 2.4 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
   - bundle --version
   - rm -f .bundle/config
 rvm:
-  - 2.3.5
   - 2.4.2
   - 2.5.0
   - ruby-head

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://docs.chef.io/ohai.html"
 
-  s.required_ruby_version = ">= 2.3"
+  s.required_ruby_version = ">= 2.4"
 
   s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "ffi-yajl", "~> 2.2"


### PR DESCRIPTION
Support the last 2 major releases.

Signed-off-by: Tim Smith <tsmith@chef.io>