### PR TITLE
Support optional plugins

### DIFF
--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -36,6 +36,10 @@ module Ohai
       default :plugin, Ohai::PluginConfig.new { |h, k| h[k] = Ohai::PluginConfig.new }
       default :plugin_path, [ File.expand_path(File.join(File.dirname(__FILE__), "plugins")), ChefConfig::Config.platform_specific_path("/etc/chef/ohai/plugins") ]
       default :critical_plugins, []
+      # causes all optional plugins to be run.
+      default :run_all_plugins, false
+      # optional plugins are the set of plugins that are marked optional but you wish to run.
+      default :optional_plugins, []
     end
   end
 

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -32,15 +32,8 @@ module Ohai
       name.is_a?(Symbol) && name.to_s.match(/^[^A-Z]|_/).nil?
     end
 
-    # dealing with ruby 1.8
-    if Module.method(:const_defined?).arity == 1
-      def self.strict_const_defined?(const)
-        const_defined?(const)
-      end
-    else
-      def self.strict_const_defined?(const)
-        const_defined?(const, false)
-      end
+    def self.strict_const_defined?(const)
+      const_defined?(const, false)
     end
   end
 

--- a/lib/ohai/dsl/plugin/versionvii.rb
+++ b/lib/ohai/dsl/plugin/versionvii.rb
@@ -66,6 +66,14 @@ module Ohai
           end
         end
 
+        def self.optional(opt = true)
+          @optional = opt
+        end
+
+        def self.optional?
+          !!@optional
+        end
+
         def self.collect_data(platform = :default, *other_platforms, &block)
           [platform, other_platforms].flatten.each do |plat|
             if data_collector.has_key?(plat)
@@ -91,6 +99,10 @@ module Ohai
           else
             Ohai::Log.debug("Plugin #{name}: No data to collect. Skipping...")
           end
+        end
+
+        def optional?
+          self.class.optional?
         end
 
         def provides(*paths)

--- a/lib/ohai/plugins/linux/lspci.rb
+++ b/lib/ohai/plugins/linux/lspci.rb
@@ -20,6 +20,7 @@
 Ohai.plugin(:Lspci) do
   depends "platform"
   provides "pci"
+  optional true
 
   collect_data(:linux) do
     devices = Mash.new

--- a/lib/ohai/plugins/linux/sessions.rb
+++ b/lib/ohai/plugins/linux/sessions.rb
@@ -18,6 +18,7 @@
 
 Ohai.plugin(:Sessions) do
   provides "sessions/by_session", "sessions/by_user"
+  optional true
 
   collect_data(:linux) do
     loginctl_path = which("loginctl")

--- a/lib/ohai/plugins/passwd.rb
+++ b/lib/ohai/plugins/passwd.rb
@@ -2,6 +2,7 @@
 Ohai.plugin(:Passwd) do
   require "etc"
   provides "etc", "current_user"
+  optional true
 
   def fix_encoding(str)
     str.force_encoding(Encoding.default_external) if str.respond_to?(:force_encoding)

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -59,6 +59,10 @@ module Ohai
     end
 
     def run_v7_plugin(plugin)
+      return true if plugin.optional? &&
+          !Ohai.config[:run_all_plugins] &&
+          !Ohai.config[:optional_plugins].include?(plugin.name)
+
       visited = [ plugin ]
       until visited.empty?
         next_plugin = visited.pop

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -177,6 +177,17 @@ Ohai.plugin(:Fails) do
 end
 EOF
 
+      with_plugin("optional.rb", <<EOF)
+Ohai.plugin(:Optional) do
+  provides 'optional'
+  optional true
+
+  collect_data(:default) do
+    optional("canteloupe")
+  end
+end
+EOF
+
       it "should collect data from all the plugins" do
         Ohai.config[:plugin_path] = [ path_to(".") ]
         ohai.all_plugins
@@ -228,6 +239,28 @@ EOF
           Ohai.config[:plugin_path] = [ path_to(".") ]
           expect { ohai.all_plugins }.to raise_error(Ohai::Exceptions::CriticalPluginFailure,
                                                      "The following Ohai plugins marked as critical failed: [:Fails]. Failing Chef run.")
+        end
+      end
+
+      describe "when using :optional_plugins" do
+        it "should not run optional plugins by default" do
+          Ohai.config[:plugin_path] = [ path_to(".") ]
+          ohai.all_plugins
+          expect(ohai.data[:optional]).to be_nil
+        end
+
+        it "should run optional plugins when specifically enabled" do
+          Ohai.config[:optional_plugins] = [ :Optional ]
+          Ohai.config[:plugin_path] = [ path_to(".") ]
+          ohai.all_plugins
+          expect(ohai.data[:optional]).to eq("canteloupe")
+        end
+
+        it "should run optional plugins when all plugins are enabled" do
+          Ohai.config[:run_all_plugins] = true
+          Ohai.config[:plugin_path] = [ path_to(".") ]
+          ohai.all_plugins
+          expect(ohai.data[:optional]).to eq("canteloupe")
         end
       end
     end


### PR DESCRIPTION
Some plugins are useful enough to ship in Ohai, but should be off by
default. Those plugins can be (and are) marked as optional. Implements
RFC 103