### PR TITLE
Move ohai to structured logging

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -93,6 +93,7 @@ class Ohai::Application
 
   def run_application
     config[:invoked_from_cli] = true
+    config[:logger] = Ohai::Log.with_child
     ohai = Ohai::System.new(config)
     ohai.all_plugins(@attributes)
 

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -80,9 +80,11 @@ module Ohai
 
       attr_reader :data
       attr_reader :failed
+      attr_reader :logger
 
-      def initialize(data)
+      def initialize(data, logger)
         @data = data
+        @logger = logger.with_child({ subsystem: "plugin", plugin: name })
         @has_run = false
         @failed = false
       end
@@ -91,7 +93,7 @@ module Ohai
         @has_run = true
 
         if Ohai.config[:disabled_plugins].include?(name)
-          Ohai::Log.debug("Skipping disabled plugin #{name}")
+          logger.trace("Skipping disabled plugin #{name}")
         else
           run_plugin
         end
@@ -182,8 +184,8 @@ module Ohai
         raise e
       rescue => e
         @failed = true
-        Ohai::Log.debug("Plugin #{name} threw #{e.inspect}")
-        e.backtrace.each { |line| Ohai::Log.debug( line ) }
+        logger.trace("Plugin #{name} threw #{e.inspect}")
+        e.backtrace.each { |line| logger.trace( line ) }
       end
 
       def method_missing(name, *args)

--- a/lib/ohai/dsl/plugin/versionvii.rb
+++ b/lib/ohai/dsl/plugin/versionvii.rb
@@ -24,8 +24,8 @@ module Ohai
         attr_reader :version
         attr_reader :source
 
-        def initialize(data)
-          super(data)
+        def initialize(data, logger)
+          super(data, logger)
           @source = self.class.sources
           @version = :version7
         end
@@ -97,7 +97,7 @@ module Ohai
           elsif collector.has_key?(:default)
             instance_eval(&collector[:default])
           else
-            Ohai::Log.debug("Plugin #{name}: No data to collect. Skipping...")
+            logger.trace("Plugin #{name}: No data to collect. Skipping...")
           end
         end
 
@@ -106,11 +106,11 @@ module Ohai
         end
 
         def provides(*paths)
-          Ohai::Log.warn("[UNSUPPORTED OPERATION] \'provides\' is no longer supported in a \'collect_data\' context. Please specify \'provides\' before collecting plugin data. Ignoring command \'provides #{paths.join(", ")}")
+          logger.warn("[UNSUPPORTED OPERATION] \'provides\' is no longer supported in a \'collect_data\' context. Please specify \'provides\' before collecting plugin data. Ignoring command \'provides #{paths.join(", ")}")
         end
 
         def require_plugin(*args)
-          Ohai::Log.warn("[UNSUPPORTED OPERATION] \'require_plugin\' is no longer supported. Please use \'depends\' instead.\nIgnoring plugin(s) #{args.join(", ")}")
+          logger.warn("[UNSUPPORTED OPERATION] \'require_plugin\' is no longer supported. Please use \'depends\' instead.\nIgnoring plugin(s) #{args.join(", ")}")
         end
 
         def configuration(option, *options)

--- a/lib/ohai/hints.rb
+++ b/lib/ohai/hints.rb
@@ -41,11 +41,11 @@ module Ohai
       Ohai.config[:hints_path].each do |path|
         filename = File.join(path, "#{name}.json")
         next unless File.exist?(filename)
-        Ohai::Log.debug("Found hint #{name}.json at #{filename}")
+        Ohai::Log.trace("Found hint #{name}.json at #{filename}")
         @hints[name] = parse_hint_file(filename)
       end
 
-      Ohai::Log.debug("Did not find hint #{name}.json in the hint path(s): #{Ohai.config[:hints_path].join(', ')} ") unless @hints.key?(name)
+      Ohai::Log.trace("Did not find hint #{name}.json in the hint path(s): #{Ohai.config[:hints_path].join(', ')} ") unless @hints.key?(name)
       @hints[name]
     end
   end

--- a/lib/ohai/mixin/azure_metadata.rb
+++ b/lib/ohai/mixin/azure_metadata.rb
@@ -32,7 +32,7 @@ module Ohai
       end
 
       def fetch_metadata
-        Ohai::Log.debug("Mixin AzureMetadata: Fetching metadata from host #{AZURE_METADATA_ADDR} at #{AZURE_METADATA_URL}")
+        logger.trace("Mixin AzureMetadata: Fetching metadata from host #{AZURE_METADATA_ADDR} at #{AZURE_METADATA_URL}")
         response = http_get(AZURE_METADATA_URL)
         if response.code == "200"
           begin
@@ -40,11 +40,11 @@ module Ohai
             parser = FFI_Yajl::Parser.new
             parser.parse(data)
           rescue FFI_Yajl::ParseError
-            Ohai::Log.warn("Mixin AzureMetadata: Metadata response is NOT valid JSON")
+            logger.warn("Mixin AzureMetadata: Metadata response is NOT valid JSON")
             nil
           end
         else
-          Ohai::Log.warn("Mixin AzureMetadata: Received response code #{response.code} requesting metadata")
+          logger.warn("Mixin AzureMetadata: Received response code #{response.code} requesting metadata")
           nil
         end
       end

--- a/lib/ohai/mixin/command.rb
+++ b/lib/ohai/mixin/command.rb
@@ -37,13 +37,13 @@ module Ohai
         so = Mixlib::ShellOut.new(cmd, options)
         begin
           so.run_command
-          Ohai::Log.debug("Plugin #{name}: ran '#{cmd}' and returned #{so.exitstatus}")
+          logger.trace("Plugin #{name}: ran '#{cmd}' and returned #{so.exitstatus}")
           so
         rescue Errno::ENOENT => e
-          Ohai::Log.debug("Plugin #{name}: ran '#{cmd}' and failed #{e.inspect}")
+          logger.trace("Plugin #{name}: ran '#{cmd}' and failed #{e.inspect}")
           raise Ohai::Exceptions::Exec, e
         rescue Mixlib::ShellOut::CommandTimeout => e
-          Ohai::Log.debug("Plugin #{name}: ran '#{cmd}' and timed out after #{options[:timeout]} seconds")
+          logger.trace("Plugin #{name}: ran '#{cmd}' and timed out after #{options[:timeout]} seconds")
           raise Ohai::Exceptions::Exec, e
         end
       end

--- a/lib/ohai/mixin/do_metadata.rb
+++ b/lib/ohai/mixin/do_metadata.rb
@@ -35,7 +35,7 @@ module Ohai
           parser = FFI_Yajl::Parser.new
           parser.parse(response.body)
         when "404"
-          Ohai::Log.debug("Mixin DOMetadata: Encountered 404 response retrieving Digital Ocean metadata: #{uri} ; continuing.")
+          logger.trace("Mixin DOMetadata: Encountered 404 response retrieving Digital Ocean metadata: #{uri} ; continuing.")
           {}
         else
           raise "Mixin DOMetadata: Encountered error retrieving Digital Ocean metadata (#{uri} returned #{response.code} response)"

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -49,10 +49,10 @@ module Ohai
 
       def best_api_version
         @api_version ||= begin
-          Ohai::Log.debug("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}/ to determine the latest supported metadata release")
+          logger.trace("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}/ to determine the latest supported metadata release")
           response = http_client.get("/")
           if response.code == "404"
-            Ohai::Log.debug("Mixin EC2: Received HTTP 404 from metadata server while determining API version, assuming 'latest'")
+            logger.trace("Mixin EC2: Received HTTP 404 from metadata server while determining API version, assuming 'latest'")
             return "latest"
           elsif response.code != "200"
             raise "Mixin EC2: Unable to determine EC2 metadata version (returned #{response.code} response)"
@@ -62,9 +62,9 @@ module Ohai
           versions = response.body.split("\n").sort
           until versions.empty? || EC2_SUPPORTED_VERSIONS.include?(versions.last)
             pv = versions.pop
-            Ohai::Log.debug("Mixin EC2: EC2 lists metadata version: #{pv} not yet supported by Ohai") unless pv == "latest"
+            logger.trace("Mixin EC2: EC2 lists metadata version: #{pv} not yet supported by Ohai") unless pv == "latest"
           end
-          Ohai::Log.debug("Mixin EC2: Latest supported EC2 metadata version: #{versions.last}")
+          logger.trace("Mixin EC2: Latest supported EC2 metadata version: #{versions.last}")
           if versions.empty?
             raise "Mixin EC2: Unable to determine EC2 metadata version (no supported entries found)"
           end
@@ -88,13 +88,13 @@ module Ohai
       #   `nil` and continue the run instead of failing it.
       def metadata_get(id, api_version)
         path = "/#{api_version}/meta-data/#{id}"
-        Ohai::Log.debug("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}#{path}")
+        logger.trace("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}#{path}")
         response = http_client.get(path)
         case response.code
         when "200"
           response.body
         when "404"
-          Ohai::Log.debug("Mixin EC2: Encountered 404 response retrieving EC2 metadata path: #{path} ; continuing.")
+          logger.trace("Mixin EC2: Encountered 404 response retrieving EC2 metadata path: #{path} ; continuing.")
           nil
         else
           raise "Mixin EC2: Encountered error retrieving EC2 metadata (#{path} returned #{response.code} response)"
@@ -169,7 +169,7 @@ module Ohai
       end
 
       def fetch_userdata
-        Ohai::Log.debug("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}/#{best_api_version}/user-data/")
+        logger.trace("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}/#{best_api_version}/user-data/")
         response = http_client.get("/#{best_api_version}/user-data/")
         response.code == "200" ? response.body : nil
       end

--- a/lib/ohai/mixin/http_helper.rb
+++ b/lib/ohai/mixin/http_helper.rb
@@ -25,7 +25,7 @@ module Ohai
         begin
           saddr = Socket.pack_sockaddr_in(port, addr)
         rescue SocketError => e # generally means dns resolution error
-          Ohai::Log.debug("Mixin HttpHelper: can_socket_connect? failed setting up socket connection: #{e}")
+          logger.trace("Mixin HttpHelper: can_socket_connect? failed setting up socket connection: #{e}")
           return false
         end
 
@@ -48,7 +48,7 @@ module Ohai
           end
         rescue SystemCallError
         end
-        Ohai::Log.debug("Mixin HttpHelper: can_socket_connect? == #{connected}")
+        logger.trace("Mixin HttpHelper: can_socket_connect? == #{connected}")
         connected
       end
     end

--- a/lib/ohai/mixin/scaleway_metadata.rb
+++ b/lib/ohai/mixin/scaleway_metadata.rb
@@ -35,7 +35,7 @@ module Ohai
           parser = FFI_Yajl::Parser.new
           parser.parse(response.body)
         when "404"
-          Ohai::Log.debug("Mixin ScalewayMetadata: Encountered 404 response retrieving Scaleway metadata: #{uri} ; continuing.")
+          logger.trace("Mixin ScalewayMetadata: Encountered 404 response retrieving Scaleway metadata: #{uri} ; continuing.")
           {}
         else
           raise "Mixin ScalewayMetadata: Encountered error retrieving Scaleway metadata (#{uri} returned #{response.code} response)"

--- a/lib/ohai/mixin/softlayer_metadata.rb
+++ b/lib/ohai/mixin/softlayer_metadata.rb
@@ -54,11 +54,11 @@ module ::Ohai::Mixin::SoftlayerMetadata
     if res.code.to_i.between?(200, 299)
       res.body
     else
-      ::Ohai::Log.error("Mixin Softlayer: Unable to fetch item #{full_url}: status (#{res.code}) body (#{res.body})")
+      logger.error("Mixin Softlayer: Unable to fetch item #{full_url}: status (#{res.code}) body (#{res.body})")
       nil
     end
   rescue => e
-    ::Ohai::Log.error("Mixin Softlayer: Unable to fetch softlayer metadata from #{u}: #{e.class}: #{e.message}")
+    logger.error("Mixin Softlayer: Unable to fetch softlayer metadata from #{u}: #{e.class}: #{e.message}")
     raise e
   end
 end

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -30,16 +30,16 @@ Ohai.plugin(:Azure) do
     # project for details
     azure_metadata_from_hints = hint?("azure")
     if azure_metadata_from_hints
-      Ohai::Log.debug("Plugin Azure: Azure hint is present. Parsing any hint data.")
+      logger.trace("Plugin Azure: Azure hint is present. Parsing any hint data.")
       azure Mash.new
       azure_metadata_from_hints.each { |k, v| azure[k] = v }
       azure["metadata"] = parse_metadata
     elsif has_waagent? || has_dhcp_option_245?
-      Ohai::Log.debug("Plugin Azure: No hints present, but system appears to be on Azure.")
+      logger.trace("Plugin Azure: No hints present, but system appears to be on Azure.")
       azure Mash.new
       azure["metadata"] = parse_metadata
     else
-      Ohai::Log.debug("Plugin Azure: No hints present and doesn't appear to be on Azure.")
+      logger.trace("Plugin Azure: No hints present and doesn't appear to be on Azure.")
       false
     end
   end
@@ -48,7 +48,7 @@ Ohai.plugin(:Azure) do
   # http://blog.mszcool.com/index.php/2015/04/detecting-if-a-virtual-machine-runs-in-microsoft-azure-linux-windows-to-protect-your-software-when-distributed-via-the-azure-marketplace/
   def has_waagent?
     if File.exist?("/usr/sbin/waagent") || Dir.exist?('C:\WindowsAzure')
-      Ohai::Log.debug("Plugin Azure: Found waagent used by Azure.")
+      logger.trace("Plugin Azure: Found waagent used by Azure.")
       true
     end
   end
@@ -58,7 +58,7 @@ Ohai.plugin(:Azure) do
     if File.exist?("/var/lib/dhcp/dhclient.eth0.leases")
       File.open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
         if line =~ /unknown-245/
-          Ohai::Log.debug("Plugin Azure: Found unknown-245 DHCP option used by Azure.")
+          logger.trace("Plugin Azure: Found unknown-245 DHCP option used by Azure.")
           has_245 = true
           break
         end

--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "jail"
       virtualization[:role] = "guest"
       virtualization[:systems][:jail] = "guest"
-      Ohai::Log.debug("Plugin Virtualization: Guest running in FreeBSD jail detected")
+      logger.trace("Plugin Virtualization: Guest running in FreeBSD jail detected")
     end
 
     # run jls to get a list of running jails
@@ -45,7 +45,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "jail"
       virtualization[:role] = "host"
       virtualization[:systems][:jail] = "host"
-      Ohai::Log.debug("Plugin Virtualization: Host running FreeBSD jails detected")
+      logger.trace("Plugin Virtualization: Host running FreeBSD jails detected")
     end
 
     # detect from modules
@@ -56,12 +56,12 @@ Ohai.plugin(:Virtualization) do
         virtualization[:system] = "vbox"
         virtualization[:role] = "host"
         virtualization[:systems][:vbox] = "host"
-        Ohai::Log.debug("Plugin Virtualization: Guest running on VirtualBox detected")
+        logger.trace("Plugin Virtualization: Guest running on VirtualBox detected")
       when /vboxguest/
         virtualization[:system] = "vbox"
         virtualization[:role] = "guest"
         virtualization[:systems][:vbox] = "guest"
-        Ohai::Log.debug("Plugin Virtualization: Host running VirtualBox detected")
+        logger.trace("Plugin Virtualization: Host running VirtualBox detected")
       end
     end
 
@@ -70,7 +70,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "bhyve"
       virtualization[:role] = "host"
       virtualization[:systems][:bhyve] = "host"
-      Ohai::Log.debug("Plugin Virtualization: Host running bhyve detected")
+      logger.trace("Plugin Virtualization: Host running bhyve detected")
     end
 
     # Detect KVM/QEMU paravirt guests from cpu, report as KVM
@@ -80,7 +80,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "kvm"
       virtualization[:role] = "guest"
       virtualization[:systems][:kvm] = "guest"
-      Ohai::Log.debug("Plugin Virtualization: Guest running on KVM detected")
+      logger.trace("Plugin Virtualization: Guest running on KVM detected")
     end
 
     # gather hypervisor of guests from sysctl kern.vm_guest
@@ -92,22 +92,22 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "vmware"
       virtualization[:role] = "guest"
       virtualization[:systems][:vmware] = "guest"
-      Ohai::Log.debug("Plugin Virtualization: Guest running on VMware detected")
+      logger.trace("Plugin Virtualization: Guest running on VMware detected")
     when /hv/
       virtualization[:system] = "hyperv"
       virtualization[:role] = "guest"
       virtualization[:systems][:hyperv] = "guest"
-      Ohai::Log.debug("Plugin Virtualization: Guest running on Hyper-V detected")
+      logger.trace("Plugin Virtualization: Guest running on Hyper-V detected")
     when /xen/
       virtualization[:system] = "xen"
       virtualization[:role] = "guest"
       virtualization[:systems][:xen] = "guest"
-      Ohai::Log.debug("Plugin Virtualization: Guest running on Xen detected")
+      logger.trace("Plugin Virtualization: Guest running on Xen detected")
     when /bhyve/
       virtualization[:system] = "bhyve"
       virtualization[:role] = "guest"
       virtualization[:systems][:bhyve] = "guest"
-      Ohai::Log.debug("Plugin Virtualization: Guest running on bhyve detected")
+      logger.trace("Plugin Virtualization: Guest running on bhyve detected")
     end
 
     # parse dmidecode to discover various virtualization guests
@@ -117,7 +117,7 @@ Ohai.plugin(:Virtualization) do
         virtualization[:system] = guest
         virtualization[:role] = "guest"
         virtualization[:systems][guest.to_sym] = "guest"
-        Ohai::Log.debug("Plugin Virtualization: Guest running on #{guest} detected")
+        logger.trace("Plugin Virtualization: Guest running on #{guest} detected")
       end
     end
   end

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -25,24 +25,24 @@ Ohai.plugin(:C) do
     if so.exitstatus == 0
       yield(so)
     else
-      Ohai::Log.debug("Plugin C: '#{cmd}' failed. Skipping data.")
+      logger.trace("Plugin C: '#{cmd}' failed. Skipping data.")
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug("Plugin C: '#{cmd}' binary could not be found. Skipping data.")
+    logger.trace("Plugin C: '#{cmd}' binary could not be found. Skipping data.")
   end
 
   def xcode_installed?
-    Ohai::Log.debug("Plugin C: Checking for Xcode Command Line Tools.")
+    logger.trace("Plugin C: Checking for Xcode Command Line Tools.")
     so = shell_out("/usr/bin/xcode-select -p")
     if so.exitstatus == 0
-      Ohai::Log.debug("Plugin C: Xcode Command Line Tools found.")
+      logger.trace("Plugin C: Xcode Command Line Tools found.")
       return true
     else
-      Ohai::Log.debug("Plugin C: Xcode Command Line Tools not found.")
+      logger.trace("Plugin C: Xcode Command Line Tools not found.")
       return false
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug("Plugin C: xcode-select binary could not be found. Skipping data.")
+    logger.trace("Plugin C: xcode-select binary could not be found. Skipping data.")
   end
 
   def collect_gcc
@@ -60,7 +60,7 @@ Ohai.plugin(:C) do
     # COLLECT_GCC=gcc
     # COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/5/lto-wrapper
     # Target: x86_64-linux-gnu
-    # Configured with: ../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.4' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
+    # Configured with: ../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.4' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-trace --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
     # Thread model: posix
     # gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
     gcc = Mash.new
@@ -134,7 +134,7 @@ Ohai.plugin(:C) do
       end
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug("Plugin C: 'xlc' binary could not be found. Skipping data.")
+    logger.trace("Plugin C: 'xlc' binary could not be found. Skipping data.")
   end
 
   def collect_sunpro

--- a/lib/ohai/plugins/chef.rb
+++ b/lib/ohai/plugins/chef.rb
@@ -23,7 +23,7 @@ Ohai.plugin(:Chef) do
     begin
       require "chef/version"
     rescue Gem::LoadError
-      Ohai::Log.debug("Plugin Chef: Unable to load the chef gem to determine the version")
+      logger.trace("Plugin Chef: Unable to load the chef gem to determine the version")
       # this catches when you've done a major version bump of ohai, but
       # your chef gem is incompatible, so we can't load it in the same VM
       # (affects mostly internal testing)

--- a/lib/ohai/plugins/darwin/hardware.rb
+++ b/lib/ohai/plugins/darwin/hardware.rb
@@ -30,7 +30,7 @@ Ohai.plugin(:Hardware) do
     unless hardware
       hardware Mash.new
     else
-      Ohai::Log.debug("Plugin Hardware: namespace already exists")
+      logger.trace("Plugin Hardware: namespace already exists")
       next
     end
 
@@ -38,7 +38,7 @@ Ohai.plugin(:Hardware) do
       require "plist"
     rescue LoadError => e
       # In case the plist gem isn't present, skip this plugin.
-      Ohai::Log.debug("Plugin Hardware: Can't load gem: #{e}. Cannot continue.")
+      logger.trace("Plugin Hardware: Can't load gem: #{e}. Cannot continue.")
       next
     end
 

--- a/lib/ohai/plugins/darwin/system_profiler.rb
+++ b/lib/ohai/plugins/darwin/system_profiler.rb
@@ -66,7 +66,7 @@ SPAirPortData},
 
       system_profile ( items.sort_by { |h| h["_dataType"] } ) # rubocop: disable Lint/ParenthesesAsGroupedExpression
     rescue LoadError => e
-      Ohai::Log.debug("Can't load gem: #{e})")
+      logger.trace("Can't load gem: #{e})")
     end
   end
 end

--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -31,13 +31,13 @@ Ohai.plugin(:DigitalOcean) do
     begin
       # detect a vendor of "DigitalOcean"
       if dmi[:bios][:all_records][0][:Vendor] == "DigitalOcean"
-        Ohai::Log.debug("Plugin DigitalOcean: has_do_dmi? == true")
+        logger.trace("Plugin DigitalOcean: has_do_dmi? == true")
         return true
       end
     rescue NoMethodError
       # dmi[:bios][:all_records][0][:Vendor] may not exist
     end
-    Ohai::Log.debug("Plugin DigitalOcean: has_do_dmi? == false")
+    logger.trace("Plugin DigitalOcean: has_do_dmi? == false")
     false
   end
 
@@ -49,14 +49,14 @@ Ohai.plugin(:DigitalOcean) do
 
   collect_data do
     if looks_like_digital_ocean?
-      Ohai::Log.debug("Plugin Digitalocean: looks_like_digital_ocean? == true")
+      logger.trace("Plugin Digitalocean: looks_like_digital_ocean? == true")
       digital_ocean Mash.new
       fetch_metadata.each do |k, v|
         next if k == "vendor_data" # this may have sensitive data we shouldn't store
         digital_ocean[k] = v
       end
     else
-      Ohai::Log.debug("Plugin Digitalocean: No hints present for and doesn't look like digitalocean")
+      logger.trace("Plugin Digitalocean: No hints present for and doesn't look like digitalocean")
       false
     end
   end

--- a/lib/ohai/plugins/dmi.rb
+++ b/lib/ohai/plugins/dmi.rb
@@ -93,14 +93,14 @@ Ohai.plugin(:DMI) do
 
         elsif ( type = type_line.match(line) )
           if dmi_record .nil?
-            Ohai::Log.debug("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
+            logger.trace("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
             next
           end
           dmi[dmi_record[:type]][:all_records][dmi_record[:position]][:application_identifier] = type[1]
 
         elsif ( data = data_line.match(line) )
           if dmi_record .nil?
-            Ohai::Log.debug("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
+            logger.trace("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
             next
           end
           dmi[dmi_record[:type]][:all_records][dmi_record[:position]][data[1]] = data[2]
@@ -108,11 +108,11 @@ Ohai.plugin(:DMI) do
 
         elsif ( extended_data = extended_data_line.match(line) )
           if dmi_record .nil?
-            Ohai::Log.debug("Plugin DMI: unexpected extended data line found before header; discarding:\n#{line}")
+            logger.trace("Plugin DMI: unexpected extended data line found before header; discarding:\n#{line}")
             next
           end
           if field .nil?
-            Ohai::Log.debug("Plugin DMI: unexpected extended data line found outside data section; discarding:\n#{line}")
+            logger.trace("Plugin DMI: unexpected extended data line found outside data section; discarding:\n#{line}")
             next
           end
           # overwrite "raw" value with a new Mash
@@ -120,14 +120,14 @@ Ohai.plugin(:DMI) do
           dmi[dmi_record[:type]][:all_records][dmi_record[:position]][field][extended_data[1]] = nil
 
         else
-          Ohai::Log.debug("Plugin DMI: unrecognized output line; discarding:\n#{line}")
+          logger.trace("Plugin DMI: unrecognized output line; discarding:\n#{line}")
 
         end
       end
 
       Ohai::Common::DMI.convenience_keys(dmi)
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin DMI: Could not shell_out "dmidecode". Skipping data')
+      logger.trace('Plugin DMI: Could not shell_out "dmidecode". Skipping data')
     end
   end
 end

--- a/lib/ohai/plugins/docker.rb
+++ b/lib/ohai/plugins/docker.rb
@@ -27,7 +27,7 @@ Ohai.plugin(:Docker) do
       return JSON.parse(so.stdout)
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug('Plugin Docker: Could not shell_out "docker info --format \'{{json .}}\'". Skipping plugin')
+    logger.trace('Plugin Docker: Could not shell_out "docker info --format \'{{json .}}\'". Skipping plugin')
   end
 
   def docker_ohai_data(shellout_data)

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -42,10 +42,10 @@ Ohai.plugin(:EC2) do
   def has_ec2_amazon_dmi?
     # detect a version of '4.2.amazon'
     if file_val_if_exists("/sys/class/dmi/id/bios_vendor") =~ /Amazon/
-      Ohai::Log.debug("Plugin EC2: has_ec2_amazon_dmi? == true")
+      logger.trace("Plugin EC2: has_ec2_amazon_dmi? == true")
       true
     else
-      Ohai::Log.debug("Plugin EC2: has_ec2_amazon_dmi? == false")
+      logger.trace("Plugin EC2: has_ec2_amazon_dmi? == false")
       false
     end
   end
@@ -57,10 +57,10 @@ Ohai.plugin(:EC2) do
   def has_ec2_xen_dmi?
     # detect a version of '4.2.amazon'
     if file_val_if_exists("/sys/class/dmi/id/bios_version") =~ /amazon/
-      Ohai::Log.debug("Plugin EC2: has_ec2_xen_dmi? == true")
+      logger.trace("Plugin EC2: has_ec2_xen_dmi? == true")
       true
     else
-      Ohai::Log.debug("Plugin EC2: has_ec2_xen_dmi? == false")
+      logger.trace("Plugin EC2: has_ec2_xen_dmi? == false")
       false
     end
   end
@@ -69,10 +69,10 @@ Ohai.plugin(:EC2) do
   # @return [Boolean] do we have a Xen UUID or not?
   def has_ec2_xen_uuid?
     if file_val_if_exists("/sys/hypervisor/uuid") =~ /^ec2/
-      Ohai::Log.debug("Plugin EC2: has_ec2_xen_uuid? == true")
+      logger.trace("Plugin EC2: has_ec2_xen_uuid? == true")
       return true
     end
-    Ohai::Log.debug("Plugin EC2: has_ec2_xen_uuid? == false")
+    logger.trace("Plugin EC2: has_ec2_xen_uuid? == false")
     false
   end
 
@@ -85,11 +85,11 @@ Ohai.plugin(:EC2) do
       require "wmi-lite/wmi"
       wmi = WmiLite::Wmi.new
       if wmi.first_of("Win32_ComputerSystemProduct")["identifyingnumber"] =~ /^ec2/
-        Ohai::Log.debug("Plugin EC2: has_ec2_identifying_number? == true")
+        logger.trace("Plugin EC2: has_ec2_identifying_number? == true")
         return true
       end
     else
-      Ohai::Log.debug("Plugin EC2: has_ec2_identifying_number? == false")
+      logger.trace("Plugin EC2: has_ec2_identifying_number? == false")
       false
     end
   end
@@ -116,7 +116,7 @@ Ohai.plugin(:EC2) do
 
   collect_data do
     if looks_like_ec2?
-      Ohai::Log.debug("Plugin EC2: looks_like_ec2? == true")
+      logger.trace("Plugin EC2: looks_like_ec2? == true")
       ec2 Mash.new
       fetch_metadata.each do |k, v|
         # fetch_metadata returns IAM security credentials, including the IAM user's
@@ -132,11 +132,11 @@ Ohai.plugin(:EC2) do
       ec2[:region] = fetch_dynamic_data["region"]
       # ASCII-8BIT is equivalent to BINARY in this case
       if ec2[:userdata] && ec2[:userdata].encoding.to_s == "ASCII-8BIT"
-        Ohai::Log.debug("Plugin EC2: Binary UserData Found. Storing in base64")
+        logger.trace("Plugin EC2: Binary UserData Found. Storing in base64")
         ec2[:userdata] = Base64.encode64(ec2[:userdata])
       end
     else
-      Ohai::Log.debug("Plugin EC2: looks_like_ec2? == false")
+      logger.trace("Plugin EC2: looks_like_ec2? == false")
       false
     end
   end

--- a/lib/ohai/plugins/elixir.rb
+++ b/lib/ohai/plugins/elixir.rb
@@ -30,7 +30,7 @@ Ohai.plugin(:Elixir) do
         languages[:elixir] = elixir
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Elixir: Could not shell_out "elixir -v". Skipping plugin')
+      logger.trace('Plugin Elixir: Could not shell_out "elixir -v". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/erlang.rb
+++ b/lib/ohai/plugins/erlang.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Erlang) do
         erlang[:nif_version] = output[2]
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Erlang: Could not shell_out "erl -eval \'erlang:display(erlang:system_info(otp_release)), erlang:display(erlang:system_info(version)), erlang:display(erlang:system_info(nif_version)), halt().\'  -noshell". Skipping data')
+      logger.trace('Plugin Erlang: Could not shell_out "erl -eval \'erlang:display(erlang:system_info(otp_release)), erlang:display(erlang:system_info(version)), erlang:display(erlang:system_info(nif_version)), halt().\'  -noshell". Skipping data')
     end
 
     begin
@@ -51,7 +51,7 @@ Ohai.plugin(:Erlang) do
         end
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Erlang: Could not shell_out "erl +V". Skipping data')
+      logger.trace('Plugin Erlang: Could not shell_out "erl +V". Skipping data')
     end
 
     languages[:erlang] = erlang unless erlang.empty?

--- a/lib/ohai/plugins/eucalyptus.rb
+++ b/lib/ohai/plugins/eucalyptus.rb
@@ -43,12 +43,12 @@ Ohai.plugin(:Eucalyptus) do
     network[:interfaces].each_value do |iface|
       mac = get_mac_address(iface[:addresses])
       if mac =~ /^[dD]0:0[dD]:/
-        Ohai::Log.debug("Plugin Eucalyptus: has_euca_mac? == true (#{mac})")
+        logger.trace("Plugin Eucalyptus: has_euca_mac? == true (#{mac})")
         return true
       end
     end
 
-    Ohai::Log.debug("Plugin Eucalyptus: has_euca_mac? == false")
+    logger.trace("Plugin Eucalyptus: has_euca_mac? == false")
     false
   end
 
@@ -60,7 +60,7 @@ Ohai.plugin(:Eucalyptus) do
 
   collect_data do
     if looks_like_euca?
-      Ohai::Log.debug("Plugin Eucalyptus: looks_like_euca? == true")
+      logger.trace("Plugin Eucalyptus: looks_like_euca? == true")
       eucalyptus Mash.new
       fetch_metadata.each do |k, v|
         # Eucalyptus 3.4+ supports IAM roles and Instance Profiles much like AWS
@@ -75,7 +75,7 @@ Ohai.plugin(:Eucalyptus) do
       end
       eucalyptus[:userdata] = fetch_userdata
     else
-      Ohai::Log.debug("Plugin Eucalyptus: looks_like_euca? == false")
+      logger.trace("Plugin Eucalyptus: looks_like_euca? == false")
       false
     end
   end

--- a/lib/ohai/plugins/gce.rb
+++ b/lib/ohai/plugins/gce.rb
@@ -43,11 +43,11 @@ Ohai.plugin(:GCE) do
 
   collect_data do
     if looks_like_gce?
-      Ohai::Log.debug("Plugin GCE: looks_like_gce? == true")
+      logger.trace("Plugin GCE: looks_like_gce? == true")
       gce Mash.new
       fetch_metadata.each { |k, v| gce[k] = v }
     else
-      Ohai::Log.debug("Plugin GCE: looks_like_gce? == false")
+      logger.trace("Plugin GCE: looks_like_gce? == false")
       false
     end
   end

--- a/lib/ohai/plugins/go.rb
+++ b/lib/ohai/plugins/go.rb
@@ -28,7 +28,7 @@ Ohai.plugin(:Go) do
         languages[:go] = go
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Go: Could not shell_out "go version". Skipping plugin')
+      logger.trace('Plugin Go: Could not shell_out "go version". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/groovy.rb
+++ b/lib/ohai/plugins/groovy.rb
@@ -32,7 +32,7 @@ Ohai.plugin(:Groovy) do
         languages[:groovy] = groovy
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Groovy: Could not shell_out "groovy -v". Skipping plugin')
+      logger.trace('Plugin Groovy: Could not shell_out "groovy -v". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/haskell.rb
+++ b/lib/ohai/plugins/haskell.rb
@@ -39,7 +39,7 @@ Ohai.plugin(:Haskell) do
         haskell[:ghc][:description] = so.stdout.chomp
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Haskell: Could not shell_out "ghc --version". Skipping data')
+      logger.trace('Plugin Haskell: Could not shell_out "ghc --version". Skipping data')
     end
 
     # Check for ghci
@@ -54,7 +54,7 @@ Ohai.plugin(:Haskell) do
         haskell[:ghci][:description] = so.stdout.chomp
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Haskell: Could not shell_out "ghci --version". Skipping data')
+      logger.trace('Plugin Haskell: Could not shell_out "ghci --version". Skipping data')
     end
 
     # Check for cabal
@@ -70,7 +70,7 @@ Ohai.plugin(:Haskell) do
         haskell[:cabal][:description] = so.stdout.split("\n")[0].chomp
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Haskell: Could not shell_out "cabal --version". Skipping data')
+      logger.trace('Plugin Haskell: Could not shell_out "cabal --version". Skipping data')
     end
 
     # Check for stack
@@ -87,7 +87,7 @@ Ohai.plugin(:Haskell) do
         haskell[:stack][:description] = so.stdout.chomp
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Haskell: Could not shell_out "stack --version". Skipping data')
+      logger.trace('Plugin Haskell: Could not shell_out "stack --version". Skipping data')
     end
 
     languages[:haskell] = haskell unless haskell.empty?

--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -103,18 +103,18 @@ Ohai.plugin(:Hostname) do
       # Sometimes... very rarely, but sometimes, 'hostname --fqdn' falsely
       # returns a blank string. WTF.
       if ourfqdn.nil? || ourfqdn.empty?
-        Ohai::Log.debug("Plugin Hostname: hostname returned an empty string, retrying once.")
+        logger.trace("Plugin Hostname: hostname returned an empty string, retrying once.")
         ourfqdn = resolve_fqdn
       end
 
       if ourfqdn.nil? || ourfqdn.empty?
-        Ohai::Log.debug("Plugin Hostname: hostname returned an empty string twice and will" +
+        logger.trace("Plugin Hostname: hostname returned an empty string twice and will" +
                         "not be set.")
       else
         fqdn ourfqdn
       end
     rescue
-      Ohai::Log.debug(
+      logger.trace(
         "Plugin Hostname: hostname returned an error, probably no domain set")
     end
     domain collect_domain
@@ -135,19 +135,19 @@ Ohai.plugin(:Hostname) do
       # Sometimes... very rarely, but sometimes, 'hostname --fqdn' falsely
       # returns a blank string. WTF.
       if ourfqdn.nil? || ourfqdn.empty?
-        Ohai::Log.debug("Plugin Hostname: hostname --fqdn returned an empty string, retrying " +
+        logger.trace("Plugin Hostname: hostname --fqdn returned an empty string, retrying " +
                         "once.")
         ourfqdn = from_cmd("hostname --fqdn")
       end
 
       if ourfqdn.nil? || ourfqdn.empty?
-        Ohai::Log.debug("Plugin Hostname: hostname --fqdn returned an empty string twice and " +
+        logger.trace("Plugin Hostname: hostname --fqdn returned an empty string twice and " +
                         "will not be set.")
       else
         fqdn ourfqdn
       end
     rescue
-      Ohai::Log.debug("Plugin Hostname: hostname --fqdn returned an error, probably no domain set")
+      logger.trace("Plugin Hostname: hostname --fqdn returned an error, probably no domain set")
     end
     domain collect_domain
   end

--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -42,7 +42,7 @@ Ohai.plugin(:Java) do
       languages[:java] = java unless java.empty?
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug('Plugin Java: Could not shell_out "java -mx64m -version". Skipping plugin')
+    logger.trace('Plugin Java: Could not shell_out "java -mx64m -version". Skipping plugin')
   end
 
   # On Mac OS X, the development tools include "stubs" for JVM executables that

--- a/lib/ohai/plugins/libvirt.rb
+++ b/lib/ohai/plugins/libvirt.rb
@@ -31,9 +31,9 @@ Ohai.plugin(:Libvirt) do
 
   def load_libvirt
     require "libvirt" # this is the ruby-libvirt gem not the libvirt gem
-    Ohai::Log.debug("Plugin Libvirt: Successfully loaded ruby-libvirt gem")
+    logger.trace("Plugin Libvirt: Successfully loaded ruby-libvirt gem")
   rescue LoadError
-    Ohai::Log.debug("Plugin Libvirt: Can't load gem ruby-libvirt.")
+    logger.trace("Plugin Libvirt: Can't load gem ruby-libvirt.")
   end
 
   def virtconn
@@ -102,12 +102,12 @@ Ohai.plugin(:Libvirt) do
         virtconn.close
         libvirt libvirt_data
       rescue NameError
-        Ohai::Log.debug("Plugin Libvirt: Cannot load ruby-libvirt gem. Skipping...")
+        logger.trace("Plugin Libvirt: Cannot load ruby-libvirt gem. Skipping...")
       rescue Libvirt::ConnectionError
-        Ohai::Log.debug("Plugin Libvirt: Failed to connect to #{emu}:///system. Skipping...")
+        logger.trace("Plugin Libvirt: Failed to connect to #{emu}:///system. Skipping...")
       end
     else
-      Ohai::Log.debug("Plugin Libvirt: Node is not a virtualization host. Skipping...")
+      logger.trace("Plugin Libvirt: Node is not a virtualization host. Skipping...")
     end
   end
 end

--- a/lib/ohai/plugins/linode.rb
+++ b/lib/ohai/plugins/linode.rb
@@ -53,13 +53,13 @@ Ohai.plugin(:Linode) do
   collect_data do
     # Setup linode mash if it is a linode system
     if looks_like_linode?
-      Ohai::Log.debug("Plugin Linode: looks_like_linode? == true")
+      logger.trace("Plugin Linode: looks_like_linode? == true")
       linode Mash.new
       get_ip_address(:public_ip, :eth0)
       get_ip_address(:private_ip, "eth0:1")
       hint?("linode").each { |k, v| linode[k] = v } if hint?("linode").kind_of?(Hash)
     else
-      Ohai::Log.debug("Plugin Linode: looks_like_linode? == false")
+      logger.trace("Plugin Linode: looks_like_linode? == false")
     end
   end
 end

--- a/lib/ohai/plugins/linux/cpu.rb
+++ b/lib/ohai/plugins/linux/cpu.rb
@@ -92,7 +92,7 @@ Ohai.plugin(:CPU) do
       cpu[:cores] = real_cpu.keys.length * cpu["0"]["cores"].to_i
     else
       begin
-        Ohai::Log.debug("Plugin CPU: Falling back to aggregate data from lscpu as real cpu & core data is missing in /proc/cpuinfo")
+        logger.trace("Plugin CPU: Falling back to aggregate data from lscpu as real cpu & core data is missing in /proc/cpuinfo")
         so = shell_out("lscpu")
         if so.exitstatus == 0
           lscpu_data = Mash.new
@@ -110,10 +110,10 @@ Ohai.plugin(:CPU) do
           cpu[:real] = lscpu_data[:sockets]
           cpu[:cores] = lscpu_data[:sockets] * lscpu_data[:cores]
         else
-          Ohai::Log.debug("Plugin CPU: Error executing lscpu. CPU data may not be available.")
+          logger.trace("Plugin CPU: Error executing lscpu. CPU data may not be available.")
         end
       rescue Ohai::Exceptions::Exec # util-linux isn't installed most likely
-        Ohai::Log.debug("Plugin CPU: Error executing lscpu. util-linux may not be installed.")
+        logger.trace("Plugin CPU: Error executing lscpu. util-linux may not be installed.")
       end
     end
   end

--- a/lib/ohai/plugins/linux/filesystem.rb
+++ b/lib/ohai/plugins/linux/filesystem.rb
@@ -133,7 +133,7 @@ Ohai.plugin(:Filesystem) do
       unless Ohai.config[:plugin][:filesystem][:allow_partial_data]
         raise e
       end
-      Ohai::Log.warn("Plugin Filesystem: df binary is not available. Some data will not be available.")
+      logger.warn("Plugin Filesystem: df binary is not available. Some data will not be available.")
     end
 
     # Grab mount information from /bin/mount
@@ -153,7 +153,7 @@ Ohai.plugin(:Filesystem) do
       unless Ohai.config[:plugin][:filesystem][:allow_partial_data]
         raise e
       end
-      Ohai::Log.warn("Plugin Filesystem: mount binary is not available. Some data will not be available.")
+      logger.warn("Plugin Filesystem: mount binary is not available. Some data will not be available.")
     end
 
     # We used to try to decide if we wanted to run lsblk or blkid

--- a/lib/ohai/plugins/linux/lsb.rb
+++ b/lib/ohai/plugins/linux/lsb.rb
@@ -54,7 +54,7 @@ Ohai.plugin(:LSB) do
         end
       end
     else
-      Ohai::Log.debug("Plugin LSB: Skipping LSB, cannot find /etc/lsb-release or /usr/bin/lsb_release")
+      logger.trace("Plugin LSB: Skipping LSB, cannot find /etc/lsb-release or /usr/bin/lsb_release")
     end
   end
 end

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -81,7 +81,7 @@ Ohai.plugin(:Platform) do
     release_contents = File.read("/etc/cumulus/etc.replace/os-release")
     release_contents.match(/VERSION_ID=(.*)/)[1]
   rescue NoMethodError, Errno::ENOENT, Errno::EACCES # rescue regex failure, file missing, or permission denied
-    Ohai::Log.warn("Detected Cumulus Linux, but /etc/cumulus/etc/replace/os-release could not be parsed to determine platform_version")
+    logger.warn("Detected Cumulus Linux, but /etc/cumulus/etc/replace/os-release could not be parsed to determine platform_version")
     nil
   end
 
@@ -94,7 +94,7 @@ Ohai.plugin(:Platform) do
     release_contents = File.read("/etc/f5-release")
     release_contents.match(/BIG-IP release (\S*)/)[1] # http://rubular.com/r/O8nlrBVqSb
   rescue NoMethodError, Errno::ENOENT, Errno::EACCES # rescue regex failure, file missing, or permission denied
-    Ohai::Log.warn("Detected F5 Big-IP, but /etc/f5-release could not be parsed to determine platform_version")
+    logger.warn("Detected F5 Big-IP, but /etc/f5-release could not be parsed to determine platform_version")
     nil
   end
 

--- a/lib/ohai/plugins/linux/sessions.rb
+++ b/lib/ohai/plugins/linux/sessions.rb
@@ -47,7 +47,7 @@ Ohai.plugin(:Sessions) do
         end
       end
     else
-      Ohai::Log.debug("Plugin Sessions: Could not find loginctl. Skipping plugin.")
+      logger.trace("Plugin Sessions: Could not find loginctl. Skipping plugin.")
     end
   end
 end

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -59,7 +59,7 @@ Ohai.plugin(:Virtualization) do
       # This file should exist on most Xen systems, normally empty for guests
       if File.exist?("/proc/xen/capabilities")
         if File.read("/proc/xen/capabilities") =~ /control_d/i
-          Ohai::Log.debug("Plugin Virtualization: /proc/xen/capabilities contains control_d. Detecting as Xen host")
+          logger.trace("Plugin Virtualization: /proc/xen/capabilities contains control_d. Detecting as Xen host")
           virtualization[:role] = "host"
           virtualization[:systems][:xen] = "host"
         end
@@ -70,12 +70,12 @@ Ohai.plugin(:Virtualization) do
     if File.exist?("/proc/modules")
       modules = File.read("/proc/modules")
       if modules =~ /^vboxdrv/
-        Ohai::Log.debug("Plugin Virtualization: /proc/modules contains vboxdrv. Detecting as vbox host")
+        logger.trace("Plugin Virtualization: /proc/modules contains vboxdrv. Detecting as vbox host")
         virtualization[:system] = "vbox"
         virtualization[:role] = "host"
         virtualization[:systems][:vbox] = "host"
       elsif modules =~ /^vboxguest/
-        Ohai::Log.debug("Plugin Virtualization: /proc/modules contains vboxguest. Detecting as vbox guest")
+        logger.trace("Plugin Virtualization: /proc/modules contains vboxguest. Detecting as vbox guest")
         virtualization[:system] = "vbox"
         virtualization[:role] = "guest"
         virtualization[:systems][:vbox] = "guest"
@@ -84,7 +84,7 @@ Ohai.plugin(:Virtualization) do
 
     # if nova binary is present we're on an openstack host
     if nova_exists?
-      Ohai::Log.debug("Plugin Virtualization: nova command exists. Detecting as openstack host")
+      logger.trace("Plugin Virtualization: nova command exists. Detecting as openstack host")
       virtualization[:system] = "openstack"
       virtualization[:role] = "host"
       virtualization[:systems][:openstack] = "host"
@@ -93,7 +93,7 @@ Ohai.plugin(:Virtualization) do
     # Detect paravirt KVM/QEMU from cpuinfo, report as KVM
     if File.exist?("/proc/cpuinfo")
       if File.read("/proc/cpuinfo") =~ /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/
-        Ohai::Log.debug("Plugin Virtualization: /proc/cpuinfo lists a KVM paravirt CPU string. Detecting as kvm guest")
+        logger.trace("Plugin Virtualization: /proc/cpuinfo lists a KVM paravirt CPU string. Detecting as kvm guest")
         virtualization[:system] = "kvm"
         virtualization[:role] = "guest"
         virtualization[:systems][:kvm] = "guest"
@@ -105,11 +105,11 @@ Ohai.plugin(:Virtualization) do
     if File.exist?("/sys/devices/virtual/misc/kvm")
       virtualization[:system] = "kvm"
       if File.read("/proc/cpuinfo") =~ /hypervisor/
-        Ohai::Log.debug("Plugin Virtualization: /sys/devices/virtual/misc/kvm present and /proc/cpuinfo lists the hypervisor feature. Detecting as kvm guest")
+        logger.trace("Plugin Virtualization: /sys/devices/virtual/misc/kvm present and /proc/cpuinfo lists the hypervisor feature. Detecting as kvm guest")
         virtualization[:role] = "guest"
         virtualization[:systems][:kvm] = "guest"
       else
-        Ohai::Log.debug("Plugin Virtualization: /sys/devices/virtual/misc/kvm present and /proc/cpuinfo does not list the hypervisor feature. Detecting as kvm host")
+        logger.trace("Plugin Virtualization: /sys/devices/virtual/misc/kvm present and /proc/cpuinfo does not list the hypervisor feature. Detecting as kvm host")
         virtualization[:role] = "host"
         virtualization[:systems][:kvm] = "host"
       end
@@ -118,12 +118,12 @@ Ohai.plugin(:Virtualization) do
     # Detect OpenVZ / Virtuozzo.
     # http://wiki.openvz.org/BC_proc_entries
     if File.exist?("/proc/bc/0")
-      Ohai::Log.debug("Plugin Virtualization: /proc/bc/0 exists. Detecting as openvz host")
+      logger.trace("Plugin Virtualization: /proc/bc/0 exists. Detecting as openvz host")
       virtualization[:system] = "openvz"
       virtualization[:role] = "host"
       virtualization[:systems][:openvz] = "host"
     elsif File.exist?("/proc/vz")
-      Ohai::Log.debug("Plugin Virtualization: /proc/vz exists. Detecting as openvz guest")
+      logger.trace("Plugin Virtualization: /proc/vz exists. Detecting as openvz guest")
       virtualization[:system] = "openvz"
       virtualization[:role] = "guest"
       virtualization[:systems][:openvz] = "guest"
@@ -132,7 +132,7 @@ Ohai.plugin(:Virtualization) do
     # Detect Parallels virtual machine from pci devices
     if File.exist?("/proc/bus/pci/devices")
       if File.read("/proc/bus/pci/devices") =~ /1ab84000/
-        Ohai::Log.debug("Plugin Virtualization: /proc/bus/pci/devices contains '1ab84000' pci device. Detecting as parallels guest")
+        logger.trace("Plugin Virtualization: /proc/bus/pci/devices contains '1ab84000' pci device. Detecting as parallels guest")
         virtualization[:system] = "parallels"
         virtualization[:role] = "guest"
         virtualization[:systems][:parallels] = "guest"
@@ -143,7 +143,7 @@ Ohai.plugin(:Virtualization) do
     if File.exist?("/usr/sbin/dmidecode")
       guest = guest_from_dmi(shell_out("dmidecode").stdout)
       if guest
-        Ohai::Log.debug("Plugin Virtualization: dmidecode contains string indicating #{guest} guest")
+        logger.trace("Plugin Virtualization: dmidecode contains string indicating #{guest} guest")
         virtualization[:system] = guest
         virtualization[:role] = "guest"
         virtualization[:systems][guest.to_sym] = "guest"
@@ -157,11 +157,11 @@ Ohai.plugin(:Virtualization) do
       if vxid && vxid[2]
         virtualization[:system] = "linux-vserver"
         if vxid[2] == "0"
-          Ohai::Log.debug("Plugin Virtualization: /proc/self/status contains 's_context' or 'VxID' with a value of 0. Detecting as linux-vserver host")
+          logger.trace("Plugin Virtualization: /proc/self/status contains 's_context' or 'VxID' with a value of 0. Detecting as linux-vserver host")
           virtualization[:role] = "host"
           virtualization[:systems]["linux-vserver"] = "host"
         else
-          Ohai::Log.debug("Plugin Virtualization: /proc/self/status contains 's_context' or 'VxID' with a non-0 value. Detecting as linux-vserver guest")
+          logger.trace("Plugin Virtualization: /proc/self/status contains 's_context' or 'VxID' with a non-0 value. Detecting as linux-vserver guest")
           virtualization[:role] = "guest"
           virtualization[:systems]["linux-vserver"] = "guest"
         end
@@ -190,17 +190,17 @@ Ohai.plugin(:Virtualization) do
       cgroup_content = File.read("/proc/self/cgroup")
       if cgroup_content =~ %r{^\d+:[^:]+:/(lxc|docker)/.+$} ||
           cgroup_content =~ %r{^\d+:[^:]+:/[^/]+/(lxc|docker)-?.+$}
-        Ohai::Log.debug("Plugin Virtualization: /proc/self/cgroup indicates #{$1} container. Detecting as #{$1} guest")
+        logger.trace("Plugin Virtualization: /proc/self/cgroup indicates #{$1} container. Detecting as #{$1} guest")
         virtualization[:system] = $1
         virtualization[:role] = "guest"
         virtualization[:systems][$1.to_sym] = "guest"
       elsif File.read("/proc/1/environ") =~ /container=lxc/
-        Ohai::Log.debug("Plugin Virtualization: /proc/1/environ indicates lxc container. Detecting as lxc guest")
+        logger.trace("Plugin Virtualization: /proc/1/environ indicates lxc container. Detecting as lxc guest")
         virtualization[:system] = "lxc"
         virtualization[:role] = "guest"
         virtualization[:systems][:lxc] = "guest"
       elsif File.read("/proc/1/environ") =~ /container=systemd-nspawn/
-        Ohai::Log.debug("Plugin Virtualization: /proc/1/environ indicates nspawn container. Detecting as nspawn guest")
+        logger.trace("Plugin Virtualization: /proc/1/environ indicates nspawn container. Detecting as nspawn guest")
         virtualization[:system] = "nspawn"
         virtualization[:role] = "guest"
         virtualization[:systems][:nspawn] = "guest"
@@ -209,7 +209,7 @@ Ohai.plugin(:Virtualization) do
         # Even so, it is likely we are on an LXC capable host that is not being used as such
         # So we're cautious here to not overwrite other existing values (OHAI-573)
         unless virtualization[:system] && virtualization[:role]
-          Ohai::Log.debug("Plugin Virtualization: /proc/self/cgroup and lxc-version command exist. Detecting as lxc host")
+          logger.trace("Plugin Virtualization: /proc/self/cgroup and lxc-version command exist. Detecting as lxc host")
           virtualization[:system] = "lxc"
           virtualization[:role] = "host"
         end
@@ -219,7 +219,7 @@ Ohai.plugin(:Virtualization) do
         virtualization[:systems][:lxc] = "host"
       end
     elsif File.exist?("/.dockerenv") || File.exist?("/.dockerinit")
-      Ohai::Log.debug("Plugin Virtualization: .dockerenv or .dockerinit exist. Detecting as docker guest")
+      logger.trace("Plugin Virtualization: .dockerenv or .dockerinit exist. Detecting as docker guest")
       virtualization[:system] = "docker"
       virtualization[:role] = "guest"
       virtualization[:systems][:docker] = "guest"
@@ -228,7 +228,7 @@ Ohai.plugin(:Virtualization) do
     # Detect LXD
     # See https://github.com/lxc/lxd/blob/master/doc/dev-lxd.md
     if File.exist?("/dev/lxd/sock")
-      Ohai::Log.debug("Plugin Virtualization: /dev/lxd/sock exists. Detecting as lxd guest")
+      logger.trace("Plugin Virtualization: /dev/lxd/sock exists. Detecting as lxd guest")
       virtualization[:system] = "lxd"
       virtualization[:role] = "guest"
     else
@@ -242,7 +242,7 @@ Ohai.plugin(:Virtualization) do
       #   - includes all future releases starting with 2.21, and will be the only source of 3.1+ feature releases post-bionic
       ["/var/lib/lxd/devlxd", "/var/snap/lxd/common/lxd/devlxd"].each do |devlxd|
         if File.exist?(devlxd)
-          Ohai::Log.debug("Plugin Virtualization: #{devlxd} exists. Detecting as lxd host")
+          logger.trace("Plugin Virtualization: #{devlxd} exists. Detecting as lxd host")
           virtualization[:system] = "lxd"
           virtualization[:role] = "host"
           break

--- a/lib/ohai/plugins/lua.rb
+++ b/lib/ohai/plugins/lua.rb
@@ -33,7 +33,7 @@ Ohai.plugin(:Lua) do
         languages[:lua] = lua if lua[:version]
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Lua: Could not shell_out "lua -v". Skipping plugin')
+      logger.trace('Plugin Lua: Could not shell_out "lua -v". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/mono.rb
+++ b/lib/ohai/plugins/mono.rb
@@ -31,7 +31,7 @@ Ohai.plugin(:Mono) do
       # 	Notification:  kqueue
       # 	Architecture:  amd64
       # 	Disabled:      none
-      # 	Misc:          softdebug
+      # 	Misc:          softtrace
       # 	LLVM:          supported, not enabled.
       # 	GC:            sgen
       if so.exitstatus == 0
@@ -44,7 +44,7 @@ Ohai.plugin(:Mono) do
         languages[:mono] = mono unless mono.empty?
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Mono: Could not shell_out "mono -V". Skipping plugin')
+      logger.trace('Plugin Mono: Could not shell_out "mono -V". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -76,13 +76,13 @@ Ohai.plugin(:NetworkAddresses) do
         v[:iface] == network[int_attr]
       end
       if gw_if_ips.empty?
-        Ohai::Log.warn("Plugin Network: [#{family}] no ip address on #{network[int_attr]}")
+        logger.warn("Plugin Network: [#{family}] no ip address on #{network[int_attr]}")
       elsif network[gw_attr] &&
           network["interfaces"][network[int_attr]] &&
           network["interfaces"][network[int_attr]]["addresses"]
         if [ "0.0.0.0", "::", /^fe80:/ ].any? { |pat| pat === network[gw_attr] }
           # link level default route
-          Ohai::Log.debug("Plugin Network: link level default #{family} route, picking ip from #{network[gw_attr]}")
+          logger.trace("Plugin Network: link level default #{family} route, picking ip from #{network[gw_attr]}")
           r = gw_if_ips.first
         else
           # checking network masks
@@ -91,9 +91,9 @@ Ohai.plugin(:NetworkAddresses) do
           end.first
           if r.nil?
             r = gw_if_ips.first
-            Ohai::Log.debug("Plugin Network: [#{family}] no ipaddress/mask on #{network[int_attr]} matching the gateway #{network[gw_attr]}, picking #{r[:ipaddress]}")
+            logger.trace("Plugin Network: [#{family}] no ipaddress/mask on #{network[int_attr]} matching the gateway #{network[gw_attr]}, picking #{r[:ipaddress]}")
           else
-            Ohai::Log.debug("Plugin Network: [#{family}] Using default interface #{network[int_attr]} and default gateway #{network[gw_attr]} to set the default ip to #{r[:ipaddress]}")
+            logger.trace("Plugin Network: [#{family}] Using default interface #{network[int_attr]} and default gateway #{network[gw_attr]} to set the default ip to #{r[:ipaddress]}")
           end
         end
       else
@@ -102,7 +102,7 @@ Ohai.plugin(:NetworkAddresses) do
       end
     else
       r = ips.first
-      Ohai::Log.debug("Plugin Network: [#{family}] no default interface, picking the first ipaddress")
+      logger.trace("Plugin Network: [#{family}] no default interface, picking the first ipaddress")
     end
 
     return [ nil, nil ] if r.nil? || r.empty?
@@ -148,13 +148,13 @@ Ohai.plugin(:NetworkAddresses) do
       # don't overwrite attributes if they've already been set by the "#{os}::network" plugin
       if (family == "inet") && ipaddress.nil?
         if r["ip"].nil?
-          Ohai::Log.warn("Plugin Network: unable to detect ipaddress")
+          logger.warn("Plugin Network: unable to detect ipaddress")
         else
           ipaddress r["ip"]
         end
       elsif (family == "inet6") && ip6address.nil?
         if r["ip"].nil?
-          Ohai::Log.debug("Plugin Network: unable to detect ip6address")
+          logger.trace("Plugin Network: unable to detect ip6address")
         else
           ip6address r["ip"]
         end
@@ -164,10 +164,10 @@ Ohai.plugin(:NetworkAddresses) do
       # otherwise we set macaddress on a first-found basis (and we started with ipv4)
       if macaddress.nil?
         if r["mac"]
-          Ohai::Log.debug("Plugin Network: setting macaddress to '#{r["mac"]}' from interface '#{r["iface"]}' for family '#{family}'")
+          logger.trace("Plugin Network: setting macaddress to '#{r["mac"]}' from interface '#{r["iface"]}' for family '#{family}'")
           macaddress r["mac"]
         else
-          Ohai::Log.debug("Plugin Network: unable to detect macaddress for family '#{family}'")
+          logger.trace("Plugin Network: unable to detect macaddress for family '#{family}'")
         end
       end
 
@@ -176,7 +176,7 @@ Ohai.plugin(:NetworkAddresses) do
 
     if results["inet"]["iface"] && results["inet6"]["iface"] &&
         (results["inet"]["iface"] != results["inet6"]["iface"])
-      Ohai::Log.debug("Plugin Network: ipaddress and ip6address are set from different interfaces (#{results["inet"]["iface"]} & #{results["inet6"]["iface"]})")
+      logger.trace("Plugin Network: ipaddress and ip6address are set from different interfaces (#{results["inet"]["iface"]} & #{results["inet6"]["iface"]})")
     end
   end
 end

--- a/lib/ohai/plugins/nodejs.rb
+++ b/lib/ohai/plugins/nodejs.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Nodejs) do
         languages[:nodejs] = nodejs if nodejs[:version]
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Nodejs: Could not shell_out "node -v". Skipping plugin')
+      logger.trace('Plugin Nodejs: Could not shell_out "node -v". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -30,21 +30,21 @@ Ohai.plugin(:Openstack) do
   def openstack_dmi?
     # detect a manufacturer of OpenStack Foundation
     if get_attribute(:dmi, :system, :all_records, 0, :Manufacturer) =~ /OpenStack/
-      Ohai::Log.debug("Plugin Openstack: has_openstack_dmi? == true")
+      logger.trace("Plugin Openstack: has_openstack_dmi? == true")
       true
     else
-      Ohai::Log.debug("Plugin Openstack: has_openstack_dmi? == false")
+      logger.trace("Plugin Openstack: has_openstack_dmi? == false")
       false
     end
   end
 
-  # check for the ohai hint and log debug messaging
+  # check for the ohai hint and log trace messaging
   def openstack_hint?
     if hint?("openstack")
-      Ohai::Log.debug("Plugin Openstack: openstack hint present")
+      logger.trace("Plugin Openstack: openstack hint present")
       true
     else
-      Ohai::Log.debug("Plugin Openstack: openstack hint not present")
+      logger.trace("Plugin Openstack: openstack hint not present")
       false
     end
   end
@@ -66,12 +66,12 @@ Ohai.plugin(:Openstack) do
         fetch_metadata.each do |k, v|
           openstack[k] = v
         end
-        Ohai::Log.debug("Plugin Openstack: Successfully fetched Openstack metadata from the metadata endpoint")
+        logger.trace("Plugin Openstack: Successfully fetched Openstack metadata from the metadata endpoint")
       else
-        Ohai::Log.debug("Plugin Openstack: Timed out connecting to Openstack metadata endpoint. Skipping metadata.")
+        logger.trace("Plugin Openstack: Timed out connecting to Openstack metadata endpoint. Skipping metadata.")
       end
     else
-      Ohai::Log.debug("Plugin Openstack: Node does not appear to be an Openstack node")
+      logger.trace("Plugin Openstack: Node does not appear to be an Openstack node")
     end
   end
 end

--- a/lib/ohai/plugins/perl.rb
+++ b/lib/ohai/plugins/perl.rb
@@ -39,7 +39,7 @@ Ohai.plugin(:Perl) do
         languages[:perl] = perl unless perl.empty?
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Perl: Could not shell_out "perl -V:version -V:archname". Skipping plugin')
+      logger.trace('Plugin Perl: Could not shell_out "perl -V:version -V:archname". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/php.rb
+++ b/lib/ohai/plugins/php.rb
@@ -46,7 +46,7 @@ Ohai.plugin(:PHP) do
         languages[:php] = php unless php.empty?
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Php: Could not shell_out "php -v". Skipping plugin')
+      logger.trace('Plugin Php: Could not shell_out "php -v". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/powershell.rb
+++ b/lib/ohai/plugins/powershell.rb
@@ -51,7 +51,7 @@ Ohai.plugin(:Powershell) do
         languages[:powershell] = powershell unless powershell.empty?
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Powershell: Could not shell_out "powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable". Skipping plugin')
+      logger.trace('Plugin Powershell: Could not shell_out "powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable". Skipping plugin')
     end
   end
 

--- a/lib/ohai/plugins/python.rb
+++ b/lib/ohai/plugins/python.rb
@@ -37,7 +37,7 @@ Ohai.plugin(:Python) do
         languages[:python] = python unless python.empty?
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Python: Could not shell_out "python -c "import sys; print (sys.version)"". Skipping plugin')
+      logger.trace('Plugin Python: Could not shell_out "python -c "import sys; print (sys.version)"". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -52,7 +52,7 @@ Ohai.plugin(:Rackspace) do
     require "wmi-lite/wmi"
     wmi = WmiLite::Wmi.new
     if wmi.first_of("Win32_ComputerSystem")["PrimaryOwnerName"] == "Rackspace"
-      Ohai::Log.debug("Plugin Rackspace: has_rackspace_manufacturer? == true")
+      logger.trace("Plugin Rackspace: has_rackspace_manufacturer? == true")
       return true
     end
   end
@@ -105,7 +105,7 @@ Ohai.plugin(:Rackspace) do
       end
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug("Plugin Rackspace: Unable to find xenstore-ls, cannot capture region information for Rackspace cloud")
+    logger.trace("Plugin Rackspace: Unable to find xenstore-ls, cannot capture region information for Rackspace cloud")
     nil
   end
 
@@ -117,7 +117,7 @@ Ohai.plugin(:Rackspace) do
       rackspace[:instance_id] = so.stdout.gsub(/instance-/, "")
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug("Plugin Rackspace: Unable to find xenstore-read, cannot capture instance ID information for Rackspace cloud")
+    logger.trace("Plugin Rackspace: Unable to find xenstore-read, cannot capture instance ID information for Rackspace cloud")
     nil
   end
 
@@ -132,7 +132,7 @@ Ohai.plugin(:Rackspace) do
         if so.exitstatus == 0
           networks.push(FFI_Yajl::Parser.new.parse(so.stdout))
         else
-          Ohai::Log.debug("Plugin Rackspace: Unable to capture custom private networking information for Rackspace cloud")
+          logger.trace("Plugin Rackspace: Unable to capture custom private networking information for Rackspace cloud")
           return false
         end
       end
@@ -141,7 +141,7 @@ Ohai.plugin(:Rackspace) do
       networks.delete_if { |hash| hash["label"] == "public" }
     end
   rescue Ohai::Exceptions::Exec
-    Ohai::Log.debug("Plugin Rackspace: Unable to capture custom private networking information for Rackspace cloud")
+    logger.trace("Plugin Rackspace: Unable to capture custom private networking information for Rackspace cloud")
     nil
   end
 

--- a/lib/ohai/plugins/rust.rb
+++ b/lib/ohai/plugins/rust.rb
@@ -28,7 +28,7 @@ Ohai.plugin(:Rust) do
         languages[:rust] = rust if rust[:version]
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Rust: Could not shell_out "rustc --version". Skipping plugin')
+      logger.trace('Plugin Rust: Could not shell_out "rustc --version". Skipping plugin')
     end
   end
 end

--- a/lib/ohai/plugins/scala.rb
+++ b/lib/ohai/plugins/scala.rb
@@ -29,7 +29,7 @@ Ohai.plugin(:Scala) do
         scala[:version] = so.stderr.match(/.*version (\S*)/)[1]
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Scala: Could not shell_out "scala -version". Skipping data')
+      logger.trace('Plugin Scala: Could not shell_out "scala -version". Skipping data')
     end
 
     languages[:scala] = scala unless scala.empty?

--- a/lib/ohai/plugins/scaleway.rb
+++ b/lib/ohai/plugins/scaleway.rb
@@ -27,10 +27,10 @@ Ohai.plugin(:Scaleway) do
   # @return [Boolean] do we have the keyword or not?
   def has_scaleway_cmdline?
     if ::File.read("/proc/cmdline") =~ /scaleway/
-      Ohai::Log.debug("Plugin Scaleway: has_scaleway_cmdline? == true")
+      logger.trace("Plugin Scaleway: has_scaleway_cmdline? == true")
       return true
     end
-    Ohai::Log.debug("Plugin Scaleway: has_scaleway_cmdline? == false")
+    logger.trace("Plugin Scaleway: has_scaleway_cmdline? == false")
     false
   end
 
@@ -44,13 +44,13 @@ Ohai.plugin(:Scaleway) do
 
   collect_data do
     if looks_like_scaleway?
-      Ohai::Log.debug("Plugin Scaleway: looks_like_scaleway? == true")
+      logger.trace("Plugin Scaleway: looks_like_scaleway? == true")
       scaleway Mash.new
       fetch_metadata.each do |k, v|
         scaleway[k] = v
       end
     else
-      Ohai::Log.debug("Plugin Scaleway: No hints present for and doesn't look like scaleway")
+      logger.trace("Plugin Scaleway: No hints present for and doesn't look like scaleway")
     end
   end
 end

--- a/lib/ohai/plugins/softlayer.rb
+++ b/lib/ohai/plugins/softlayer.rb
@@ -36,12 +36,12 @@ Ohai.plugin(:Softlayer) do
   collect_data do
     # Adds softlayer Mash
     if looks_like_softlayer?
-      Ohai::Log.debug("Plugin Softlayer: looks_like_softlayer? == true")
+      logger.trace("Plugin Softlayer: looks_like_softlayer? == true")
       metadata = fetch_metadata
       softlayer Mash.new
       metadata.each { |k, v| softlayer[k] = v } if metadata
     else
-      Ohai::Log.debug("Plugin Softlayer: looks_like_softlayer? == false")
+      logger.trace("Plugin Softlayer: looks_like_softlayer? == false")
     end
   end
 end

--- a/lib/ohai/plugins/solaris2/dmi.rb
+++ b/lib/ohai/plugins/solaris2/dmi.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:DMI) do
     # if we already have a "dmi" with keys (presumably from dmidecode), don't try smbios
     # note that a single key just means dmidecode exited with its version
     if (dmi.class.to_s == "Mash") && (dmi.keys.length > 1)
-      Ohai::Log.debug("Plugin DMI: skipping smbios output, since DMI information has already been provided")
+      logger.trace("Plugin DMI: skipping smbios output, since DMI information has already been provided")
       return
     end
 
@@ -118,7 +118,7 @@ Ohai.plugin(:DMI) do
       # remove/replace any characters that don't fall inside permissible ASCII range, or whitespace
       line = raw_line.gsub(/[^\x20-\x7E\n\t\r]/, ".")
       if line != raw_line
-        Ohai::Log.debug("Plugin DMI: converted characters from line:\n#{raw_line}")
+        logger.trace("Plugin DMI: converted characters from line:\n#{raw_line}")
       end
 
       if ( header_information = header_information_line.match(line) )
@@ -137,7 +137,7 @@ Ohai.plugin(:DMI) do
           dmi_record[:type] = Ohai::Common::DMI.id_lookup(id)
 
         else
-          Ohai::Log.debug("Plugin DMI: unrecognized header type; skipping")
+          logger.trace("Plugin DMI: unrecognized header type; skipping")
           dmi_record = nil
           next
         end
@@ -153,7 +153,7 @@ Ohai.plugin(:DMI) do
 
       elsif ( data = data_key_value_line.match(line) )
         if dmi_record.nil?
-          Ohai::Log.debug("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
+          logger.trace("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
           next
         end
         dmi[dmi_record[:type]][:all_records][dmi_record[:position]][data[1]] = data[2]
@@ -161,7 +161,7 @@ Ohai.plugin(:DMI) do
 
       elsif ( data = data_key_only_line.match(line) )
         if dmi_record.nil?
-          Ohai::Log.debug("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
+          logger.trace("Plugin DMI: unexpected data line found before header; discarding:\n#{line}")
           next
         end
         dmi[dmi_record[:type]][:all_records][dmi_record[:position]][data[1]] = ""
@@ -169,11 +169,11 @@ Ohai.plugin(:DMI) do
 
       elsif ( extended_data = extended_data_line.match(line) )
         if dmi_record.nil?
-          Ohai::Log.debug("Plugin DMI: unexpected extended data line found before header; discarding:\n#{line}")
+          logger.trace("Plugin DMI: unexpected extended data line found before header; discarding:\n#{line}")
           next
         end
         if field.nil?
-          Ohai::Log.debug("Plugin DMI: unexpected extended data line found outside data section; discarding:\n#{line}")
+          logger.trace("Plugin DMI: unexpected extended data line found outside data section; discarding:\n#{line}")
           next
         end
         # overwrite "raw" value with a new Mash
@@ -181,7 +181,7 @@ Ohai.plugin(:DMI) do
         dmi[dmi_record[:type]][:all_records][dmi_record[:position]][field][extended_data[1]] = extended_data[2]
 
       else
-        Ohai::Log.debug("Plugin DMI: unrecognized output line; discarding:\n#{line}")
+        logger.trace("Plugin DMI: unrecognized output line; discarding:\n#{line}")
 
       end
     end

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -181,11 +181,11 @@ Ohai.plugin(:Network) do
           else
             matches[:name]
           end
-        Ohai::Log.debug("Plugin Network: found interface device: #{network[:default_interface]} #{matches[:name]}")
+        logger.trace("Plugin Network: found interface device: #{network[:default_interface]} #{matches[:name]}")
       end
       matches = /gateway: (\S+)/.match(line)
       if matches
-        Ohai::Log.debug("Plugin Network: found gateway: #{matches[1]}")
+        logger.trace("Plugin Network: found gateway: #{matches[1]}")
         network[:default_gateway] = matches[1]
       end
     end

--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -44,7 +44,7 @@ Ohai.plugin(:SSHHostKey) do
                     # Darwin
                     "/etc/sshd_config"
                   else
-                    Ohai::Log.debug("Plugin SSHHostKey: Failed to find sshd configuration file")
+                    logger.trace("Plugin SSHHostKey: Failed to find sshd configuration file")
                     nil
                   end
 

--- a/lib/ohai/plugins/virtualbox.rb
+++ b/lib/ohai/plugins/virtualbox.rb
@@ -43,7 +43,7 @@ Ohai.plugin(:Virtualbox) do
         end
       end
     rescue Ohai::Exceptions::Exec
-      Ohai::Log.debug('Plugin Virtualbox: Could not execute "VBoxControl guestproperty enumerate". Skipping data')
+      logger.trace('Plugin Virtualbox: Could not execute "VBoxControl guestproperty enumerate". Skipping data')
     end
   end
 end

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -42,7 +42,7 @@ Ohai.plugin(:VMware) do
 
   def get_vm_attributes(vmtools_path)
     if !File.exist?(vmtools_path)
-      Ohai::Log.debug("Plugin VMware: #{vmtools_path} not found")
+      logger.trace("Plugin VMware: #{vmtools_path} not found")
     else
       vmware Mash.new
       begin
@@ -62,7 +62,7 @@ Ohai.plugin(:VMware) do
           vmware[param] = from_cmd("#{vmtools_path} #{param} status")
         end
       rescue
-        Ohai::Log.debug("Plugin VMware: Error while collecting VMware guest attributes")
+        logger.trace("Plugin VMware: Error while collecting VMware guest attributes")
       end
     end
   end

--- a/lib/ohai/plugins/zpools.rb
+++ b/lib/ohai/plugins/zpools.rb
@@ -33,7 +33,7 @@ Ohai.plugin(:Zpools) do
     so.stdout.lines do |line|
       case line
       when /^([-_0-9A-Za-z]*)\s+([.0-9]+[MGTPE])\s+([.0-9]+[MGTPE])\s+([.0-9]+[MGTPE])\s+(\d+%)\s+([.0-9]+x)\s+([-_0-9A-Za-z]+)\s+(\d+|-)$/
-        Ohai::Log.debug("Plugin Zpools: Parsing zpool list line: #{line.chomp}")
+        logger.trace("Plugin Zpools: Parsing zpool list line: #{line.chomp}")
         pools[$1] = Mash.new
         pools[$1][:pool_size] = sanitize_value($2)
         pools[$1][:pool_allocated] = sanitize_value($3)
@@ -70,7 +70,7 @@ Ohai.plugin(:Zpools) do
         # solaris: http://rubular.com/r/FqOBzUQQ4p
         # freebsd: http://rubular.com/r/RYkMNlytXl
         when /^\s+((sd|c|ad|da)[-_a-zA-Z0-9]+)\s+([-_a-zA-Z0-9]+)\s+(\d+)\s+(\d+)\s+(\d+)$/
-          Ohai::Log.debug("Plugin Zpools: Parsing zpool status line: #{line.chomp}")
+          logger.trace("Plugin Zpools: Parsing zpool status line: #{line.chomp}")
           pools[pool][:devices][$1] = Mash.new
           pools[pool][:devices][$1][:state] = $3
           pools[pool][:devices][$1][:errors] = Mash.new

--- a/lib/ohai/util/file_helper.rb
+++ b/lib/ohai/util/file_helper.rb
@@ -26,11 +26,11 @@ module Ohai
         paths.each do |path|
           filename = File.join(path, cmd)
           if File.executable?(filename)
-            Ohai::Log.debug("Plugin #{name}: found #{cmd} at #{filename}")
+            logger.trace("Plugin #{name}: found #{cmd} at #{filename}")
             return filename
           end
         end
-        Ohai::Log.debug("Plugin #{name}: did not find #{cmd}")
+        logger.trace("Plugin #{name}: did not find #{cmd}")
         false
       end
     end

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "mixlib-cli"
   s.add_dependency "mixlib-config", "~> 2.0"
-  s.add_dependency "mixlib-log", ">= 1.7.1", "< 2.0"
+  s.add_dependency "mixlib-log", "~> 2.0", ">= 2.0.1"
   s.add_dependency "mixlib-shellout", "~> 2.0"
   s.add_dependency "plist", "~> 3.1"
   s.add_dependency "ipaddress"

--- a/spec/unit/dsl/plugin_spec.rb
+++ b/spec/unit/dsl/plugin_spec.rb
@@ -62,8 +62,8 @@ shared_examples "Ohai::DSL::Plugin" do
         plugin.run
       end
 
-      it "logs a message to debug" do
-        expect(Ohai::Log).to receive(:debug).with(/Skipping disabled plugin TestPlugin/)
+      it "logs a message to trace" do
+        expect(plugin.logger).to receive(:trace).with(/Skipping disabled plugin TestPlugin/)
         plugin.run
       end
 
@@ -382,8 +382,9 @@ shared_examples "Ohai::DSL::Plugin" do
 end
 
 describe Ohai::DSL::Plugin::VersionVII do
+  let(:logger) { Ohai::Log }
   it "does not modify the plugin name when the plugin is named correctly" do
-    plugin = Ohai.plugin(:FunkyVALIDpluginName) {}.new({})
+    plugin = Ohai.plugin(:FunkyVALIDpluginName) {}.new({}, logger)
     expect(plugin.name).to eql(:FunkyVALIDpluginName)
   end
 
@@ -538,16 +539,16 @@ describe Ohai::DSL::Plugin::VersionVII do
 
   describe "#provides (deprecated)" do
     it "logs a warning" do
-      plugin = Ohai::DSL::Plugin::VersionVII.new(Mash.new)
-      expect(Ohai::Log).to receive(:warn).with(/\[UNSUPPORTED OPERATION\]/)
+      plugin = Ohai.plugin(:Test).new(Mash.new, logger)
+      expect_any_instance_of(Mixlib::Log::Child).to receive(:warn).with(/\[UNSUPPORTED OPERATION\]/)
       plugin.provides("attribute")
     end
   end
 
   describe "#require_plugin (deprecated)" do
     it "logs a warning" do
-      plugin = Ohai::DSL::Plugin::VersionVII.new(Mash.new)
-      expect(Ohai::Log).to receive(:warn).with(/\[UNSUPPORTED OPERATION\]/)
+      plugin = Ohai.plugin(:Test).new(Mash.new, logger)
+      expect_any_instance_of(Mixlib::Log::Child).to receive(:warn).with(/\[UNSUPPORTED OPERATION\]/)
       plugin.require_plugin("plugin")
     end
   end
@@ -555,7 +556,7 @@ describe Ohai::DSL::Plugin::VersionVII do
   describe "#configuration" do
     let(:plugin) do
       klass = Ohai.plugin(camel_name) {}
-      klass.new({})
+      klass.new({}, logger)
     end
 
     shared_examples_for "plugin config lookup" do
@@ -627,7 +628,7 @@ describe Ohai::DSL::Plugin::VersionVII do
 
   it_behaves_like "Ohai::DSL::Plugin" do
     let(:ohai) { Ohai::System.new }
-    let(:plugin) { Ohai::DSL::Plugin::VersionVII.new(ohai.data) }
+    let(:plugin) { Ohai.plugin(:Test).new(ohai.data, ohai.logger) }
     let(:version) { :version7 }
   end
 end

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -23,7 +23,7 @@ describe Ohai::Loader do
   extend IntegrationSupport
 
   let(:loader) { Ohai::Loader.new(ohai) }
-  let(:ohai) { double("Ohai::System", :data => Mash.new, :provides_map => provides_map) }
+  let(:ohai) { double("Ohai::System", :data => Mash.new, :provides_map => provides_map, logger: Ohai::Log) }
   let(:provides_map) { Ohai::ProvidesMap.new }
 
   describe "#initialize" do
@@ -108,7 +108,7 @@ EOF
     describe "load_plugin() method" do
       describe "when the plugin uses Ohai.plugin instead of Ohai.plugins" do
         it "logs an unsupported operation warning" do
-          expect(Ohai::Log).to receive(:warn).with(/Plugin Method Error: <#{path_to("extra_s.rb")}>:/)
+          expect(loader.logger).to receive(:warn).with(/Plugin Method Error: <#{path_to("extra_s.rb")}>:/)
           loader.load_plugin(path_to("extra_s.rb"))
         end
 
@@ -119,7 +119,7 @@ EOF
 
       describe "when the plugin tries to call an unexisting method" do
         it "shoud log an unsupported operation warning" do
-          expect(Ohai::Log).to receive(:warn).with(/Plugin Method Error: <#{path_to("no_method.rb")}>:/)
+          expect(loader.logger).to receive(:warn).with(/Plugin Method Error: <#{path_to("no_method.rb")}>:/)
           loader.load_plugin(path_to("no_method.rb"))
         end
 
@@ -130,7 +130,7 @@ EOF
 
       describe "when the plugin defines collect_data on the same platform more than once" do
         it "shoud log an illegal plugin definition warning" do
-          expect(Ohai::Log).to receive(:warn).with(/Plugin Definition Error: <#{path_to("illegal_def.rb")}>:/)
+          expect(loader.logger).to receive(:warn).with(/Plugin Definition Error: <#{path_to("illegal_def.rb")}>:/)
           loader.load_plugin(path_to("illegal_def.rb"))
         end
 
@@ -141,7 +141,7 @@ EOF
 
       describe "when an unexpected error is encountered" do
         it "logs a warning" do
-          expect(Ohai::Log).to receive(:warn).with(/Plugin Error: <#{path_to("unexpected_error.rb")}>:/)
+          expect(loader.logger).to receive(:warn).with(/Plugin Error: <#{path_to("unexpected_error.rb")}>:/)
           loader.load_plugin(path_to("unexpected_error.rb"))
         end
 
@@ -152,7 +152,7 @@ EOF
 
       describe "when the plugin name symbol has bad syntax" do
         it "logs a syntax error warning" do
-          expect(Ohai::Log).to receive(:warn).with(/Plugin Syntax Error: <#{path_to("bad_symbol.rb")}>:/)
+          expect(loader.logger).to receive(:warn).with(/Plugin Syntax Error: <#{path_to("bad_symbol.rb")}>:/)
           loader.load_plugin(path_to("bad_symbol.rb"))
         end
 
@@ -163,7 +163,7 @@ EOF
 
       describe "when the plugin forgets an 'end'" do
         it "logs a syntax error warning" do
-          expect(Ohai::Log).to receive(:warn).with(/Plugin Syntax Error: <#{path_to("no_end.rb")}>:/)
+          expect(loader.logger).to receive(:warn).with(/Plugin Syntax Error: <#{path_to("no_end.rb")}>:/)
           loader.load_plugin(path_to("no_end.rb"))
         end
 
@@ -174,7 +174,7 @@ EOF
 
       describe "when the plugin has an invalid name" do
         it "logs an invalid plugin name warning" do
-          expect(Ohai::Log).to receive(:warn).with(/Plugin Name Error: <#{path_to("bad_name.rb")}>:/)
+          expect(loader.logger).to receive(:warn).with(/Plugin Name Error: <#{path_to("bad_name.rb")}>:/)
           loader.load_plugin(path_to("bad_name.rb"))
         end
 

--- a/spec/unit/mixin/azure_metadata_spec.rb
+++ b/spec/unit/mixin/azure_metadata_spec.rb
@@ -25,6 +25,11 @@ describe Ohai::Mixin::AzureMetadata do
     mixin
   end
 
+  before do
+    logger = instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil)
+    allow(mixin).to receive(:logger).and_return(logger)
+  end
+
   describe "#http_get" do
     it "gets the passed URI" do
       http_mock = double("http")
@@ -41,7 +46,7 @@ describe Ohai::Mixin::AzureMetadata do
       http_mock = double("http", { :code => "500" })
       allow(mixin).to receive(:http_get).and_return(http_mock)
 
-      expect(Ohai::Log).to receive(:warn)
+      expect(mixin.logger).to receive(:warn)
       vals = mixin.fetch_metadata
       expect(vals).to eq(nil)
     end
@@ -50,7 +55,7 @@ describe Ohai::Mixin::AzureMetadata do
       http_mock = double("http", { :code => "200", :body => '{ "foo" "bar"}' })
       allow(mixin).to receive(:http_get).and_return(http_mock)
 
-      expect(Ohai::Log).to receive(:warn)
+      expect(mixin.logger).to receive(:warn)
       vals = mixin.fetch_metadata
       expect(vals).to eq(nil)
     end
@@ -59,7 +64,7 @@ describe Ohai::Mixin::AzureMetadata do
       http_mock = double("http", { :code => "200", :body => '{ "foo": "bar"}' })
       allow(mixin).to receive(:http_get).and_return(http_mock)
 
-      expect(Ohai::Log).not_to receive(:warn)
+      expect(mixin.logger).not_to receive(:warn)
       vals = mixin.fetch_metadata
       expect(vals).to eq({ "foo" => "bar" })
     end

--- a/spec/unit/mixin/command_spec.rb
+++ b/spec/unit/mixin/command_spec.rb
@@ -28,7 +28,10 @@ describe Ohai::Mixin::Command, "shell_out" do
 
   let(:options) { windows? ? { timeout: 30 } : { timeout: 30, env: { "PATH" => "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" } } }
 
+  let(:logger) { instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil) }
+
   before(:each) do
+    allow(Ohai::Mixin::Command).to receive(:logger).and_return(logger)
     allow(Ohai::Mixin::Command).to receive(:name).and_return(plugin_name)
     @original_env = ENV.to_hash
     ENV.clear
@@ -53,7 +56,7 @@ describe Ohai::Mixin::Command, "shell_out" do
         to receive(:exitstatus).
         and_return(256)
 
-      expect(Ohai::Log).to receive(:debug).
+      expect(logger).to receive(:trace).
         with("Plugin OSSparkleDream: ran 'sparkle-dream --version' and returned 256")
 
       Ohai::Mixin::Command.shell_out(cmd)
@@ -71,8 +74,8 @@ describe Ohai::Mixin::Command, "shell_out" do
         to receive(:run_command).
         and_raise(Errno::ENOENT, "sparkle-dream")
 
-      expect(Ohai::Log).
-        to receive(:debug).
+      expect(logger).
+        to receive(:trace).
         with("Plugin OSSparkleDream: ran 'sparkle-dream --version' and failed " \
              "#<Errno::ENOENT: No such file or directory - sparkle-dream>")
 
@@ -92,8 +95,8 @@ describe Ohai::Mixin::Command, "shell_out" do
         to receive(:run_command).
         and_raise(Mixlib::ShellOut::CommandTimeout)
 
-      expect(Ohai::Log).
-        to receive(:debug).
+      expect(logger).
+        to receive(:trace).
         with("Plugin OSSparkleDream: ran 'sparkle-dream --version' and timed " \
              "out after 30 seconds")
 
@@ -118,7 +121,7 @@ describe Ohai::Mixin::Command, "shell_out" do
         to receive(:exitstatus).
         and_return(256)
 
-      expect(Ohai::Log).to receive(:debug).
+      expect(logger).to receive(:trace).
         with("Plugin OSSparkleDream: ran 'sparkle-dream --version' and returned 256")
 
       Ohai::Mixin::Command.shell_out(cmd, options)
@@ -135,8 +138,8 @@ describe Ohai::Mixin::Command, "shell_out" do
           to receive(:run_command).
           and_raise(Mixlib::ShellOut::CommandTimeout)
 
-        expect(Ohai::Log).
-          to receive(:debug).
+        expect(logger).
+          to receive(:trace).
           with("Plugin OSSparkleDream: ran 'sparkle-dream --version' and timed " \
                "out after 10 seconds")
 

--- a/spec/unit/mixin/ec2_metadata_spec.rb
+++ b/spec/unit/mixin/ec2_metadata_spec.rb
@@ -28,6 +28,11 @@ describe Ohai::Mixin::Ec2Metadata do
     metadata_object
   end
 
+  before do
+    logger = instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil)
+    allow(mixin).to receive(:logger).and_return(logger)
+  end
+
   context "#best_api_version" do
     context "with a sorted list of metadata versions" do
       let(:response) { double("Net::HTTP Response", :body => "1.0\n2011-05-01\n2012-01-12\nUnsupported", :code => "200") }

--- a/spec/unit/mixin/softlayer_metadata_spec.rb
+++ b/spec/unit/mixin/softlayer_metadata_spec.rb
@@ -27,6 +27,11 @@ describe ::Ohai::Mixin::SoftlayerMetadata do
     mixin
   end
 
+  before do
+    logger = instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil)
+    allow(mixin).to receive(:logger).and_return(logger)
+  end
+
   def make_request(item)
     "/rest/v3.1/SoftLayer_Resource_Metadata/#{item}"
   end
@@ -41,7 +46,7 @@ describe ::Ohai::Mixin::SoftlayerMetadata do
       allow(http_mock).to receive(:get).and_raise(StandardError.new("API return fake error"))
       allow(::Net::HTTP).to receive(:new).with("api.service.softlayer.com", 443).and_return(http_mock)
 
-      expect(::Ohai::Log).to receive(:error).at_least(:once)
+      expect(mixin.logger).to receive(:error).at_least(:once)
       expect { mixin.fetch_metadata }.to raise_error(StandardError)
     end
 

--- a/spec/unit/plugins/fail_spec.rb
+++ b/spec/unit/plugins/fail_spec.rb
@@ -60,7 +60,7 @@ shared_examples "a v7 loading failure" do
   end
 
   it "should write to Ohai::Log" do
-    expect(Ohai::Log).to receive(:warn).once
+    expect(@loader.logger).to receive(:warn).once
     @loader.load_plugin("#{tmp}/plugins/fail.rb")
   end
 end
@@ -103,7 +103,7 @@ shared_examples "a v7 loading success" do
   end
 
   it "should not write to Ohai::Log" do
-    expect(Ohai::Log).not_to receive(:warn)
+    expect(@loader.logger).not_to receive(:warn)
     @loader.load_plugin("#{tmp}/plugins/fail.rb")
   end
 end
@@ -146,7 +146,7 @@ shared_examples "a v7 run failure" do
   end
 
   it "should write to Ohai::Log" do
-    expect(Ohai::Log).to receive(:warn).once
+    expect(@loader.logger).to receive(:warn).once
     @loader.load_plugin("#{tmp}/plugins/fail.rb").new(@ohai).run
   end
 end

--- a/spec/unit/plugins/linux/filesystem_spec.rb
+++ b/spec/unit/plugins/linux/filesystem_spec.rb
@@ -540,7 +540,7 @@ BLKID_TYPE
       it "logs warning about #{command} missing" do
         Ohai.config[:plugin][:filesystem][:allow_partial_data] = true
         allow(plugin).to receive(:shell_out).with(/#{command}/).and_raise(Ohai::Exceptions::Exec)
-        expect(Ohai::Log).to receive(:warn).with("Plugin Filesystem: #{command} binary is not available. Some data will not be available.")
+        expect_any_instance_of(Mixlib::Log::Child).to receive(:warn).with("Plugin Filesystem: #{command} binary is not available. Some data will not be available.")
         plugin.run
       end
     end

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -552,7 +552,7 @@ EOM
       end
 
       it "completes the run" do
-        expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+        expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
         expect(plugin["network"]).not_to be_nil
       end
 
@@ -814,7 +814,7 @@ EOM
     end
 
     it "completes the run" do
-      expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+      expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
       expect(plugin["network"]).not_to be_nil
     end
 
@@ -934,7 +934,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           expect(plugin["network"]).not_to be_nil
         end
 
@@ -975,7 +975,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           expect(plugin["network"]).not_to be_nil
         end
 
@@ -1018,7 +1018,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           expect(plugin["network"]).not_to be_nil
         end
 
@@ -1053,7 +1053,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           plugin.run
           expect(plugin["network"]).not_to be_nil
         end
@@ -1094,7 +1094,7 @@ EOM
             let(:linux_ip_route_inet6) { "" }
 
             it "completes the run" do
-              expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+              expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
               plugin.run
               expect(plugin["network"]).not_to be_nil
             end
@@ -1119,7 +1119,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           expect(plugin["network"]).not_to be_nil
         end
 
@@ -1140,7 +1140,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           expect(plugin["network"]).not_to be_nil
         end
 
@@ -1165,7 +1165,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           expect(plugin["network"]).not_to be_nil
         end
 
@@ -1190,7 +1190,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           expect(plugin["network"]).not_to be_nil
         end
 
@@ -1224,7 +1224,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           expect(plugin["network"]).not_to be_nil
         end
 
@@ -1265,7 +1265,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           expect(plugin["network"]).not_to be_nil
         end
 
@@ -1308,7 +1308,7 @@ EOM
         end
 
         it "completes the run" do
-          expect(Ohai::Log).not_to receive(:debug).with(/Plugin linux::network threw exception/)
+          expect(plugin.logger).not_to receive(:trace).with(/Plugin linux::network threw exception/)
           expect(plugin["network"]).not_to be_nil
         end
 
@@ -1336,8 +1336,8 @@ EOM
         end
 
         it "logs a message and skips previously unseen interfaces in 'ip route show'" do
-          expect(Ohai::Log).to receive(:debug).with(/Skipping previously unseen interface from 'ip route show': virbr0/).once
-          allow(Ohai::Log).to receive(:debug) # Catches the 'Loading plugin network' type messages
+          expect(plugin.logger).to receive(:trace).with(/Skipping previously unseen interface from 'ip route show': virbr0/).once
+          allow(plugin.logger).to receive(:trace) # Catches the 'Loading plugin network' type messages
           plugin.run
         end
       end

--- a/spec/unit/plugins/network_spec.rb
+++ b/spec/unit/plugins/network_spec.rb
@@ -20,8 +20,8 @@ require_relative "../../spec_helper.rb"
 
 def it_doesnt_fail
   it "doesnt fail" do
-    allow(Ohai::Log).to receive(:warn)
-    expect(Ohai::Log).not_to receive(:debug).with(/^Plugin network threw exception/)
+    allow(@plugin.logger).to receive(:warn)
+    expect(@plugin.logger).not_to receive(:trace).with(/^Plugin network threw exception/)
     @plugin.run
   end
 end
@@ -32,8 +32,8 @@ def it_populates_ipaddress_attributes
 
   it "populates ipaddress, macaddress and ip6address" do
     begin
-      allow(Ohai::Log).to receive(:warn)
-      expect(Ohai::Log).not_to receive(:debug).with(/^Plugin network threw exception/)
+      allow(@plugin.logger).to receive(:warn)
+      expect(@plugin.logger).not_to receive(:trace).with(/^Plugin network threw exception/)
       @plugin.run
       %w{ ipaddress macaddress ip6address }.each do |attribute|
         expect(@plugin).to have_key(attribute)
@@ -367,8 +367,8 @@ describe Ohai::System, "Network Plugin" do
           end
 
           it "informs about this setup" do
-            expect(Ohai::Log).to receive(:debug).with(/ipaddress and ip6address are set from different interfaces/)
-            allow(Ohai::Log).to receive(:debug)
+            expect(@plugin.logger).to receive(:trace).with(/ipaddress and ip6address are set from different interfaces/)
+            allow(@plugin.logger).to receive(:trace)
             @plugin.run
           end
         end
@@ -396,8 +396,8 @@ describe Ohai::System, "Network Plugin" do
           end
 
           it "informs about this setup" do
-            expect(Ohai::Log).to receive(:debug).with(/ipaddress and ip6address are set from different interfaces/)
-            allow(Ohai::Log).to receive(:debug)
+            expect(@plugin.logger).to receive(:trace).with(/ipaddress and ip6address are set from different interfaces/)
+            allow(@plugin.logger).to receive(:trace)
             @plugin.run
           end
         end
@@ -413,7 +413,7 @@ describe Ohai::System, "Network Plugin" do
           it_populates_ipaddress_attributes
 
           it "picks {ip,ip6,mac}address" do
-            allow(Ohai::Log).to receive(:warn)
+            allow(@plugin.logger).to receive(:warn)
             @plugin.run
             expect(@plugin["ipaddress"]).to eq("192.168.99.11")
             expect(@plugin["macaddress"]).to eq("00:16:3E:2F:36:80")
@@ -421,9 +421,9 @@ describe Ohai::System, "Network Plugin" do
           end
 
           it "warns about this conflict" do
-            expect(Ohai::Log).to receive(:debug).with(/\[inet\] no ipaddress\/mask on eth1/).once
-            expect(Ohai::Log).to receive(:debug).with(/\[inet6\] no ipaddress\/mask on eth1/).once
-            allow(Ohai::Log).to receive(:debug)
+            expect(@plugin.logger).to receive(:trace).with(/\[inet\] no ipaddress\/mask on eth1/).once
+            expect(@plugin.logger).to receive(:trace).with(/\[inet6\] no ipaddress\/mask on eth1/).once
+            allow(@plugin.logger).to receive(:trace)
             @plugin.run
           end
         end
@@ -435,7 +435,7 @@ describe Ohai::System, "Network Plugin" do
           end
 
           it "picks {ip,ip6,mac}address" do
-            allow(Ohai::Log).to receive(:warn)
+            allow(@plugin.logger).to receive(:warn)
             @plugin.run
             expect(@plugin["ipaddress"]).to eq("192.168.66.33")
             expect(@plugin["macaddress"]).to eq("00:16:3E:2F:36:79")
@@ -452,7 +452,7 @@ describe Ohai::System, "Network Plugin" do
           it_doesnt_fail
 
           it "doesn't detect {ip,ip6,mac}address" do
-            allow(Ohai::Log).to receive(:warn)
+            allow(@plugin.logger).to receive(:warn)
             @plugin.run
             expect(@plugin["ipaddress"]).to be_nil
             expect(@plugin["macaddress"]).to be_nil
@@ -460,11 +460,11 @@ describe Ohai::System, "Network Plugin" do
           end
 
           it "warns about this conflict" do
-            expect(Ohai::Log).to receive(:warn).with(/unable to detect ipaddress/).once
-            expect(Ohai::Log).to receive(:warn).with(/\[inet\] no ip address on eth0/).once
-            expect(Ohai::Log).to receive(:debug).with(/unable to detect ip6address/).once
-            expect(Ohai::Log).to receive(:debug).with(/unable to detect macaddress/).twice # for each family
-            expect(Ohai::Log).to receive(:warn).with(/\[inet6\] no ip address on eth0/).once
+            expect(@plugin.logger).to receive(:warn).with(/unable to detect ipaddress/).once
+            expect(@plugin.logger).to receive(:warn).with(/\[inet\] no ip address on eth0/).once
+            expect(@plugin.logger).to receive(:trace).with(/unable to detect ip6address/).once
+            expect(@plugin.logger).to receive(:trace).with(/unable to detect macaddress/).twice # for each family
+            expect(@plugin.logger).to receive(:warn).with(/\[inet6\] no ip address on eth0/).once
             @plugin.run
           end
         end
@@ -483,7 +483,7 @@ describe Ohai::System, "Network Plugin" do
           it_doesnt_fail
 
           it "doesn't detect {ip,ip6,mac}address" do
-            allow(Ohai::Log).to receive(:warn)
+            allow(@plugin.logger).to receive(:warn)
             @plugin.run
             expect(@plugin["ipaddress"]).to be_nil
             expect(@plugin["macaddress"]).to be_nil
@@ -491,9 +491,9 @@ describe Ohai::System, "Network Plugin" do
           end
 
           it "should warn about it" do
-            expect(Ohai::Log).to receive(:warn).with(/unable to detect ipaddress/).once
-            expect(Ohai::Log).to receive(:debug).with(/unable to detect macaddress/).twice # for each family
-            expect(Ohai::Log).to receive(:debug).with(/unable to detect ip6address/).once
+            expect(@plugin.logger).to receive(:warn).with(/unable to detect ipaddress/).once
+            expect(@plugin.logger).to receive(:trace).with(/unable to detect macaddress/).twice # for each family
+            expect(@plugin.logger).to receive(:trace).with(/unable to detect ip6address/).once
             @plugin.run
           end
         end
@@ -643,9 +643,9 @@ describe Ohai::System, "Network Plugin" do
           it_populates_ipaddress_attributes
 
           it "picks {ip,mac,ip6}address from the first interface" do
-            expect(Ohai::Log).to receive(:debug).with(/\[inet\] no default interface/).once
-            expect(Ohai::Log).to receive(:debug).with(/\[inet6\] no default interface/).once
-            allow(Ohai::Log).to receive(:debug)
+            expect(@plugin.logger).to receive(:trace).with(/\[inet\] no default interface/).once
+            expect(@plugin.logger).to receive(:trace).with(/\[inet6\] no default interface/).once
+            allow(@plugin.logger).to receive(:trace)
             @plugin.run
             expect(@plugin["ipaddress"]).to eq("192.168.99.11")
             expect(@plugin["macaddress"]).to eq("00:16:3E:2F:36:80")
@@ -666,9 +666,9 @@ describe Ohai::System, "Network Plugin" do
           it_populates_ipaddress_attributes
 
           it "prefers global scope addressses to set {ip,mac,ip6}address" do
-            expect(Ohai::Log).to receive(:debug).with(/\[inet\] no default interface/).once
-            expect(Ohai::Log).to receive(:debug).with(/\[inet6\] no default interface/).once
-            allow(Ohai::Log).to receive(:debug)
+            expect(@plugin.logger).to receive(:trace).with(/\[inet\] no default interface/).once
+            expect(@plugin.logger).to receive(:trace).with(/\[inet6\] no default interface/).once
+            allow(@plugin.logger).to receive(:trace)
             @plugin.run
             expect(@plugin["ipaddress"]).to eq("192.168.99.11")
             expect(@plugin["macaddress"]).to eq("00:16:3E:2F:36:80")
@@ -789,29 +789,29 @@ describe Ohai::System, "Network Plugin" do
         it_doesnt_fail
 
         it "can't detect ipaddress" do
-          allow(Ohai::Log).to receive(:warn)
+          allow(@plugin.logger).to receive(:warn)
           @plugin.run
           expect(@plugin["ipaddress"]).to be_nil
         end
 
         it "warns about not being able to set {ip,mac}address (ipv4)" do
-          expect(Ohai::Log).to receive(:warn).with(/unable to detect ipaddress/).once
-          expect(Ohai::Log).to receive(:debug).with(/unable to detect macaddress/) # for ipv4
-          expect(Ohai::Log).to receive(:debug).with(/setting macaddress to/) # for ipv6
-          expect(Ohai::Log).to receive(:debug).with(/\[inet6\] Using default interface eth0 and default gateway/) # for ipv6
+          expect(@plugin.logger).to receive(:warn).with(/unable to detect ipaddress/).once
+          expect(@plugin.logger).to receive(:trace).with(/unable to detect macaddress/) # for ipv4
+          expect(@plugin.logger).to receive(:trace).with(/setting macaddress to/) # for ipv6
+          expect(@plugin.logger).to receive(:trace).with(/\[inet6\] Using default interface eth0 and default gateway/) # for ipv6
           @plugin.run
         end
 
         it "sets {ip6,mac}address" do
-          allow(Ohai::Log).to receive(:warn)
+          allow(@plugin.logger).to receive(:warn)
           @plugin.run
           expect(@plugin["ip6address"]).to eq("3ffe:1111:2222::33")
           expect(@plugin["macaddress"]).to eq("00:16:3E:2F:36:79")
         end
 
         it "informs about macaddress being set using the ipv6 setup" do
-          expect(Ohai::Log).to receive(:debug).with(/setting macaddress to '00:16:3E:2F:36:79'/)
-          allow(Ohai::Log).to receive(:debug)
+          expect(@plugin.logger).to receive(:trace).with(/setting macaddress to '00:16:3E:2F:36:79'/)
+          allow(@plugin.logger).to receive(:trace)
           @plugin.run
         end
       end
@@ -829,21 +829,21 @@ describe Ohai::System, "Network Plugin" do
         it_doesnt_fail
 
         it "can't detect ipaddress" do
-          allow(Ohai::Log).to receive(:warn)
+          allow(@plugin.logger).to receive(:warn)
           @plugin.run
           expect(@plugin["ipaddress"]).to eq("127.0.0.1")
         end
 
         it "sets {ip6,mac}address" do
-          allow(Ohai::Log).to receive(:warn)
+          allow(@plugin.logger).to receive(:warn)
           @plugin.run
           expect(@plugin["ip6address"]).to eq("3ffe:1111:2222::33")
           expect(@plugin["macaddress"]).to eq("00:16:3E:2F:36:79")
         end
 
         it "informs about macaddress being set using the ipv6 setup" do
-          expect(Ohai::Log).to receive(:debug).with(/setting macaddress to '00:16:3E:2F:36:79'/)
-          allow(Ohai::Log).to receive(:debug)
+          expect(@plugin.logger).to receive(:trace).with(/setting macaddress to '00:16:3E:2F:36:79'/)
+          allow(@plugin.logger).to receive(:trace)
           @plugin.run
         end
       end
@@ -950,24 +950,24 @@ describe Ohai::System, "Network Plugin" do
             it_doesnt_fail
 
             it "can't detect ipaddress (ipv4)" do
-              allow(Ohai::Log).to receive(:warn)
+              allow(@plugin.logger).to receive(:warn)
               @plugin.run
               expect(@plugin["ipaddress"]).to be_nil
             end
 
             it "takes the macaddress from ipv6" do
-              allow(Ohai::Log).to receive(:warn)
+              allow(@plugin.logger).to receive(:warn)
               @plugin.run
               expect(@plugin["macaddress"]).to eq(@expected_results[os]["macaddress"])
             end
 
             it "warns about not being able to set ipaddress" do
-              expect(Ohai::Log).to receive(:warn).with(/unable to detect ipaddress/).once
+              expect(@plugin.logger).to receive(:warn).with(/unable to detect ipaddress/).once
               @plugin.run
             end
 
             it "doesn't overwrite ip6address" do
-              allow(Ohai::Log).to receive(:warn)
+              allow(@plugin.logger).to receive(:warn)
               @plugin.run
               expect(@plugin["ip6address"]).to eq("3ffe:8888:9999::1")
             end
@@ -1025,13 +1025,13 @@ describe Ohai::System, "Network Plugin" do
             it_doesnt_fail
 
             it "can't set ipaddress" do
-              allow(Ohai::Log).to receive(:warn)
+              allow(@plugin.logger).to receive(:warn)
               @plugin.run
               expect(@plugin["ipaddress"]).to be_nil
             end
 
             it "doesn't overwrite {ip6,mac}address" do
-              allow(Ohai::Log).to receive(:warn)
+              allow(@plugin.logger).to receive(:warn)
               @plugin.run
               expect(@plugin["ip6address"]).to eq("3ffe:8888:9999::1")
               expect(@plugin["macaddress"]).to eq("00:AA:BB:CC:DD:EE")

--- a/spec/unit/plugins/rackspace_spec.rb
+++ b/spec/unit/plugins/rackspace_spec.rb
@@ -149,8 +149,8 @@ OUT
         with("xenstore-ls vm-data/provider_data").
         and_raise(Ohai::Exceptions::Exec)
 
-      expect(Ohai::Log).
-        to receive(:debug).
+      expect(plugin.logger).
+        to receive(:trace).
         with("Plugin Rackspace: Unable to find xenstore-ls, cannot capture " \
              "region information for Rackspace cloud")
 
@@ -172,8 +172,8 @@ OUT
         with("xenstore-read name").
         and_raise(Ohai::Exceptions::Exec)
 
-      expect(Ohai::Log).
-        to receive(:debug).
+      expect(plugin.logger).
+        to receive(:trace).
         with("Plugin Rackspace: Unable to find xenstore-read, cannot capture " \
              "instance ID information for Rackspace cloud")
 
@@ -276,8 +276,8 @@ OUT
         with("xenstore-ls vm-data/networking").
         and_raise(Ohai::Exceptions::Exec)
 
-      expect(Ohai::Log).
-        to receive(:debug).
+      expect(plugin.logger).
+        to receive(:trace).
         with("Plugin Rackspace: Unable to capture custom private networking " \
              "information for Rackspace cloud")
 

--- a/spec/unit/provides_map_spec.rb
+++ b/spec/unit/provides_map_spec.rb
@@ -23,10 +23,10 @@ describe Ohai::ProvidesMap do
 
   let(:ohai_system) { Ohai::System.new }
   let(:provides_map) { Ohai::ProvidesMap.new }
-  let(:plugin_1) { Ohai::DSL::Plugin.new(ohai_system.data) }
-  let(:plugin_2) { Ohai::DSL::Plugin.new(ohai_system.data) }
-  let(:plugin_3) { Ohai::DSL::Plugin.new(ohai_system.data) }
-  let(:plugin_4) { Ohai::DSL::Plugin.new(ohai_system.data) }
+  let(:plugin_1) { Ohai::DSL::Plugin.new(ohai_system.data, ohai_system.logger) }
+  let(:plugin_2) { Ohai::DSL::Plugin.new(ohai_system.data, ohai_system.logger) }
+  let(:plugin_3) { Ohai::DSL::Plugin.new(ohai_system.data, ohai_system.logger) }
+  let(:plugin_4) { Ohai::DSL::Plugin.new(ohai_system.data, ohai_system.logger) }
 
   describe "when looking up providing plugins for a single attribute" do
     describe "when the attribute does not exist" do

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -71,7 +71,7 @@ describe Ohai::Runner, "run_plugin" do
           thing(Mash.new)
         end
       end
-      klass.new(@ohai.data)
+      klass.new(@ohai.data, @ohai.logger)
     end
 
     it "should run the plugin" do
@@ -96,7 +96,7 @@ describe Ohai::Runner, "run_plugin" do
             thing(other_thing)
           end
         end
-        @plugin = klass.new(@ohai.data)
+        @plugin = klass.new(@ohai.data, @ohai.logger)
       end
 
       it "should raise Ohai::Excpetions::AttributeNotFound" do
@@ -127,7 +127,7 @@ describe Ohai::Runner, "run_plugin" do
 
         @plugins = []
         [klass1, klass2].each do |klass|
-          @plugins << klass.new(@ohai.data)
+          @plugins << klass.new(@ohai.data, @ohai.logger)
         end
         @plugin1, @plugin2 = @plugins
 
@@ -160,7 +160,7 @@ describe Ohai::Runner, "run_plugin" do
 
         @plugins = []
         [klass1, klass1, klass2].each do |klass|
-          @plugins << klass.new(@ohai.data)
+          @plugins << klass.new(@ohai.data, @ohai.logger)
         end
         @plugin1, @plugin2, @plugin3 = @plugins
 
@@ -204,7 +204,7 @@ describe Ohai::Runner, "run_plugin" do
 
       @plugins = []
       [klass1, klass2, klass3].each do |klass|
-        @plugins << klass.new(@ohai.data)
+        @plugins << klass.new(@ohai.data, @ohai.logger)
       end
       @plugin1, @plugin2, @plugin3 = @plugins
       @ohai.provides_map.set_providers_for(@plugin1, %w{one two})
@@ -232,7 +232,7 @@ describe Ohai::Runner, "run_plugin" do
           end
         end
       end
-      let(:plugin) { plugin_class.new(@ohai.data) }
+      let(:plugin) { plugin_class.new(@ohai.data, @ohai.logger) }
 
       it "ignores the cycle" do
         @ohai.provides_map.set_providers_for(plugin, ["thing"])
@@ -260,7 +260,7 @@ describe Ohai::Runner, "run_plugin" do
 
         @plugins = []
         [klass1, klass2].each_with_index do |klass, idx|
-          @plugins << klass.new(@ohai.data)
+          @plugins << klass.new(@ohai.data, @ohai.logger)
         end
 
         @plugin1, @plugin2 = @plugins
@@ -297,7 +297,7 @@ describe Ohai::Runner, "run_plugin" do
 
       @plugins = []
       [klass_a, klass_b, klass_c].each do |klass|
-        @plugins << klass.new(@ohai.data)
+        @plugins << klass.new(@ohai.data, @ohai.logger)
       end
       @plugin_a, @plugin_b, @plugin_c = @plugins
     end
@@ -334,12 +334,12 @@ describe Ohai::Runner, "fetch_plugins" do
   before(:each) do
     @provides_map = Ohai::ProvidesMap.new
     @data = Mash.new
-    @ohai = double("Ohai::System", :data => @data, :provides_map => @provides_map)
+    @ohai = double("Ohai::System", :data => @data, :provides_map => @provides_map, logger: Ohai::Log.with_child)
     @runner = Ohai::Runner.new(@ohai, true)
   end
 
   it "should collect the provider" do
-    plugin = Ohai::DSL::Plugin.new(@ohai.data)
+    plugin = Ohai::DSL::Plugin.new(@ohai.data, @ohai.logger)
     @ohai.provides_map.set_providers_for(plugin, ["top/middle/bottom"])
 
     dependency_providers = @runner.fetch_plugins(["top/middle/bottom"])
@@ -349,7 +349,7 @@ describe Ohai::Runner, "fetch_plugins" do
   describe "when the attribute is not provided by any plugin" do
     describe "and some parent attribute has providers" do
       it "should return the providers for the parent" do
-        plugin = Ohai::DSL::Plugin.new(@ohai.data)
+        plugin = Ohai::DSL::Plugin.new(@ohai.data, @ohai.logger)
         @provides_map.set_providers_for(plugin, ["test/attribute"])
         expect(@runner.fetch_plugins(["test/attribute/too_far"])).to eql([plugin])
       end
@@ -364,7 +364,7 @@ describe Ohai::Runner, "fetch_plugins" do
   end
 
   it "should return unique providers" do
-    plugin = Ohai::DSL::Plugin.new(@ohai.data)
+    plugin = Ohai::DSL::Plugin.new(@ohai.data, @ohai.logger)
     @provides_map.set_providers_for(plugin, ["test", "test/too_far/way_too_far"])
     expect(@runner.fetch_plugins(["test", "test/too_far/way_too_far"])).to eql([plugin])
   end
@@ -399,7 +399,7 @@ describe Ohai::Runner, "#get_cycle" do
 
     plugins = []
     [klass1, klass2, klass3].each_with_index do |klass, idx|
-      plugins << klass.new(@ohai.data)
+      plugins << klass.new(@ohai.data, @ohai.logger)
     end
     @plugin1, @plugin2, @plugin3 = plugins
   end

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -202,7 +202,7 @@ EOF
         # Make sure the stubbing of runner is not overriden with reset_system during test
         allow(ohai).to receive(:reset_system)
         allow(ohai.instance_variable_get("@runner")).to receive(:run_plugin).and_raise(Ohai::Exceptions::AttributeNotFound)
-        expect(Ohai::Log).to receive(:error).with(/Encountered error while running plugins/)
+        expect(ohai.logger).to receive(:error).with(/Encountered error while running plugins/)
         expect { ohai.all_plugins }.to raise_error(Ohai::Exceptions::AttributeNotFound)
       end
 

--- a/spec/unit/util/file_helper_spec.rb
+++ b/spec/unit/util/file_helper_spec.rb
@@ -28,6 +28,8 @@ describe "Ohai::Util::FileHelper" do
 
   before(:each) do
     allow(file_helper).to receive(:name).and_return("Fakeclass")
+    logger = instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil)
+    allow(file_helper).to receive(:logger).and_return(logger)
     allow(File).to receive(:executable?).and_return(false)
   end
 


### PR DESCRIPTION
This does two things:
it moves away from the old model of using a log module throughout, to injecting the logger in to the various classes. This means that each class can attach metadata to the logger, allowing - in future - us to add tooling to drill into specific plugins or similar.
It converts (the second commit) everything to be at log level trace rather than debug. In general, a cookbook author does not give two hoots about which ohai plugins are loaded or in we failed to load a hint on azure, and we should respect their attention.