### PR TITLE
Make the shard plugin work under FIPS by using SHA2 instead of MD5

### DIFF
--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -17,7 +17,7 @@
 #
 
 Ohai.plugin(:ShardSeed) do
-  depends "hostname", "dmi", "machine_id", "machinename", "fips", "hardware"
+  depends "hostname", "dmi", "machine_id", "machinename", "fips", "hardware", "kernel"
   provides "shard_seed"
 
   def get_dmi_property(dmi, thing)
@@ -94,6 +94,8 @@ Ohai.plugin(:ShardSeed) do
       case src
       when :serial
         wmi.first_of("Win32_BIOS")["SerialNumber"]
+      when :os_serial
+        kernel["os_info"]["serial_number"]
       when :uuid
         wmi.first_of("Win32_ComputerSystemProduct")["UUID"]
       else

--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -17,10 +17,13 @@
 #
 
 Ohai.plugin(:ShardSeed) do
+  require "openssl"
   require "digest/md5"
   depends "hostname", "dmi", "machine_id", "machinename"
   provides "shard_seed"
-  optional true
+  # Disable this plugin by default under FIPS mode because even though we aren't
+  # using MD5 for cryptography, it will still throw up an error.
+  optional true if defined?(OpenSSL.fips_mode) && OpenSSL.fips_mode
 
   def get_dmi_property(dmi, thing)
     %w{system base_board chassis}.each do |section|

--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -17,8 +17,7 @@
 #
 
 Ohai.plugin(:ShardSeed) do
-  require "openssl"
-  depends "hostname", "dmi", "machine_id", "machinename"
+  depends "hostname", "dmi", "machine_id", "machinename", "fips"
   provides "shard_seed"
 
   def get_dmi_property(dmi, thing)
@@ -34,7 +33,7 @@ Ohai.plugin(:ShardSeed) do
   end
 
   def default_digest_algorithm
-    if defined?(OpenSSL.fips_mode) && OpenSSL.fips_mode
+    if fips["kernel"]["enabled"]
       # Even though it is being used safely, FIPS-mode will still blow up on
       # any use of MD5 so default to SHA2 instead.
       "sha256"

--- a/spec/unit/plugins/shard_spec.rb
+++ b/spec/unit/plugins/shard_spec.rb
@@ -41,7 +41,7 @@ describe Ohai::System, "shard plugin" do
     plugin["dmi"] = { "system" => {} }
     plugin["dmi"]["system"]["uuid"] = uuid
     plugin["dmi"]["system"]["serial_number"] = serial
-    plugin["fips"] = {"kernel" => {"enabled" => fips}}
+    plugin["fips"] = { "kernel" => { "enabled" => fips } }
     allow(plugin).to receive(:collect_os).and_return(:linux)
   end
 
@@ -61,8 +61,8 @@ describe Ohai::System, "shard plugin" do
 
   it "should provide a shard with a configured algorithm" do
     Ohai.config[:plugin][:shard_seed][:digest_algorithm] = "sha256"
-      expect(Digest::MD5).to_not receive(:new)
-      expect(subject).to eq(117055036)
+    expect(Digest::MD5).to_not receive(:new)
+    expect(subject).to eq(117055036)
   end
 
   context "with FIPS mode enabled" do

--- a/spec/unit/plugins/shard_spec.rb
+++ b/spec/unit/plugins/shard_spec.rb
@@ -26,6 +26,12 @@ describe Ohai::System, "shard plugin" do
   let(:serial) { "234du3m4i498xdjr2" }
   let(:machine_id) { "0a1f869f457a4c8080ab19faf80af9cc" }
   let(:machinename) { "somehost004" }
+  let(:fips) { false }
+
+  subject do
+    plugin.run
+    plugin[:shard_seed]
+  end
 
   before(:each) do
     allow(plugin).to receive(:collect_os).and_return(:linux)
@@ -35,26 +41,36 @@ describe Ohai::System, "shard plugin" do
     plugin["dmi"] = { "system" => {} }
     plugin["dmi"]["system"]["uuid"] = uuid
     plugin["dmi"]["system"]["serial_number"] = serial
+    plugin["fips"] = {"kernel" => {"enabled" => fips}}
     allow(plugin).to receive(:collect_os).and_return(:linux)
   end
 
   it "should provide a shard with a default-safe set of sources" do
-    plugin.run
-    result = Digest::MD5.hexdigest(
-      "#{machinename}#{serial}#{uuid}"
-    )[0...7].to_i(16)
-    expect(plugin[:shard_seed]).to eq(result)
+    expect(subject).to eq(27767217)
   end
 
   it "should provide a shard with a configured source" do
     Ohai.config[:plugin][:shard_seed][:sources] = [:fqdn]
-    plugin.run
-    result = Digest::MD5.hexdigest(fqdn)[0...7].to_i(16)
-    expect(plugin[:shard_seed]).to eq(result)
+    expect(subject).to eq(203669792)
   end
 
   it "fails on an unrecognized source" do
     Ohai.config[:plugin][:shard_seed][:sources] = [:GreatGooglyMoogly]
-    expect { plugin.run }.to raise_error(RuntimeError)
+    expect { subject }.to raise_error(RuntimeError)
+  end
+
+  it "should provide a shard with a configured algorithm" do
+    Ohai.config[:plugin][:shard_seed][:digest_algorithm] = "sha256"
+      expect(Digest::MD5).to_not receive(:new)
+      expect(subject).to eq(117055036)
+  end
+
+  context "with FIPS mode enabled" do
+    let(:fips) { true }
+
+    it "should use SHA2" do
+      expect(Digest::MD5).to_not receive(:new)
+      expect(subject).to eq(117055036)
+    end
   end
 end

--- a/spec/unit/plugins/shard_spec.rb
+++ b/spec/unit/plugins/shard_spec.rb
@@ -80,13 +80,21 @@ describe Ohai::System, "shard plugin" do
     let(:os) { :windows }
     before do
       wmi = double("WmiLite::Wmi")
-      expect(WmiLite::Wmi).to receive(:new).and_return(wmi)
-      expect(wmi).to receive(:first_of).with("Win32_BIOS").and_return("SerialNumber" => serial)
-      expect(wmi).to receive(:first_of).with("Win32_ComputerSystemProduct").and_return("UUID" => uuid)
+      allow(WmiLite::Wmi).to receive(:new).and_return(wmi)
+      allow(wmi).to receive(:first_of).with("Win32_BIOS").and_return("SerialNumber" => serial)
+      allow(wmi).to receive(:first_of).with("Win32_ComputerSystemProduct").and_return("UUID" => uuid)
+      plugin["kernel"] = { "os_info" => { "serial_number" => serial + "0" } }
+      plugin.data.delete("dmi") # To make sure we aren't using the wrong data.
     end
 
     it "should provide a shard with a default-safe set of sources" do
       expect(subject).to eq(27767217)
+    end
+
+    it "should allow os_serial source" do
+      Ohai.config[:plugin][:shard_seed][:sources] = [:machinename, :os_serial, :uuid]
+      # Different from above.
+      expect(subject).to eq(178738102)
     end
   end
 

--- a/spec/unit/plugins/shard_spec.rb
+++ b/spec/unit/plugins/shard_spec.rb
@@ -111,7 +111,7 @@ describe Ohai::System, "shard plugin" do
     let(:fips) { true }
 
     it "should use SHA2" do
-      expect(Digest::MD5).to_not receive(:new)
+      expect(Digest::MD5).to_not receive(:hexdigest)
       expect(subject).to eq(117055036)
     end
   end


### PR DESCRIPTION
This makes life easier for most users since there is no reason to disable this plugin by default other than FIPS, and having to set `optional_plugins` is more of a barrier than I think we planned (I couldn't find an implementation of the cookbook-metadata-driven path we had talked about).
