### PR TITLE
[filesystem2] Backport filesystem2 for Ohai 13

### DIFF
--- a/lib/ohai/plugins/bsd/filesystem2.rb
+++ b/lib/ohai/plugins/bsd/filesystem2.rb
@@ -1,0 +1,121 @@
+#
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Tim Smith (<tsmith@chef.io>)
+# Author:: Phil Dibowitz (<phil@ipom.com>)
+# Copyright:: Copyright (c) 2008-2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:Filesystem2) do
+  provides "filesystem2"
+
+  def generate_device_view(fs)
+    view = {}
+    fs.each_value do |entry|
+      view[entry[:device]] = Mash.new unless view[entry[:device]]
+      entry.each do |key, val|
+        next if %w{device mount}.include?(key)
+        view[entry[:device]][key] = val
+      end
+      view[entry[:device]][:mounts] ||= []
+      if entry[:mount]
+        view[entry[:device]][:mounts] << entry[:mount]
+      end
+    end
+    view
+  end
+
+  def generate_mountpoint_view(fs)
+    view = {}
+    fs.each_value do |entry|
+      next unless entry[:mount]
+      view[entry[:mount]] = Mash.new unless view[entry[:mount]]
+      entry.each do |key, val|
+        next if %w{mount device}.include?(key)
+        view[entry[:mount]][key] = val
+      end
+      view[entry[:mount]][:devices] ||= []
+      if entry[:device]
+        view[entry[:mount]][:devices] << entry[:device]
+      end
+    end
+    view
+  end
+
+  collect_data(:freebsd, :openbsd, :netbsd, :dragonflybsd) do
+    fs = Mash.new
+
+    # Grab filesystem data from df
+    so = shell_out("df")
+    so.stdout.lines do |line|
+      case line
+      when /^Filesystem/
+        next
+      when /^(\S+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+\%)\s+(\S+)$/
+        key = "#{$1},#{$6}"
+        fs[key] = Mash.new
+        fs[key][:device] = $1
+        fs[key][:kb_size] = $2
+        fs[key][:kb_used] = $3
+        fs[key][:kb_available] = $4
+        fs[key][:percent_used] = $5
+        fs[key][:mount] = $6
+      end
+    end
+
+    # inode parsing from 'df -iP'
+    so = shell_out("df -iP")
+    so.stdout.lines do |line|
+      case line
+      when /^Filesystem/ # skip the header
+        next
+      when /^(\S+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\%\s+(\d+)\s+(\d+)\s+(\d+)%\s+(\S+)$/
+        key = "#{$1},#{$9}"
+        fs[key] ||= Mash.new
+        fs[key][:device] = $1
+        fs[key][:inodes_used] = $6
+        fs[key][:inodes_available] = $7
+        fs[key][:total_inodes] = ($6.to_i + $7.to_i).to_s
+        fs[key][:inodes_percent_used] = $8
+        fs[key][:mount] = $9
+      end
+    end
+
+    # Grab mount information from mount
+    so = shell_out("mount -l")
+    so.stdout.lines do |line|
+      if line =~ /^(.+?) on (.+?) \((.+?), (.+?)\)$/
+        key = "#{$1},#{$2}"
+        fs[key] ||= Mash.new
+        fs[key][:device] = $1
+        fs[key][:mount] = $2
+        fs[key][:fs_type] = $3
+        fs[key][:mount_options] = $4.split(/,\s*/)
+      end
+    end
+
+    # create views
+    by_pair = fs
+    by_device = generate_device_view(fs)
+    by_mountpoint = generate_mountpoint_view(fs)
+
+    fs_data = Mash.new
+    fs_data["by_device"] = by_device
+    fs_data["by_mountpoint"] = by_mountpoint
+    fs_data["by_pair"] = by_pair
+
+    filesystem2 fs_data
+  end
+end

--- a/spec/unit/plugins/bsd/filesystem2_spec.rb
+++ b/spec/unit/plugins/bsd/filesystem2_spec.rb
@@ -1,0 +1,126 @@
+#
+# Author:: Matthew Kent (<mkent@magoazul.com>)
+# Author:: Tim Smith (<tsmith@chef.io>)
+# Copyright:: Copyright (c) 2011-2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../spec_helper.rb"
+
+describe Ohai::System, "BSD filesystem2 plugin" do
+  let(:plugin) { get_plugin("bsd/filesystem2") }
+  before(:each) do
+    allow(plugin).to receive(:collect_os).and_return(:freebsd)
+
+    allow(plugin).to receive(:shell_out).with("df").and_return(mock_shell_out(0, "", ""))
+    allow(plugin).to receive(:shell_out).with("df -iP").and_return(mock_shell_out(0, "", ""))
+    allow(plugin).to receive(:shell_out).with("mount -l").and_return(mock_shell_out(0, "", ""))
+  end
+
+  describe "when gathering filesystem usage data from df" do
+    before(:each) do
+      @stdout = <<-DF
+Filesystem  1K-blocks    Used   Avail Capacity  Mounted on
+/dev/ada0p2   9637788 3313504 5553264    37%    /
+devfs               1       1       0   100%    /dev
+DF
+      allow(plugin).to receive(:shell_out).with("df").and_return(mock_shell_out(0, @stdout, ""))
+
+      @inode_stdout = <<-DFi
+Filesystem  512-blocks    Used   Avail Capacity iused  ifree %iused  Mounted on
+/dev/ada0p2   15411832 5109256 9069632    36%  252576 790750   24%   /
+devfs                2       2       0   100%       0      0  100%   /dev
+DFi
+      allow(plugin).to receive(:shell_out).with("df -iP").and_return(mock_shell_out(0, @inode_stdout, ""))
+    end
+
+    it "should run df and df -iP" do
+      expect(plugin).to receive(:shell_out).ordered.with("df").and_return(mock_shell_out(0, @stdout, ""))
+      expect(plugin).to receive(:shell_out).ordered.with("df -iP").and_return(mock_shell_out(0, @inode_stdout, ""))
+      plugin.run
+    end
+
+    it "should set kb_size to value from df" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:kb_size]).to eq("9637788")
+    end
+
+    it "should set kb_used to value from df" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:kb_used]).to eq("3313504")
+    end
+
+    it "should set kb_available to value from df" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:kb_available]).to eq("5553264")
+    end
+
+    it "should set percent_used to value from df" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:percent_used]).to eq("37%")
+    end
+
+    it "should set mount to value from df" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:mount]).to eq("/")
+    end
+
+    it "should set total_inodes to value from df -iP" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:total_inodes]).to eq("1043326")
+    end
+
+    it "should set inodes_used to value from df -iP" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:inodes_used]).to eq("252576")
+    end
+
+    it "should set inodes_available to value from df -iP" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:inodes_available]).to eq("790750")
+    end
+  end
+
+  describe "when gathering mounted filesystem data from mount" do
+    before(:each) do
+      @stdout = <<-MOUNT
+/dev/ada0p2 on / (ufs, local, journaled soft-updates)
+devfs on /dev (devfs, local, multilabel)
+MOUNT
+      allow(plugin).to receive(:shell_out).with("mount -l").and_return(mock_shell_out(0, @stdout, ""))
+    end
+
+    it "should run mount" do
+      expect(plugin).to receive(:shell_out).with("mount -l").and_return(mock_shell_out(0, @stdout, ""))
+      plugin.run
+    end
+
+    it "should set mount to value from mount" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:mount]).to eq("/")
+    end
+
+    it "should set fs_type to value from mount" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:fs_type]).to eq("ufs")
+    end
+
+    it "should set mount_options to an array of values from mount" do
+      plugin.run
+      expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:mount_options]).to eq(["local", "journaled soft-updates"])
+    end
+  end
+
+end


### PR DESCRIPTION
### Description

This is partial backport of #1181. Rather than do the merging it simply makes an
additional plugin to be as non-intrusive to 13 as possible, but to provide some
level of upgradability to those who need it.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
