### PR TITLE
Fix specs failures in the scaleway plugin

### DIFF
--- a/lib/ohai/plugins/scaleway.rb
+++ b/lib/ohai/plugins/scaleway.rb
@@ -51,7 +51,6 @@ Ohai.plugin(:Scaleway) do
       end
     else
       Ohai::Log.debug("Plugin Scaleway: No hints present for and doesn't look like scaleway")
-      false
     end
   end
 end

--- a/spec/unit/plugins/scaleway_spec.rb
+++ b/spec/unit/plugins/scaleway_spec.rb
@@ -22,6 +22,7 @@ describe Ohai::System, "plugin scaleway" do
 
   before(:each) do
     allow(plugin).to receive(:hint?).with("scaleway").and_return(false)
+    allow(File).to receive(:read).with("/proc/cmdline").and_return(false)
   end
 
   shared_examples_for "!scaleway" do
@@ -64,7 +65,7 @@ describe Ohai::System, "plugin scaleway" do
         and_return(double("Net::HTTP Response", :body => "", :code => "404"))
       plugin.run
 
-      expect(plugin[:scaleway]).to be_nil
+      expect(plugin[:scaleway]).not_to be_nil
     end
   end
 


### PR DESCRIPTION
Make sure we mock out the /proc/cmdline so we don't fail on non-Linux
systems and properly expect an empty hash when we're on scaleway, but
metadata fetching fails

Signed-off-by: Tim Smith <tsmith@chef.io>