### PR TITLE
Remove support for Windows 2003 from uptime/cpu plugins

### DIFF
--- a/lib/ohai/plugins/uptime.rb
+++ b/lib/ohai/plugins/uptime.rb
@@ -28,7 +28,6 @@ Ohai.plugin(:Uptime) do
   require "ohai/mixin/seconds_to_human"
   provides "uptime", "uptime_seconds"
   provides "idletime", "idletime_seconds" # linux only
-  depends "platform_version"
 
   def collect_uptime(path)
     # kern.boottime: { sec = 1232765114, usec = 823118 } Fri Jan 23 18:45:14 2009
@@ -87,12 +86,8 @@ Ohai.plugin(:Uptime) do
   collect_data(:windows) do
     require "wmi-lite/wmi"
     wmi = WmiLite::Wmi.new
-    if platform_version.to_f >= 6.0 ## for newer version of Windows starting from Windows Server 2008 ##
-      last_boot_up_time = wmi.first_of("Win32_OperatingSystem")["lastbootuptime"]
-      uptime_seconds Time.new.to_i - Time.parse(last_boot_up_time).to_i
-    else ## for older version of Windows starting from Windows Server 2003 ##
-      uptime_seconds wmi.first_of("Win32_PerfFormattedData_PerfOS_System")["systemuptime"].to_i
-    end
+    last_boot_up_time = wmi.first_of("Win32_OperatingSystem")["lastbootuptime"]
+    uptime_seconds Time.new.to_i - Time.parse(last_boot_up_time).to_i
     uptime seconds_to_human(uptime_seconds)
   end
 

--- a/lib/ohai/plugins/windows/cpu.rb
+++ b/lib/ohai/plugins/windows/cpu.rb
@@ -32,23 +32,9 @@ Ohai.plugin(:CPU) do
     processors.each_with_index do |processor, index|
       current_cpu = index.to_s
       cpu[current_cpu] = Mash.new
-      #
-      # On Windows Server 2003 R2 (i.e. 5.2.*), numberofcores property
-      # doesn't exist on the Win32_Processor class unless the user has
-      # patched their system with:
-      # http://support.microsoft.com/kb/932370
-      #
-      # We're returning nil for cpu["cores"]
-      # when we don't see numberofcores property
-      #
 
-      begin
-        cpu[current_cpu]["cores"] = processor["numberofcores"]
-        cores += processor["numberofcores"]
-      rescue NoMethodError => e
-        Ohai::Log.info("Can not find numberofcores property on Win32_Processor. Consider applying this patch: http://support.microsoft.com/kb/932370")
-        cpu[current_cpu]["cores"] = nil
-      end
+      cpu[current_cpu]["cores"] = processor["numberofcores"]
+      cores += processor["numberofcores"]
 
       logical_processors += processor["numberoflogicalprocessors"]
       cpu[current_cpu]["vendor_id"] = processor["manufacturer"]

--- a/spec/functional/plugins/windows/uptime_spec.rb
+++ b/spec/functional/plugins/windows/uptime_spec.rb
@@ -49,33 +49,4 @@ describe Ohai::System, "Windows plugin uptime" do
       expect(uptime_plugin[:uptime]).to eq("22 hours 18 minutes 51 seconds")
     end
   end
-
-  context "for older version of Windows" do
-    let(:uptime_plugin) do
-      get_plugin("uptime").tap do |plugin|
-        plugin[:platform_version] = "5.0.2195"
-      end
-    end
-
-    let(:wmi) do
-      double("wmi", { :first_of =>
-        { "systemuptime" => "785345" },
-      })
-    end
-
-    before(:each) do
-      allow(uptime_plugin).to receive(:collect_os).and_return(:windows)
-      allow(WmiLite::Wmi).to receive(:new).and_return(wmi)
-    end
-
-    it "should set uptime_seconds to uptime" do
-      uptime_plugin.run
-      expect(uptime_plugin[:uptime_seconds]).to be == 785345
-    end
-
-    it "should set uptime to a human readable value" do
-      uptime_plugin.run
-      expect(uptime_plugin[:uptime]).to eq("9 days 02 hours 09 minutes 05 seconds")
-    end
-  end
 end

--- a/spec/unit/plugins/windows/uptime_spec.rb
+++ b/spec/unit/plugins/windows/uptime_spec.rb
@@ -20,69 +20,19 @@ require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Windows plugin uptime" do
 
+  let(:plugin) { get_plugin("uptime") }
   let(:wmi) { double("wmi", { :first_of => "" }) }
 
   before(:each) do
     allow(WmiLite::Wmi).to receive(:new).and_return(wmi)
+    allow(plugin).to receive(:collect_os).and_return(:windows)
   end
 
-  ## Windows newer versions category here includes server OS starting from Windows Server 2008 ##
-  shared_context "WMI class for newer versions of Windows platform" do
-    before do
-      allow(uptime_plugin).to receive(:collect_os).and_return(:windows)
-    end
-
-    it "uses Win32_OperatingSystem WMI class to fetch the system's uptime" do
-      expect(wmi).to receive(:first_of).with("Win32_OperatingSystem")
-      expect(Time).to receive(:new)
-      expect(Time).to receive(:parse)
-      expect(uptime_plugin).to receive(:seconds_to_human)
-      uptime_plugin.run
-    end
-  end
-
-  ## Windows older versions category here includes server OS starting from Windows Server 2003 ##
-  shared_context "WMI class for older versions of Windows platform" do
-    before do
-      allow(uptime_plugin).to receive(:collect_os).and_return(:windows)
-    end
-
-    it "uses Win32_PerfFormattedData_PerfOS_System WMI class to fetch the system's uptime" do
-      expect(wmi).to receive(:first_of).with("Win32_PerfFormattedData_PerfOS_System")
-      expect(Time).to_not receive(:new)
-      expect(Time).to_not receive(:parse)
-      expect(uptime_plugin).to receive(:seconds_to_human)
-      uptime_plugin.run
-    end
-  end
-
-  context "platform is Windows Server 2008 R2" do
-    let(:uptime_plugin) do
-      get_plugin("uptime").tap do |plugin|
-        plugin[:platform_version] = "6.1.7601"
-      end
-    end
-
-    include_context "WMI class for newer versions of Windows platform"
-  end
-
-  context "platform is Windows Server 2003 R2" do
-    let(:uptime_plugin) do
-      get_plugin("uptime").tap do |plugin|
-        plugin[:platform_version] = "5.2.3790"
-      end
-    end
-
-    include_context "WMI class for older versions of Windows platform"
-  end
-
-  context "platform is Windows Server 2012" do
-    let(:uptime_plugin) do
-      get_plugin("uptime").tap do |plugin|
-        plugin[:platform_version] = "6.2.9200"
-      end
-    end
-
-    include_context "WMI class for newer versions of Windows platform"
+  it "uses Win32_OperatingSystem WMI class to fetch the system's uptime" do
+    expect(wmi).to receive(:first_of).with("Win32_OperatingSystem")
+    expect(Time).to receive(:new)
+    expect(Time).to receive(:parse)
+    expect(plugin).to receive(:seconds_to_human)
+    plugin.run
   end
 end


### PR DESCRIPTION
The uptime plugin will break due to this
The CPU plugin will only work if the system is unpatched

EXTENDED support for Windows 2003 ended July 14, 2015

Signed-off-by: Tim Smith <tsmith@chef.io>