### PR TITLE
WIP: Remove V6 plugin Struct to reduce memory consumption

### DIFF
--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -52,7 +52,7 @@ module Ohai
         Ohai::Log.trace("Searching for Ohai plugins in #{path}")
 
         escaped = ChefConfig::PathHelper.escape_glob_dir(path)
-        Dir[File.join(escaped, "**", "*.rb")]
+        return Dir[File.join(escaped, "**", "*.rb")]
       end.flatten
     end
 

--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -85,7 +85,7 @@ module Ohai
     # purposes.
     #
     # @param plugin_path [String]
-    def load_plugin(plugin_path)
+    def load_plugin_for_tests(plugin_path)
       plugin_class = load_plugin_class_from_file(plugin_path)
       return nil unless plugin_class.kind_of?(Class)
       if plugin_class < Ohai::DSL::Plugin::VersionVII

--- a/lib/ohai/loader.rb
+++ b/lib/ohai/loader.rb
@@ -45,7 +45,7 @@ module Ohai
     def plugin_files_by_dir(plugin_dir = Ohai.config[:plugin_path])
       Array(plugin_dir).map do |path|
         unless Dir.exist?(path)
-          Ohai::Log.info("The plugin path #{path} does not exist. Skipping...")
+          Ohai::Log.debug("The plugin path #{path} does not exist. Skipping...")
           return []
         end
 

--- a/spec/functional/loader_spec.rb
+++ b/spec/functional/loader_spec.rb
@@ -44,7 +44,7 @@ EOF
 
       it "loads all the plugins" do
         loader.load_all
-        loaded_plugins = loader.instance_variable_get(:@v7_plugin_classes)
+        loaded_plugins = loader.instance_variable_get(:@plugin_classes)
         loaded_plugins_names = loaded_plugins.map { |plugin| plugin.name }
         expect(loaded_plugins_names).to eq(["Ohai::NamedPlugin::Foo"])
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ end
 
 def get_plugin(plugin, ohai = Ohai::System.new, path = PLUGIN_PATH)
   loader = Ohai::Loader.new(ohai)
-  loader.load_plugin(File.join(path, "#{plugin}.rb"))
+  loader.load_plugin_for_tests(File.join(path, "#{plugin}.rb"))
 end
 
 def convert_windows_output(stdout)

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -187,7 +187,7 @@ EOF
         it "logs an invalid plugin path warning" do
           expect(Ohai::Log).to receive(:info).with(/The plugin path.*does not exist/)
           allow(Dir).to receive(:exist?).with("/bogus/dir").and_return(false)
-          Ohai::Loader::PluginFile.find_all_in("/bogus/dir")
+          loader.plugin_files_by_dir("/bogus/dir")
         end
       end
     end

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -182,12 +182,19 @@ EOF
           expect { loader.load_plugin(path_to("bad_name.rb")) }.not_to raise_error
         end
       end
+    end
 
+    describe "the plugin_files_by_dir() method" do
       describe "when plugin directory does not exist" do
         it "logs an invalid plugin path warning" do
           expect(Ohai::Log).to receive(:info).with(/The plugin path.*does not exist/)
           allow(Dir).to receive(:exist?).with("/bogus/dir").and_return(false)
           loader.plugin_files_by_dir("/bogus/dir")
+        end
+
+        it "does not raise an error" do
+          allow(Dir).to receive(:exist?).with("/bogus/dir").and_return(false)
+          expect { loader.plugin_files_by_dir("/bogus/dir") }.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
We built a struct to track plugin file location because we needed both the file and the directory containing the file. We don't need that data anymore with V7 plugins. Instead we can just grab a list of files and then load each of the classes.

This shaves about 500k off Ohai runs

Signed-off-by: Tim Smith <tsmith@chef.io>