### PR TITLE
Backport Fix for Softlayer disabling TLS 1.0/1.1 on 3/1/2018

### DIFF
--- a/lib/ohai/mixin/softlayer_metadata.rb
+++ b/lib/ohai/mixin/softlayer_metadata.rb
@@ -47,7 +47,7 @@ module ::Ohai::Mixin::SoftlayerMetadata
     full_url = "#{SOFTLAYER_API_QUERY_URL}/#{item}"
     u = URI(full_url)
     net = ::Net::HTTP.new(u.hostname, u.port)
-    net.ssl_version = "TLSv1"
+    net.ssl_version = :TLSv1_2
     net.use_ssl = true
     net.ca_file = ca_file_location
     res = net.get(u.request_uri)


### PR DESCRIPTION
Softlayer is forcing tlsv1_2 for all API calls.  tlsv1 calls will stop working on 3/1/2018

Signed-off-by: S. Cavallo <smcavallo@hotmail.com>