### PR TITLE
Simplify path logic by requiring chef-config 12.8+

### DIFF
--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -46,12 +46,7 @@ module Ohai
 
         Ohai::Log.debug("Searching for Ohai plugins in #{plugin_dir}")
 
-        # escape_glob_dir does not exist in 12.7 or below
-        if ChefConfig::PathHelper.respond_to?(:escape_glob_dir)
-          escaped = ChefConfig::PathHelper.escape_glob_dir(plugin_dir)
-        else
-          escaped = ChefConfig::PathHelper.escape_glob(plugin_dir)
-        end
+        escaped = ChefConfig::PathHelper.escape_glob_dir(plugin_dir)
         Dir[File.join(escaped, "**", "*.rb")].map do |file|
           new(file, plugin_dir)
         end

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ipaddress"
   s.add_dependency "wmi-lite", "~> 1.0"
   s.add_dependency "ffi", "~> 1.9"
-  s.add_dependency "chef-config", ">= 12.5.0.alpha.1", "< 15"
+  s.add_dependency "chef-config", ">= 12.8", "< 15"
   # Note for ohai developers: If chef-config causes you grief, try:
   #     bundle install --with development
   # this should work as long as chef is a development dependency in Gemfile.


### PR DESCRIPTION
We can safely assume chef-config 12.8+ now.

Signed-off-by: Tim Smith <tsmith@chef.io>