### PR TITLE
Backport "Make the DMI IDs we whitelist configurable" to Ohai 13

### DIFF
--- a/lib/ohai/plugins/dmi.rb
+++ b/lib/ohai/plugins/dmi.rb
@@ -74,9 +74,8 @@ Ohai.plugin(:DMI) do
         elsif table_location = table_location_line.match(line)
           dmi[:table_location] = table_location[1]
 
-        elsif handle = handle_line.match(line)
-          # Don't overcapture for now (OHAI-260)
-          unless Ohai::Common::DMI::ID_TO_CAPTURE.include?(handle[2].to_i)
+        elsif ( handle = handle_line.match(line) )
+          unless Ohai::Common::DMI.whitelisted_ids.include?(handle[2].to_i)
             dmi_record = nil
             next
           end

--- a/lib/ohai/plugins/solaris2/dmi.rb
+++ b/lib/ohai/plugins/solaris2/dmi.rb
@@ -129,7 +129,7 @@ Ohai.plugin(:DMI) do
           id = smb_to_id[header_information[3]]
 
           # Don't overcapture for now (OHAI-260)
-          unless Ohai::Common::DMI::ID_TO_CAPTURE.include?(id)
+          unless Ohai::Common::DMI.whitelisted_ids.include?(id)
             dmi_record = nil
             next
           end

--- a/spec/unit/plugins/dmi_spec.rb
+++ b/spec/unit/plugins/dmi_spec.rb
@@ -101,15 +101,16 @@ Chassis Information
 EOS
 
 describe Ohai::System, "plugin dmi" do
+  let(:plugin) { get_plugin("dmi") }
+  let(:stdout) { DMI_OUT }
+
   before(:each) do
-    @plugin = get_plugin("dmi")
-    @stdout = DMI_OUT
-    allow(@plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, @stdout, ""))
+    allow(plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, stdout, ""))
   end
 
-  it "should run dmidecode" do
-    expect(@plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, @stdout, ""))
-    @plugin.run
+  it "runs dmidecode" do
+    expect(plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, stdout, ""))
+    plugin.run
   end
 
   # Test some simple sample data
@@ -128,21 +129,28 @@ describe Ohai::System, "plugin dmi" do
     },
   }.each do |id, data|
     data.each do |attribute, value|
-      it "should have [:dmi][:#{id}][:#{attribute}] set" do
-        @plugin.run
-        expect(@plugin[:dmi][id][attribute]).to eql(value)
+      it "attribute [:dmi][:#{id}][:#{attribute}] is set" do
+        plugin.run
+        expect(plugin[:dmi][id][attribute]).to eql(value)
       end
-      it "should have [:dmi][:#{id}][:#{attribute}] set for windows output" do
-        @stdout = convert_windows_output(DMI_OUT)
-        expect(@plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, @stdout, ""))
-        @plugin.run
-        expect(@plugin[:dmi][id][attribute]).to eql(value)
+      it "attribute [:dmi][:#{id}][:#{attribute}] set for windows output" do
+        stdout = convert_windows_output(DMI_OUT)
+        expect(plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, stdout, ""))
+        plugin.run
+        expect(plugin[:dmi][id][attribute]).to eql(value)
       end
     end
   end
 
-  it "should correctly ignore unwanted data" do
-    @plugin.run
-    expect(@plugin[:dmi][:base_board]).not_to have_key(:error_correction_type)
+  it "allows capturing additional DMI data" do
+    Ohai.config[:additional_dmi_ids] = [ 16 ]
+    plugin.run
+    expect(plugin[:dmi]).to have_key(:physical_memory_array)
+  end
+
+  it "correctly ignores data in excluded DMI IDs" do
+    expect(plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, stdout, ""))
+    plugin.run
+    expect(plugin[:dmi]).not_to have_key(:physical_memory_array)
   end
 end


### PR DESCRIPTION
### Description

A lot of people want their OEM / IPMI dmi data (in Ohai 13). It’s super handy to have (in Ohai 13).

Backport of #970

Signed-off-by: Gavin Reynolds <gavin@chef.io>

### Chec  List

- [x] New functionality include  tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>