### PR TITLE
Mark the shard plugin as optional

### DIFF
--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -20,6 +20,7 @@ Ohai.plugin(:ShardSeed) do
   require "digest/md5"
   depends "hostname", "dmi", "machine_id", "machinename"
   provides "shard_seed"
+  optional true
 
   def get_dmi_property(dmi, thing)
     %w{system base_board chassis}.each do |section|


### PR DESCRIPTION
This avoids the MD5-on-FIPS problems that people suffer.