### PR TITLE
adding type 17 to the ID_TO_CAPTURE list of dmi.rb

### DIFF
--- a/lib/ohai/common/dmi.rb
+++ b/lib/ohai/common/dmi.rb
@@ -74,7 +74,7 @@ module Ohai
 
       # list of IDs to collect, otherwise we generate pages of hashes about cache chip size and whatnot
       # See OHAI-260. When we can give the user a choice, this will be a default.
-      ID_TO_CAPTURE = [ 0, 1, 2, 3, 4, 6, 11 ]
+      ID_TO_CAPTURE = [ 0, 1, 2, 3, 4, 6, 11, 17 ]
 
       # look up DMI ID
       def id_lookup(id)


### PR DESCRIPTION
Signed-off-by: devoptimist <sbrown@chef.io>

### Description
One of our customers complained that they can't see memory module information provided by dmi.rb in their attributes.
```
$ knife node show somenode -a dmi.memory_module -Fj 
{ 
"gbrdsr000002837": { 
"dmi.memory_module": null 
} 
}
```
I check the SMBIOS spec and type 6 (memory_module) was obsoleted as of version 2.1
I think type 17 replaces it (memory_device)

in the ohai/common/dmi.rb type 17 is included in the ID_TO_DESCRIPTION table but not in the
ID_TO_CAPTURE list

```
ID_TO_CAPTURE = [ 0, 1, 2, 3, 4, 6, 11 ]
```

this change just adds type 17 to that list


### Issues Resolved
No issue but a customer has requested memory module information from ohai.

### Check List

- [ x] New functionality includes tests
- [ x] All tests pass
- [ x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
