### PR TITLE
Fix bug in azure plugin/update to recent metadata version.

### DIFF
--- a/lib/ohai/mixin/azure_metadata.rb
+++ b/lib/ohai/mixin/azure_metadata.rb
@@ -22,7 +22,7 @@ module Ohai
     module AzureMetadata
 
       AZURE_METADATA_ADDR = "169.254.169.254" unless defined?(AZURE_METADATA_ADDR)
-      AZURE_METADATA_URL = "/metadata/instance?api-version=2017-04-02" unless defined?(AZURE_METADATA_URL)
+      AZURE_METADATA_URL = "/metadata/instance?api-version=2017-12-01" unless defined?(AZURE_METADATA_URL)
 
       # fetch the meta content with a timeout and the required header
       def http_get(uri)

--- a/lib/ohai/mixin/azure_metadata.rb
+++ b/lib/ohai/mixin/azure_metadata.rb
@@ -22,7 +22,7 @@ module Ohai
     module AzureMetadata
 
       AZURE_METADATA_ADDR = "169.254.169.254" unless defined?(AZURE_METADATA_ADDR)
-      AZURE_METADATA_URL = "/metadata/instance?api-version=2017-12-01" unless defined?(AZURE_METADATA_URL)
+      AZURE_METADATA_URL = "/metadata/instance?api-version=2017-08-01" unless defined?(AZURE_METADATA_URL)
 
       # fetch the meta content with a timeout and the required header
       def http_get(uri)

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -73,6 +73,7 @@ Ohai.plugin(:Azure) do
     metadata["compute"] = Mash.new
     metadata
   end
+
   def initialize_metadata_mash_network
     metadata = Mash.new
     metadata["network"] = Mash.new
@@ -81,7 +82,7 @@ Ohai.plugin(:Azure) do
       metadata["network"][type] = []
     end
     metadata
-  end  
+  end
 
   def fetch_ip_data(data, type, field)
     ips = []
@@ -103,7 +104,7 @@ Ohai.plugin(:Azure) do
     endpoint_data["compute"].each do |k, v|
       metadata["compute"][k] = v
     end
-    
+
     # receiving network output is not guaranteed
     unless endpoint_data["network"].nil?
       metadata = initialize_metadata_mash_network

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -68,16 +68,20 @@ Ohai.plugin(:Azure) do
   end
 
   # create the basic structure we'll store our data in
-  def initialize_metadata_mash
+  def initialize_metadata_mash_compute
     metadata = Mash.new
     metadata["compute"] = Mash.new
+    metadata
+  end
+  def initialize_metadata_mash_network
+    metadata = Mash.new
     metadata["network"] = Mash.new
     metadata["network"]["interfaces"] = Mash.new
     %w{public_ipv4 local_ipv4 public_ipv6 local_ipv6}.each do |type|
       metadata["network"][type] = []
     end
     metadata
-  end
+  end  
 
   def fetch_ip_data(data, type, field)
     ips = []
@@ -93,27 +97,31 @@ Ohai.plugin(:Azure) do
 
     endpoint_data = fetch_metadata
     return nil if endpoint_data.nil?
-    metadata = initialize_metadata_mash
+    metadata = initialize_metadata_mash_compute
 
     # blindly add everything in compute to our data structure
     endpoint_data["compute"].each do |k, v|
       metadata["compute"][k] = v
     end
+    
+    # receiving network output is not guaranteed
+    unless endpoint_data["network"].nil?
+      metadata = initialize_metadata_mash_network
+      # parse out per interface interface IP data
+      endpoint_data["network"]["interface"].each do |int|
+        metadata["network"]["interfaces"][int["macAddress"]] = Mash.new
+        metadata["network"]["interfaces"][int["macAddress"]]["mac"] = int["macAddress"]
+        metadata["network"]["interfaces"][int["macAddress"]]["public_ipv6"] = fetch_ip_data(int, "ipv6", "publicIpAddress")
+        metadata["network"]["interfaces"][int["macAddress"]]["public_ipv4"] = fetch_ip_data(int, "ipv4", "publicIpAddress")
+        metadata["network"]["interfaces"][int["macAddress"]]["local_ipv6"] = fetch_ip_data(int, "ipv6", "privateIpAddress")
+        metadata["network"]["interfaces"][int["macAddress"]]["local_ipv4"] = fetch_ip_data(int, "ipv4", "privateIpAddress")
+      end
 
-    # parse out per interface interface IP data
-    endpoint_data["network"]["interface"].each do |int|
-      metadata["network"]["interfaces"][int["macAddress"]] = Mash.new
-      metadata["network"]["interfaces"][int["macAddress"]]["mac"] = int["macAddress"]
-      metadata["network"]["interfaces"][int["macAddress"]]["public_ipv6"] = fetch_ip_data(int, "ipv6", "publicIpAddress")
-      metadata["network"]["interfaces"][int["macAddress"]]["public_ipv4"] = fetch_ip_data(int, "ipv4", "publicIpAddress")
-      metadata["network"]["interfaces"][int["macAddress"]]["local_ipv6"] = fetch_ip_data(int, "ipv6", "privateIpAddress")
-      metadata["network"]["interfaces"][int["macAddress"]]["local_ipv4"] = fetch_ip_data(int, "ipv4", "privateIpAddress")
-    end
-
-    # aggregate the total IP data
-    %w{public_ipv4 local_ipv4 public_ipv6 local_ipv6}.each do |type|
-      metadata["network"]["interfaces"].each_value do |val|
-        metadata["network"][type].concat val[type] unless val[type].empty?
+      # aggregate the total IP data
+      %w{public_ipv4 local_ipv4 public_ipv6 local_ipv6}.each do |type|
+        metadata["network"]["interfaces"].each_value do |val|
+          metadata["network"][type].concat val[type] unless val[type].empty?
+        end
       end
     end
 

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -74,8 +74,7 @@ Ohai.plugin(:Azure) do
     metadata
   end
 
-  def initialize_metadata_mash_network
-    metadata = Mash.new
+  def initialize_metadata_mash_network(metadata)
     metadata["network"] = Mash.new
     metadata["network"]["interfaces"] = Mash.new
     %w{public_ipv4 local_ipv4 public_ipv6 local_ipv6}.each do |type|
@@ -107,7 +106,7 @@ Ohai.plugin(:Azure) do
 
     # receiving network output is not guaranteed
     unless endpoint_data["network"].nil?
-      metadata = initialize_metadata_mash_network
+      metadata = initialize_metadata_mash_network(metadata)
       # parse out per interface interface IP data
       endpoint_data["network"]["interface"].each do |int|
         metadata["network"]["interfaces"][int["macAddress"]] = Mash.new


### PR DESCRIPTION
### Description

This fixes a bug discovered for the Azure plugin, and updates to the recent azure metadata api date/version.

### Issues Resolved

This fixes a bug I discovered which will crash the azure plugin if it's missing metadata. I discovered, at least on an ND24rs instance I was on, that no network metadata is received.

Also updated to the recent Azure metadata API which gives additional metadata including the resource group name, availability set info, subscription id, and VM scale set info.
