### PR TITLE
increase openstack metadata timout 2 to 10

### DIFF
--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -65,7 +65,7 @@ Ohai.plugin(:Openstack) do
       openstack[:provider] = openstack_provider
 
       # fetch the metadata if we can do a simple socket connect first
-      if can_socket_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
+      if can_socket_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, 10)
         fetch_metadata.each do |k, v|
           openstack[k] = v
         end

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -38,7 +38,7 @@ describe Ohai::System, "plugin openstack" do
     context "and the metadata service is not available" do
       before do
         allow(plugin).to receive(:can_socket_connect?)
-          .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
+          .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, 10)
           .and_return(false)
         plugin[:dmi] = dmi_data
         plugin.run
@@ -77,7 +77,7 @@ describe Ohai::System, "plugin openstack" do
     it "sets openstack provider attribute to dreamhost" do
       plugin["etc"] = { "passwd" => { "dhc-user" => {} } }
       allow(plugin).to receive(:can_socket_connect?)
-        .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
+        .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, 10)
         .and_return(false)
       plugin[:dmi] = { system: { all_records: [ { Manufacturer: "OpenStack Foundation" } ] } }
       plugin.run
@@ -89,7 +89,7 @@ describe Ohai::System, "plugin openstack" do
     context "and the metadata service is not available" do
       before do
         allow(plugin).to receive(:can_socket_connect?)
-          .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
+          .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, 10)
           .and_return(false)
         allow(plugin).to receive(:hint?).with("openstack").and_return(true)
         plugin.run
@@ -196,7 +196,7 @@ EOM
       before do
         allow(plugin).to receive(:hint?).with("openstack").and_return(true)
         allow(plugin).to receive(:can_socket_connect?)
-          .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
+          .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, 10)
           .and_return(true)
 
         allow(Net::HTTP).to receive(:start)


### PR DESCRIPTION
Signed-off-by: sawanoboly <sawanoboriyu@higanworks.com>

### Description

- increase openstack metadata timout 2 to 10

OpenStack's metadata API is often slow response. So please wait a little more.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>