### PR TITLE
Add system_enclosure plugin for Windows

### DIFF
--- a/lib/ohai/plugins/windows/system_enclosure.rb
+++ b/lib/ohai/plugins/windows/system_enclosure.rb
@@ -20,13 +20,13 @@ Ohai.plugin :SystemEnclosure do
   provides "system_enclosure"
 
   collect_data(:windows) do
-    system_enclosure(Mash.new)
-    so = shell_out('powershell.exe -Command "get-ciminstance win32_systemenclosure"')
-    if so.exitstatus == 0
-      so.stdout.strip.each_line do |line|
-        kv = line.split(/:/, 2).map(&:strip)
-        system_enclosure[kv[0].downcase] = kv[1] if kv.length == 2
-      end
+    require "wmi-lite/wmi"
+    system_enclosure Mash.new
+    wmi = WmiLite::Wmi.new
+    wmi_object = wmi.first_of("Win32_SystemEnclosure").wmi_ole_object
+    wmi_object.properties_.each do |property|
+      value = wmi_object.invoke(property.name)
+      system_enclosure[property.name.downcase] = value unless value.nil?
     end
   end
 end

--- a/lib/ohai/plugins/windows/system_enclosure.rb
+++ b/lib/ohai/plugins/windows/system_enclosure.rb
@@ -24,9 +24,7 @@ Ohai.plugin :SystemEnclosure do
     system_enclosure Mash.new
     wmi = WmiLite::Wmi.new
     wmi_object = wmi.first_of("Win32_SystemEnclosure").wmi_ole_object
-    wmi_object.properties_.each do |property|
-      value = wmi_object.invoke(property.name)
-      system_enclosure[property.name.downcase] = value unless value.nil?
-    end
+    system_enclosure[:manufacturer] = wmi_object.invoke("manufacturer")
+    system_enclosure[:serialnumber] = wmi_object.invoke("serialnumber")
   end
 end

--- a/lib/ohai/plugins/windows/system_enclosure.rb
+++ b/lib/ohai/plugins/windows/system_enclosure.rb
@@ -1,0 +1,32 @@
+#
+# Author:: Stuart Preston (<stuart@chef.io>)
+# Copyright:: Copyright (c) 2018, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin :SystemEnclosure do
+  provides "system_enclosure"
+
+  collect_data(:windows) do
+    system_enclosure(Mash.new)
+    so = shell_out('powershell.exe -Command "get-ciminstance win32_systemenclosure"')
+    if so.exitstatus == 0
+      so.stdout.strip.each_line do |line|
+        kv = line.split(/:/, 2).map(&:strip)
+        system_enclosure[kv[0].downcase] = kv[1] if kv.length == 2
+      end
+    end
+  end
+end

--- a/spec/unit/plugins/windows/system_enclosure_spec.rb
+++ b/spec/unit/plugins/windows/system_enclosure_spec.rb
@@ -1,8 +1,6 @@
 #
-# Author:: Pavel Yudin (<pyudin@parallels.com>)
-# Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: Copyright (c) 2015 Pavel Yudin
-# Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+# Author:: Stuart Preston (<stuart@chef.io>)
+# Copyright:: Copyright (c) 2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/plugins/windows/system_enclosure_spec.rb
+++ b/spec/unit/plugins/windows/system_enclosure_spec.rb
@@ -22,11 +22,11 @@ describe Ohai::System, "System Enclosure", :windows_only do
   before do
     require "wmi-lite/wmi"
     @plugin = get_plugin("windows/system_enclosure")
-    manufacturer = double("WIN32OLE", :name => "manufacturer", :value => "My Fake Manufacturer")
-    serialnumber = double("WIN32OLE", :name => "serialnumber", :value => "1234123412341234")
+    manufacturer = double("WIN32OLE", name: "manufacturer", value: "My Fake Manufacturer")
+    serialnumber = double("WIN32OLE", name: "serialnumber", value: "1234123412341234")
     property_map = [ manufacturer, serialnumber ]
 
-    wmi_ole_object = double( "WIN32OLE", :properties_ => property_map)
+    wmi_ole_object = double( "WIN32OLE", properties_: property_map)
     allow(wmi_ole_object).to receive(:invoke).with(manufacturer.name).and_return(manufacturer.value)
     allow(wmi_ole_object).to receive(:invoke).with(serialnumber.name).and_return(serialnumber.value)
     wmi_object = WmiLite::Wmi::Instance.new(wmi_ole_object)

--- a/spec/unit/plugins/windows/system_enclosure_spec.rb
+++ b/spec/unit/plugins/windows/system_enclosure_spec.rb
@@ -1,0 +1,47 @@
+#
+# Author:: Pavel Yudin (<pyudin@parallels.com>)
+# Author:: Tim Smith (<tsmith@chef.io>)
+# Copyright:: Copyright (c) 2015 Pavel Yudin
+# Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../../spec_helper.rb"
+
+describe Ohai::System, "System Enclosure", :windows_only do
+  before do
+    require "wmi-lite/wmi"
+    @plugin = get_plugin("windows/system_enclosure")
+    manufacturer = double("WIN32OLE", :name => "manufacturer", :value => "Microsoft Corporation")
+    serialnumber = double("WIN32OLE", :name => "serialnumber", :value => "000430775257")
+    property_map = [ manufacturer, serialnumber ]
+
+    wmi_ole_object = double( "WIN32OLE", :properties_ => property_map)
+    allow(wmi_ole_object).to receive(:invoke).with(manufacturer.name).and_return(manufacturer.value)
+    allow(wmi_ole_object).to receive(:invoke).with(serialnumber.name).and_return(serialnumber.value)
+    wmi_object = WmiLite::Wmi::Instance.new(wmi_ole_object)
+    expect_any_instance_of(WmiLite::Wmi).to receive(:first_of).with(("Win32_SystemEnclosure")).and_return(wmi_object)
+  end
+
+  it "should return the manufacturer" do
+    @plugin.run
+    expect(@plugin["system_enclosure"]["manufacturer"]).to eql("Microsoft Corporation")
+  end
+
+  it "should return a serial number" do
+    @plugin.run
+    expect(@plugin["system_enclosure"]["serialnumber"]).to eql("000430775257")
+  end
+end

--- a/spec/unit/plugins/windows/system_enclosure_spec.rb
+++ b/spec/unit/plugins/windows/system_enclosure_spec.rb
@@ -24,8 +24,8 @@ describe Ohai::System, "System Enclosure", :windows_only do
   before do
     require "wmi-lite/wmi"
     @plugin = get_plugin("windows/system_enclosure")
-    manufacturer = double("WIN32OLE", :name => "manufacturer", :value => "Microsoft Corporation")
-    serialnumber = double("WIN32OLE", :name => "serialnumber", :value => "000430775257")
+    manufacturer = double("WIN32OLE", :name => "manufacturer", :value => "My Fake Manufacturer")
+    serialnumber = double("WIN32OLE", :name => "serialnumber", :value => "1234123412341234")
     property_map = [ manufacturer, serialnumber ]
 
     wmi_ole_object = double( "WIN32OLE", :properties_ => property_map)
@@ -37,11 +37,11 @@ describe Ohai::System, "System Enclosure", :windows_only do
 
   it "should return the manufacturer" do
     @plugin.run
-    expect(@plugin["system_enclosure"]["manufacturer"]).to eql("Microsoft Corporation")
+    expect(@plugin["system_enclosure"]["manufacturer"]).to eql("My Fake Manufacturer")
   end
 
   it "should return a serial number" do
     @plugin.run
-    expect(@plugin["system_enclosure"]["serialnumber"]).to eql("000430775257")
+    expect(@plugin["system_enclosure"]["serialnumber"]).to eql("1234123412341234")
   end
 end


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

This plugin provides a way to access the hardware information visible to Windows from the win32_systemenclosure class

Example output:
```
C:\projects\chef\ohai [sp/1209]> bundle exec ohai system_enclosure
{
  "manufacturer": "Microsoft Corporation",
  "serialnumber": "000430775257"
}
```

### Issues Resolved

Fixes #1209 

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
