### PR TITLE
Bump the version to 14.0.0 for chef/chef

### DIFF
--- a/lib/ohai/version.rb
+++ b/lib/ohai/version.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2017, Chef Software Inc.
+# Copyright:: Copyright (c) 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,5 +18,5 @@
 
 module Ohai
   OHAI_ROOT = File.expand_path(File.dirname(__FILE__))
-  VERSION = "13.7.1"
+  VERSION = "14.0.0"
 end


### PR DESCRIPTION
We will tag / ship as 14.0 later, but this allows us to pin to 14.0 in
chef/chef and consume from master.

Signed-off-by: Tim Smith <tsmith@chef.io>