### PR TITLE
Make the default shell_out timeout of 30 seconds configurable

### DIFF
--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -40,6 +40,7 @@ module Ohai
       default :run_all_plugins, false
       # optional plugins are the set of plugins that are marked optional but you wish to run.
       default :optional_plugins, []
+      default :timeout, 30
     end
   end
 

--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -40,7 +40,7 @@ module Ohai
       default :run_all_plugins, false
       # optional plugins are the set of plugins that are marked optional but you wish to run.
       default :optional_plugins, []
-      default :timeout, 30
+      default :shellout_timeout, 30
     end
   end
 

--- a/lib/ohai/mixin/command.rb
+++ b/lib/ohai/mixin/command.rb
@@ -28,8 +28,8 @@ module Ohai
       # accept a command and any of the mixlib-shellout options
       def shell_out(cmd, **options)
         options = options.dup
-        # unless specified by the caller timeout after 30 seconds
-        options[:timeout] ||= 30
+        # unless specified by the caller timeout after configured timeout (default 30 seconds)
+        options[:timeout] ||= Ohai::Config.ohai[:timeout]
         unless RUBY_PLATFORM =~ /mswin|mingw32|windows/
           options[:env] = options.key?(:env) ? options[:env].dup : {}
           options[:env]["PATH"] ||= ((ENV["PATH"] || "").split(":") + %w{/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin}).join(":")

--- a/lib/ohai/mixin/command.rb
+++ b/lib/ohai/mixin/command.rb
@@ -29,7 +29,7 @@ module Ohai
       def shell_out(cmd, **options)
         options = options.dup
         # unless specified by the caller timeout after configured timeout (default 30 seconds)
-        options[:timeout] ||= Ohai::Config.ohai[:timeout]
+        options[:timeout] ||= Ohai::Config.ohai[:shellout_timeout]
         unless RUBY_PLATFORM =~ /mswin|mingw32|windows/
           options[:env] = options.key?(:env) ? options[:env].dup : {}
           options[:env]["PATH"] ||= ((ENV["PATH"] || "").split(":") + %w{/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin}).join(":")


### PR DESCRIPTION
### Description

This makes the default timeout of 30 seconds configurable

### Issues Resolved

- #1072 

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
