### PR TITLE
Expand what we blacklist from the kernel/network plugins on Windows

### DIFF
--- a/lib/ohai/plugins/windows/network.rb
+++ b/lib/ohai/plugins/windows/network.rb
@@ -36,7 +36,7 @@ Ohai.plugin(:Network) do
       wmi = WmiLite::Wmi.new
       data[:addresses] = wmi.instances_of("Win32_NetworkAdapterConfiguration")
 
-      # If we are running on windows nano or anothe roperating system from the future
+      # If we are running on windows nano or another operating system from the future
       # that does not populate the deprecated win32_* WMI classes, then we should
       # grab data from the newer MSFT_* classes
       return msft_adapter_data if data[:addresses].count == 0
@@ -81,6 +81,8 @@ Ohai.plugin(:Network) do
       i = adapter["index"] || adapter["InterfaceIndex"]
       iface_instance[i] = Mash.new
       adapter.wmi_ole_object.properties_.each do |p|
+        # skip wmi class name fields which make no sense in ohai
+        next if %w{creation_class_name system_creation_class_name}.include?(p.name.wmi_underscore)
         iface_instance[i][p.name.wmi_underscore.to_sym] = adapter[p.name.downcase]
       end
     end

--- a/spec/unit/plugins/windows/kernel_spec.rb
+++ b/spec/unit/plugins/windows/kernel_spec.rb
@@ -49,13 +49,15 @@ describe Ohai::System, "Windows kernel plugin", :windows_only do
 
     system_type = double("WIN32OLE", :name => "SystemType")
     pc_system_type = double("WIN32OLE", :name => "PCSystemType")
-    cs_properties = [ system_type, pc_system_type ]
+    free_virtual_memory = double("WIN32OLE", :name => "FreeVirtualMemory")
+    cs_properties = [ system_type, pc_system_type, free_virtual_memory]
 
     cs = double("WIN32OLE",
                 :properties_ => cs_properties)
 
     allow(cs).to receive(:invoke).with(system_type.name).and_return("x64-based PC")
     allow(cs).to receive(:invoke).with(pc_system_type.name).and_return(2)
+    allow(cs).to receive(:invoke).with(free_virtual_memory.name).and_return("Why would you want this data here?")
 
     cs_wmi = WmiLite::Wmi::Instance.new(cs)
     expect_any_instance_of(WmiLite::Wmi).to receive(:first_of).with("Win32_ComputerSystem").and_return(cs_wmi)
@@ -72,5 +74,6 @@ describe Ohai::System, "Windows kernel plugin", :windows_only do
     expect(plugin[:kernel][:system_type]).to eq("Mobile")
     expect(plugin[:kernel][:product_type]).to eq("Workstation")
     expect(plugin[:kernel][:server_core]).to eq(false)
+    expect(plugin[:kernel]).not_to have_key(:free_virtual_memory)
   end
 end


### PR DESCRIPTION
We're collecting some super useless data here (wmi class names) and some entirely duplicate data. Lets shave a tiny bit of storage space off the node object and make it easier to reason with.

This reduces the uncompressed node object by 1k

Signed-off-by: Tim Smith <tsmith@chef.io>