### PR TITLE
Load collect_data() even if we've already seen it

### DIFF
--- a/lib/ohai/dsl/plugin/versionvii.rb
+++ b/lib/ohai/dsl/plugin/versionvii.rb
@@ -108,11 +108,8 @@ module Ohai
         # @param block [block] the actual code to collect data for the specified platforms
         def self.collect_data(platform = :default, *other_platforms, &block)
           [platform, other_platforms].flatten.each do |plat|
-            if data_collector.key?(plat)
-              raise Ohai::Exceptions::IllegalPluginDefinition, "collect_data already defined on platform #{plat}"
-            else
-              data_collector[plat] = block
-            end
+            Ohai::Log.warn("collect_data already defined on platform '#{plat}' for #{self}, last plugin seen will be used") if data_collector.key?(plat)
+            data_collector[plat] = block
           end
         end
 

--- a/spec/unit/dsl/plugin_spec.rb
+++ b/spec/unit/dsl/plugin_spec.rb
@@ -519,21 +519,20 @@ describe Ohai::DSL::Plugin::VersionVII do
     end
 
     it "fails a platform has already been defined in the same plugin" do
-      expect do
-        Ohai.plugin(:Test) do
-          collect_data {}
-          collect_data {}
-        end
-      end.to raise_error(Ohai::Exceptions::IllegalPluginDefinition, /collect_data already defined/)
+      Ohai.plugin(:Test) { collect_data {} }
+      expect(Ohai::Log).to receive(:warn).with(/collect_data already defined on platform/).twice
+      Ohai.plugin(:Test) do
+        collect_data {}
+        collect_data {}
+      end
     end
 
     it "fails if a platform has already been defined in another plugin file" do
       Ohai.plugin(:Test) { collect_data {} }
-      expect do
-        Ohai.plugin(:Test) do
-          collect_data {}
-        end
-      end.to raise_error(Ohai::Exceptions::IllegalPluginDefinition, /collect_data already defined/)
+      expect(Ohai::Log).to receive(:warn).with(/collect_data already defined on platform/)
+      Ohai.plugin(:Test) do
+        collect_data {}
+      end
     end
   end
 

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -130,7 +130,7 @@ EOF
 
       describe "when the plugin defines collect_data on the same platform more than once" do
         it "shoud log an illegal plugin definition warning" do
-          expect(loader.logger).to receive(:warn).with(/Plugin Definition Error: <#{path_to("illegal_def.rb")}>:/)
+          expect(Ohai::Log).to receive(:warn).with(/collect_data already defined on platform/)
           loader.load_plugin(path_to("illegal_def.rb"))
         end
 


### PR DESCRIPTION
If we happen to load a plugin with the same name twice, we refuse to run #collect_data but we still
load the rest of the plugin, which means you get #collect_data from the first plugin and rest of the
plugin from the last plugin.

This makes it so you get #collect_data from the last plugin as well.

I don't know how to use the logger from the class method so I fell back to `Ohai::Log`. Happy to fix that
if someone knows the magic.

Fixes #1212

Signed-off-by: Bryan McLellan <btm@chef.io>