### PR TITLE
Uniquely name our network plugin helper methods

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -424,7 +424,7 @@ Ohai.plugin(:Network) do
   # ipv4/ipv6 routes are different enough that having a single algorithm to select the favored route for both creates unnecessary complexity
   # this method attempts to deduce the route that is most important to the user, which is later used to deduce the favored values for {ip,mac,ip6}address
   # we only consider routes that are default routes, or those routes that get us to the gateway for a default route
-  def favored_default_route(routes, iface, default_route, family)
+  def favored_default_route_linux(routes, iface, default_route, family)
     routes.select do |r|
       if family[:name] == "inet"
         # the route must have a source address
@@ -543,7 +543,7 @@ Ohai.plugin(:Network) do
           logger.trace("Plugin Network: #{default_prefix}_gateway set to #{network["#{default_prefix}_gateway"]}")
 
           # deduce the default route the user most likely cares about to pick {ip,mac,ip6}address below
-          favored_route = favored_default_route(routes, iface, default_route, family)
+          favored_route = favored_default_route_linux(routes, iface, default_route, family)
 
           # FIXME: This entire block should go away, and the network plugin should be the sole source of {ip,ip6,mac}address
 

--- a/lib/ohai/plugins/windows/network.rb
+++ b/lib/ohai/plugins/windows/network.rb
@@ -97,7 +97,7 @@ Ohai.plugin(:Network) do
   #
   # @return [Hash<:index, :interface_index, :default_ip_gateway, :ip_connection_metric>]
   #
-  def favored_default_route(configuration)
+  def favored_default_route_windows(configuration)
     return nil unless configuration.is_a?(Hash)
     config = configuration.dup
 
@@ -191,7 +191,7 @@ Ohai.plugin(:Network) do
       end
     end
 
-    if (route = favored_default_route(iface_config))
+    if (route = favored_default_route_windows(iface_config))
       network[:default_gateway] = route[:default_ip_gateway]
       network[:default_interface] = interface_code(route[:interface_index], route[:index])
     end

--- a/spec/unit/plugins/windows/network_spec.rb
+++ b/spec/unit/plugins/windows/network_spec.rb
@@ -80,7 +80,7 @@ describe Ohai::System, "Windows Network Plugin" do
     end
   end
 
-  describe "#favored_default_route" do
+  describe "#favored_default_route_windows" do
     let(:interface1) do
       { "index" => 1,
         "interface_index" => 1,
@@ -90,28 +90,28 @@ describe Ohai::System, "Windows Network Plugin" do
     let(:iface_config) { { 1 => interface1 } }
     context "When a hash is not passed" do
       it "Returns nil" do
-        expect(plugin.favored_default_route("Invalid")).to be_nil
+        expect(plugin.favored_default_route_windows("Invalid")).to be_nil
       end
     end
     context "When no interface is passed in Hash" do
       it "Returns nil" do
-        expect(plugin.favored_default_route({})).to be_nil
+        expect(plugin.favored_default_route_windows({})).to be_nil
       end
     end
     context "When an interface configuration is passed" do
       context "without default_ip_gateway" do
         it "Returns nil" do
           interface1["default_ip_gateway"] = nil
-          expect(plugin.favored_default_route(iface_config)).to be_nil
+          expect(plugin.favored_default_route_windows(iface_config)).to be_nil
         end
       end
       context "with default_ip_gateway" do
         it "Returns a hash with details" do
-          expect(plugin.favored_default_route(iface_config)).to be_a(Hash)
-          expect(plugin.favored_default_route(iface_config)).not_to be_empty
+          expect(plugin.favored_default_route_windows(iface_config)).to be_a(Hash)
+          expect(plugin.favored_default_route_windows(iface_config)).not_to be_empty
         end
         it "Returns the default_gateway in IPV4 format" do
-          expect(plugin.favored_default_route(iface_config)).to include(default_ip_gateway: "192.168.1.1")
+          expect(plugin.favored_default_route_windows(iface_config)).to include(default_ip_gateway: "192.168.1.1")
         end
       end
     end
@@ -127,10 +127,10 @@ describe Ohai::System, "Windows Network Plugin" do
           2 => interface2 }
       end
       it "Returns the default route as least metric interface" do
-        expect(plugin.favored_default_route(iface_config)).to include(interface_index: 1)
+        expect(plugin.favored_default_route_windows(iface_config)).to include(interface_index: 1)
       end
       it "Returns its default_gateway in IPV4 format" do
-        expect(plugin.favored_default_route(iface_config)).to include(default_ip_gateway: "192.168.1.1")
+        expect(plugin.favored_default_route_windows(iface_config)).to include(default_ip_gateway: "192.168.1.1")
       end
     end
   end


### PR DESCRIPTION
Simple fix for now that unbreaks the linux network plugin.

Signed-off-by: Tim Smith <tsmith@chef.io>