### PR TITLE
Update root_group plugin to use the collect_data helper

### DIFF
--- a/lib/ohai/plugins/root_group.rb
+++ b/lib/ohai/plugins/root_group.rb
@@ -18,15 +18,12 @@
 Ohai.plugin(:RootGroup) do
   provides "root_group"
 
-  require "ohai/util/win32/group_helper" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+  collect_data(:windows) do
+    require "ohai/util/win32/group_helper"
+    root_group Ohai::Util::Win32::GroupHelper.windows_root_group_name
+  end
 
-  collect_data do
-    case ::RbConfig::CONFIG["host_os"]
-    when /mswin|mingw32|windows/
-      group = Ohai::Util::Win32::GroupHelper.windows_root_group_name
-      root_group group
-    else
-      root_group Etc.getgrgid(Etc.getpwnam("root").gid).name
-    end
+  collect_data(:default) do
+    root_group Etc.getgrgid(Etc.getpwnam("root").gid).name
   end
 end

--- a/spec/unit/plugins/root_group_spec.rb
+++ b/spec/unit/plugins/root_group_spec.rb
@@ -79,7 +79,7 @@ describe Ohai::System, "root_group" do
 
   describe "windows platform" do
     it "should return the group administrators" do
-      stub_const("::RbConfig::CONFIG", { "host_os" => "windows" } )
+      allow(@plugin).to receive(:collect_os).and_return(:windows)
       expect(Ohai::Util::Win32::GroupHelper).to receive(:windows_root_group_name).and_return("administrators")
       @plugin.run
       expect(@plugin[:root_group]).to eq("administrators")


### PR DESCRIPTION
We have a helper that allows us to define specific logic on Windows. We
should use that here.

Signed-off-by: Tim Smith <tsmith@chef.io>