### PR TITLE
Backport fix for softlayer not showing up in the node['cloud'] plugin

### DIFF
--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -26,6 +26,7 @@ Ohai.plugin(:Cloud) do
   depends "openstack"
   depends "azure"
   depends "digital_ocean"
+  depends "softlayer"
 
   # Class to help enforce the interface exposed to node[:cloud] (OHAI-542)
   #
@@ -295,6 +296,27 @@ Ohai.plugin(:Cloud) do
     @cloud_attr_obj.provider = "digital_ocean"
   end
 
+  # ----------------------------------------
+  # softlayer
+  # ----------------------------------------
+
+  # Is current cloud softlayer?
+  #
+  # === Return
+  # true:: If softlayer Hash is defined
+  # false:: Otherwise
+  def on_softlayer?
+    softlayer != nil
+  end
+
+  # Fill cloud hash with softlayer values
+  def get_softlayer_values
+    @cloud_attr_obj.add_ipv4_addr(softlayer["public_ipv4"], :public)
+    @cloud_attr_obj.add_ipv4_addr(softlayer["local_ipv4"], :private)
+    @cloud_attr_obj.public_hostname = softlayer["public_fqdn"]
+    @cloud_attr_obj.provider = "softlayer"
+  end
+
   collect_data do
     require "ipaddr"
 
@@ -308,6 +330,7 @@ Ohai.plugin(:Cloud) do
     get_openstack_values if on_openstack?
     get_azure_values if on_azure?
     get_digital_ocean_values if on_digital_ocean?
+    get_softlayer_values if on_softlayer?
 
     # set node[:cloud] and node[:cloud_v2] hash here
     cloud_v2 @cloud_attr_obj.cloud_mash

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -86,6 +86,7 @@ describe Ohai::System, "plugin cloud" do
       @plugin[:azure] = nil
       @plugin[:gce] = nil
       @plugin[:digital_ocean] = nil
+      @plugin[:softlayer] = nil
       @plugin.run
       expect(@plugin[:cloud]).to be_nil
       expect(@plugin[:cloud_v2]).to be_nil
@@ -454,6 +455,41 @@ describe Ohai::System, "plugin cloud" do
 
     it "populates cloud provider" do
       expect(@plugin[:cloud][:provider]).to eq("digital_ocean")
+    end
+  end
+
+  describe "with softlayer mash" do
+    before do
+      @plugin[:softlayer] = Mash.new
+      @plugin[:softlayer] = { "local_ipv4" => "192.168.0.1",
+                              "public_ipv4" => "8.8.8.8",
+                              "public_fqdn" => "abc1234.public.com"
+      }
+    end
+
+    it "populates cloud public ip" do
+      @plugin.run
+      expect(@plugin[:cloud][:public_ipv4_addrs][0]).to eq(@plugin[:softlayer][:public_ipv4])
+    end
+
+    it "populates cloud private ip" do
+      @plugin.run
+      expect(@plugin[:cloud][:local_ipv4_addrs][0]).to eq(@plugin[:softlayer][:local_ipv4])
+    end
+
+    it "populates first cloud public ip" do
+      @plugin.run
+      expect(@plugin[:cloud][:public_ipv4_addrs].first).to eq(@plugin[:softlayer][:public_ipv4])
+    end
+
+    it "populates cloud public_hostname" do
+      @plugin.run
+      expect(@plugin[:cloud][:public_hostname]).to eq(@plugin[:softlayer][:public_fqdn])
+    end
+
+    it "populates cloud provider" do
+      @plugin.run
+      expect(@plugin[:cloud][:provider]).to eq("softlayer")
     end
   end
 

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -463,7 +463,7 @@ describe Ohai::System, "plugin cloud" do
       @plugin[:softlayer] = Mash.new
       @plugin[:softlayer] = { "local_ipv4" => "192.168.0.1",
                               "public_ipv4" => "8.8.8.8",
-                              "public_fqdn" => "abc1234.public.com"
+                              "public_fqdn" => "abc1234.public.com",
       }
     end
 


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

### Description

Ohai running on softlayer cloud will populate cloud attributes.
This functionality was removed from ohai during cloud_v2 -> cloud refactoring.
See - https://github.com/chef/ohai/commit/effa84d1129c011b2e632aec0908ec401844bd1b#diff-7b665cfb965d9a6bb7e6f0d8bdf43322


### Issues Resolved

latest ohai does not populate node['cloud'] - this is a regression
