### PR TITLE
Rework FIPS detection to only use the positive of OpenSSL.fips_mode

### DIFF
--- a/lib/ohai/plugins/linux/fips.rb
+++ b/lib/ohai/plugins/linux/fips.rb
@@ -31,8 +31,8 @@ Ohai.plugin(:Fips) do
     # Check for new fips_mode method added in Ruby 2.5. After we drop support
     # for Ruby 2.4, clean up everything after this and collapse the FIPS plugins.
     require "openssl"
-    if defined?(OpenSSL.fips_mode) && !$FIPS_TEST_MODE
-      fips["kernel"] = { "enabled" => OpenSSL.fips_mode }
+    if defined?(OpenSSL.fips_mode) && OpenSSL.fips_mode && !$FIPS_TEST_MODE
+      fips["kernel"] = { "enabled" => true }
     else
       begin
         enabled = File.read("/proc/sys/crypto/fips_enabled").chomp

--- a/lib/ohai/plugins/windows/fips.rb
+++ b/lib/ohai/plugins/windows/fips.rb
@@ -31,8 +31,8 @@ Ohai.plugin(:Fips) do
     # Check for new fips_mode method added in Ruby 2.5. After we drop support
     # for Ruby 2.4, clean up everything after this and collapse the FIPS plugins.
     require "openssl"
-    if defined?(OpenSSL.fips_mode) && !$FIPS_TEST_MODE
-      fips["kernel"] = { "enabled" => OpenSSL.fips_mode }
+    if defined?(OpenSSL.fips_mode) && OpenSSL.fips_mode && !$FIPS_TEST_MODE
+      fips["kernel"] = { "enabled" => true }
     else
       require "win32/registry"
       # from http://msdn.microsoft.com/en-us/library/windows/desktop/aa384129(v=vs.85).aspx


### PR DESCRIPTION
Until we fix https://github.com/chef/ohai/issues/1185, OpenSSL.fips_mode can only be used as a positive signal, not a negative.

Without this, running via `ohai` and through Chef can return different results.