### PR TITLE
adds whitespace stripping for the shellout stdout

### DIFF
--- a/lib/ohai/plugins/aix/uptime.rb
+++ b/lib/ohai/plugins/aix/uptime.rb
@@ -27,7 +27,7 @@ Ohai.plugin(:Uptime) do
     # 1148-20:54:50
     # This reads as 1148 days, 20 hours, 54 minutes, 50 seconds since the process was started (elapsed)
     # who -b does not return the YEAR, so we need something more concrete
-    so = shell_out("LC_ALL=POSIX ps -o etime= -p 1").stdout
+    so = shell_out("LC_ALL=POSIX ps -o etime= -p 1").stdout.strip
 
     # Here we'll check our shell_out for a dash, which indicates there is a # of days involved
     # We'll chunk off the days, hours (where applicable), minutes, seconds into seperate vars

--- a/spec/unit/plugins/aix/uptime_spec.rb
+++ b/spec/unit/plugins/aix/uptime_spec.rb
@@ -24,15 +24,19 @@ describe Ohai::System, "Aix plugin uptime" do
     @plugin = get_plugin("aix/uptime")
     allow(@plugin).to receive(:collect_os).and_return(:aix)
     allow(@plugin).to receive(:shell_out).and_call_original
+  end
+
+  it "should set uptime_seconds and uptime standard case" do
     allow(@plugin).to receive(:shell_out).with("LC_ALL=POSIX ps -o etime= -p 1").and_return(mock_shell_out(0, "1148-20:54:50", nil))
     @plugin.run
-  end
-
-  it "should set uptime_seconds to uptime with days" do
     expect(@plugin[:uptime_seconds]).to eq(99262490)
+    expect(@plugin[:uptime]).to eq("1148 days 20 hours 54 minutes 50 seconds")
   end
 
-  it "should set uptime to a human readable date with days" do
-    expect(@plugin[:uptime]).to eq("1148 days 20 hours 54 minutes 50 seconds")
+  it "should set uptime_seconds and uptime in the whitespace case" do
+    allow(@plugin).to receive(:shell_out).with("LC_ALL=POSIX ps -o etime= -p 1").and_return(mock_shell_out(0, " 2-20:54:50", nil))
+    @plugin.run
+    expect(@plugin[:uptime_seconds]).to eq(248090)
+    expect(@plugin[:uptime]).to eq("2 days 20 hours 54 minutes 50 seconds")
   end
 end


### PR DESCRIPTION
### Description

Adds whitespace stripping for shellout stdout

### Issues Resolved

turns out, ibm intentionally adds whitespace to the output here when the days number is 1-9.

adding .strip cleans up the stdout so the case regex can properly evaluate the data.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
