### PR TITLE
Remove old labels from the expeditor config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -8,7 +8,7 @@ rubygems:
   - ohai
 
 github:
-  # Cleanup merged PR branches
+  # This deletes the GitHub PR branch after successfully merged into the release branch
   delete_branch_on_merge: true
   # The tag format to use (e.g. v1.0.0)
   version_tag_format: "v{{version}}"
@@ -33,14 +33,12 @@ promote:
 merge_actions:
   - built_in:bump_version:
       ignore_labels:
-        - "Version: Skip Bump"
         - "Expeditor: Skip Version Bump"
         - "Expeditor: Skip All"
   - bash:.expeditor/update_version.sh:
       only_if: built_in:bump_version
   - built_in:update_changelog:
       ignore_labels:
-        - "Meta: Exclude From Changelog"
         - "Expeditor: Exclude From Changelog"
         - "Expeditor: Skip All"
   - built_in:build_gem:


### PR DESCRIPTION
No need for these anymore now that we've standardized the labels

Signed-off-by: Tim Smith <tsmith@chef.io>