### PR TITLE
Fix Expeditor config as to publish gems and manage changelog

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -4,6 +4,9 @@
 slack:
   notify_channel: chef-notify
 
+rubygems:
+  - ohai
+
 github:
   # The tag format to use (e.g. v1.0.0)
   version_tag_format: "v{{version}}"
@@ -19,6 +22,11 @@ github:
         version_constraint: 13.*
     - 8-stable:
         version_constraint: 8.*
+
+promote:
+  action:
+    - built_in:publish_rubygems
+    - built_in:rollover_changelog
 
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+<!-- latest_release -->
+<!-- latest_release -->
+
+<!-- release_rollup -->
+<!-- release_rollup -->
+
+<!-- latest_stable_release -->
 ## [v13.7.1](https://github.com/chef/ohai/tree/v13.7.1) (2018-01-10)
 
 [Full Changelog](https://github.com/chef/ohai/compare/v13.7.0...v13.7.1)
@@ -7,6 +14,7 @@
 - Fix docker detection when running on new Docker for mac releases
 - [linux/network] Tunnel information
 - Add a plugin to provide PCI bus information using `lspci`
+<!-- latest_stable_release -->
 
 ## [v13.7.0](https://github.com/chef/ohai/tree/v13.7.0) (2017-12-04)
 


### PR DESCRIPTION
### Description

* Add the missing `rubygems` config so Expeditor knows which rubygems to build
* Add missing changelog comment block hooks so Expeditor can manage the Changelog

### Issues Resolved

* No Gem builds
* No Changelog management

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
