### PR TITLE
Detect virtualization on newer AWS instance types. (m5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .bundle
 *~
 vendor
+.idea/*

--- a/lib/ohai/mixin/dmi_decode.rb
+++ b/lib/ohai/mixin/dmi_decode.rb
@@ -44,6 +44,8 @@ module ::Ohai::Mixin::DmiDecode
         return "bhyve"
       when /Manufacturer: Veertu/
         return "veertu"
+      when /Manufacturer: Amazon EC2/
+        return "amazonec2"
       end
     end
     nil


### PR DESCRIPTION
### Description

Detects virtualization on AWS instances using the newer "nitro" hypervisor.

### Issues Resolved

Didn't see any.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
