### PR TITLE
Pin Chefstyle and remove github_changelog_generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
-  gem "chefstyle"
+  gem "chefstyle", "= 0.6.0"
   gem "rake", ">= 10.1.0"
   gem "rspec-core", "~> 3.0"
   gem "rspec-expectations", "~> 3.0"
@@ -15,10 +15,6 @@ end
 
 group :ci do
   gem "rspec_junit_formatter"
-end
-
-group :changelog do
-  gem "github_changelog_generator", git: "https://github.com/chef/github-changelog-generator"
 end
 
 instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]


### PR DESCRIPTION
Pin chefstyle to 0.6.0 so we don't have to fix all the warnings on our
legacy branch

Signed-off-by: Tim Smith <tsmith@chef.io>