### PR TITLE
Update Expeditor to clean branches / bump minors

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -8,10 +8,15 @@ rubygems:
   - ohai
 
 github:
+  # Cleanup merged PR branches
+  delete_branch_on_merge: true
   # The tag format to use (e.g. v1.0.0)
   version_tag_format: "v{{version}}"
   # The Github Team primarily responsible for handling incoming Pull Requests.
   maintainer_group: chef/client-maintainers
+  # allow bumping the minor release via label
+  minor_bump_labels:
+    - "Expeditor: Bump Minor Version"
   # Which Github branches to build Omnibus releases from, and what versions
   # (as determined by the value in the VERSION file) those branches are responsible
   # for building.
@@ -20,8 +25,6 @@ github:
         version_constraint: 14.*
     - 13-stable:
         version_constraint: 13.*
-    - 8-stable:
-        version_constraint: 8.*
 
 promote:
   action:
@@ -44,4 +47,3 @@ merge_actions:
         - "Expeditor: Skip All"
   - built_in:build_gem:
       only_if: built_in:bump_version
-


### PR DESCRIPTION
Cleanup branches post PR merge
Add ability to bump minor via label
Remove the branch config for Ohai 8 (chef 12)

Signed-off-by: Tim Smith <tsmith@chef.io>