### PR TITLE
Softlayer is forcing tlsv1_2 for all API calls

### DIFF
--- a/lib/ohai/mixin/softlayer_metadata.rb
+++ b/lib/ohai/mixin/softlayer_metadata.rb
@@ -47,7 +47,7 @@ module ::Ohai::Mixin::SoftlayerMetadata
     full_url = "#{SOFTLAYER_API_QUERY_URL}/#{item}"
     u = URI(full_url)
     net = ::Net::HTTP.new(u.hostname, u.port)
-    net.ssl_version = "TLSv1"
+    net.ssl_version = :TLSv1_2
     net.use_ssl = true
     net.ca_file = ca_file_location
     res = net.get(u.request_uri)


### PR DESCRIPTION
Softlayer is forcing tlsv1_2 for all API calls.  tlsv1 calls will stop working on 3/1/2018

https://softlayer.github.io/release_notes/2018/20180301/

Signed-off-by: S. Cavallo <smcavallo@hotmail.com>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ X] New functionality includes tests
- [X ] All tests pass
- [X ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

