### PR TITLE
Properly detect Amazon Linux 2 final release platform version

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -24,8 +24,14 @@ Ohai.plugin(:Platform) do
     contents[/^Red Hat/i] ? "redhat" : contents[/(\w+)/i, 1].downcase
   end
 
+  # Amazon Linux AMI release 2013.09
+  # Amazon Linux 2
+  # Fedora release 28 (Twenty Eight)
+  # CentOS release 5.8 (Final)
+  # CentOS release 6.7 (Final)
+  # Red Hat Enterprise Linux Server release 7.5 (Maipo)
   def get_redhatish_version(contents)
-    contents[/Rawhide/i] ? contents[/((\d+) \(Rawhide\))/i, 1].downcase : contents[/release ([\d\.]+)/, 1]
+    contents[/Rawhide/i] ? contents[/((\d+) \(Rawhide\))/i, 1].downcase : contents[/(release)? ([\d\.]+)/, 2]
   end
 
   #

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -458,6 +458,22 @@ OS_RELEASE
         expect(@plugin[:platform_version].to_f).to eq(7.3)
       end
 
+      it "should read the platform as amazon and version as 2 on the RC release" do
+        expect(File).to receive(:read).with("/etc/redhat-release").and_return("Amazon Linux release 2 (2017.12) LTS Release Candidate")
+        @plugin.run
+        expect(@plugin[:platform]).to eq("amazon")
+        expect(@plugin[:platform_family]).to eq("amazon")
+        expect(@plugin[:platform_version].to_f).to eq(2)
+      end
+
+      it "should read the platform as amazon and version as 2 on the final release" do
+        expect(File).to receive(:read).with("/etc/redhat-release").and_return("Amazon Linux 2")
+        @plugin.run
+        expect(@plugin[:platform]).to eq("amazon")
+        expect(@plugin[:platform_family]).to eq("amazon")
+        expect(@plugin[:platform_version].to_f).to eq(2)
+      end
+
       # https://github.com/chef/ohai/issues/560
       # Issue is seen on EL7, so that's what we're testing.
       context "on versions that have /etc/os-release" do


### PR DESCRIPTION
Make the release substring on RHEL platforms optional This fixes matching the new amazon linux which is entirely different than literally every other RHEL like platform.