### PR TITLE
Resolve several performance issues identified by Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,6 @@ Layout/Tab:
   Exclude:
     - "lib/ohai/plugins/mono.rb"
     - "lib/ohai/plugins/darwin/hardware.rb"
+
+Performance/UnneededSort:
+  Enabled: true

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -388,9 +388,9 @@ Ohai.plugin(:Network) do
   def choose_default_route(routes)
     routes.select do |r|
       r[:destination] == "default"
-    end.sort do |x, y|
+    end.min do |x, y|
       (x[:metric].nil? ? 0 : x[:metric].to_i) <=> (y[:metric].nil? ? 0 : y[:metric].to_i)
-    end.first
+    end
   end
 
   def interface_has_no_addresses_in_family?(iface, family)
@@ -447,7 +447,7 @@ Ohai.plugin(:Network) do
           iface[r[:dev]][:state] == "up" &&
           route_is_valid_default_route?(r, default_route)
       end
-    end.sort_by do |r|
+    end.min_by do |r|
       # sorting the selected routes:
       # - getting default routes first
       # - then sort by metric
@@ -463,7 +463,7 @@ Ohai.plugin(:Network) do
          0
        end,
       ]
-    end.first
+    end
   end
 
   # Both the network plugin and this plugin (linux/network) are run on linux. This plugin runs first.


### PR DESCRIPTION
Enable the UnneededSort rule so we can continue to identify these.