### PR TITLE
add ohai support for softlayer cloud

### DIFF
--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -25,6 +25,7 @@ Ohai.plugin(:Cloud) do
   depends "openstack"
   depends "azure"
   depends "digital_ocean"
+  depends "softlayer"
 
   # Class to help enforce the interface exposed to node[:cloud] (OHAI-542)
   #
@@ -294,6 +295,27 @@ Ohai.plugin(:Cloud) do
     @cloud_attr_obj.provider = "digital_ocean"
   end
 
+  # ----------------------------------------
+  # softlayer
+  # ----------------------------------------
+
+  # Is current cloud softlayer?
+  #
+  # === Return
+  # true:: If softlayer Hash is defined
+  # false:: Otherwise
+  def on_softlayer?
+    softlayer != nil
+  end
+
+  # Fill cloud hash with softlayer values
+  def get_softlayer_values
+    @cloud_attr_obj.add_ipv4_addr(softlayer["public_ipv4"], :public)
+    @cloud_attr_obj.add_ipv4_addr(softlayer["local_ipv4"], :private)
+    @cloud_attr_obj.public_hostname = softlayer["public_fqdn"]
+    @cloud_attr_obj.provider = "softlayer"
+  end
+
   collect_data do
     require "ipaddr"
 
@@ -307,6 +329,7 @@ Ohai.plugin(:Cloud) do
     get_openstack_values if on_openstack?
     get_azure_values if on_azure?
     get_digital_ocean_values if on_digital_ocean?
+    get_softlayer_values if on_softlayer?
 
     cloud @cloud_attr_obj.cloud_mash
   end

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -451,7 +451,7 @@ describe Ohai::System, "plugin cloud" do
       @plugin[:softlayer] = Mash.new
       @plugin[:softlayer] = { "local_ipv4" => "192.168.0.1",
                               "public_ipv4" => "8.8.8.8",
-                              "public_fqdn" => "abc1234.public.com"
+                              "public_fqdn" => "abc1234.public.com",
       }
     end
 

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -86,6 +86,7 @@ describe Ohai::System, "plugin cloud" do
       @plugin[:azure] = nil
       @plugin[:gce] = nil
       @plugin[:digital_ocean] = nil
+      @plugin[:softlayer] = nil
       @plugin.run
       expect(@plugin[:cloud]).to be_nil
     end
@@ -442,6 +443,41 @@ describe Ohai::System, "plugin cloud" do
 
     it "populates cloud provider" do
       expect(@plugin[:cloud][:provider]).to eq("digital_ocean")
+    end
+  end
+
+  describe "with softlayer mash" do
+    before do
+      @plugin[:softlayer] = Mash.new
+      @plugin[:softlayer] = { "local_ipv4" => "192.168.0.1",
+                              "public_ipv4" => "8.8.8.8",
+                              "public_fqdn" => "abc1234.public.com"
+      }
+    end
+
+    it "populates cloud public ip" do
+      @plugin.run
+      expect(@plugin[:cloud][:public_ipv4_addrs][0]).to eq(@plugin[:softlayer][:public_ipv4])
+    end
+
+    it "populates cloud private ip" do
+      @plugin.run
+      expect(@plugin[:cloud][:local_ipv4_addrs][0]).to eq(@plugin[:softlayer][:local_ipv4])
+    end
+
+    it "populates first cloud public ip" do
+      @plugin.run
+      expect(@plugin[:cloud][:public_ipv4_addrs].first).to eq(@plugin[:softlayer][:public_ipv4])
+    end
+
+    it "populates cloud public_hostname" do
+      @plugin.run
+      expect(@plugin[:cloud][:public_hostname]).to eq(@plugin[:softlayer][:public_fqdn])
+    end
+
+    it "populates cloud provider" do
+      @plugin.run
+      expect(@plugin[:cloud][:provider]).to eq("softlayer")
     end
   end
 


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

### Description

Ohai running on softlayer cloud will populate cloud attributes.
This functionality was removed from ohai during cloud_v2 -> cloud refactoring.
See - https://github.com/chef/ohai/commit/effa84d1129c011b2e632aec0908ec401844bd1b#diff-7b665cfb965d9a6bb7e6f0d8bdf43322


### Issues Resolved

latest ohai does not populate node['cloud'] - this is a regression

### Check List

- [X ] New functionality includes tests
- [X ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
