### PR TITLE
Fix shard plugin under FIPS mode because my testing was not sufficient

### DIFF
--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -53,8 +53,8 @@ Ohai.plugin(:ShardSeed) do
       require "digest/md5"
       Digest::MD5
     when "sha256"
-      require "digest/sha2"
-      Digest::SHA256
+      require "openssl/digest"
+      OpenSSL::Digest::SHA256
     end
   end
 


### PR DESCRIPTION
So after some repro and research:

```
[centos@ip-10-0-201-37 ~]$ /opt/chef/embedded/bin/irb
irb(main):001:0> require 'openssl'
=> true
irb(main):002:0> OpenSSL.fips_mode = true
=> true
irb(main):004:0> OpenSSL::Digest::SHA256.new
=> #<OpenSSL::Digest::SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>
irb(main):006:0> (OpenSSL::Digest::SHA256.new << 'asdf').hexdigest
=> "f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b"
irb(main):009:0> require 'digest/sha2'
=> true
irb(main):011:0> Digest::SHA256.new
sha256.c(34): OpenSSL internal error, assertion failed: Low level API call to digest SHA256 forbidden in FIPS mode!
Aborted
```

or tl;dr we need to use the openssl impl. I chef-config we patch stuff for MD5 and SHA1 (https://github.com/chef/chef/blob/886d2f317f0e1db583ec76491ee71ce8fa07e988/chef-config/lib/chef-config/config.rb#L1119) but not SHA2.