### PR TITLE
Use a more standardized Rakefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,5 @@ matrix:
 
 script:
   - bundle exec chefstyle -v
-  - bundle exec chefstyle
-  - bundle exec rake spec
+  - bundle exec rake
   - bundle exec ohai

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,4 @@
 require "bundler/gem_tasks"
-require "date"
-require "ohai/version"
 
 begin
   require "rspec/core/rake_task"
@@ -11,14 +9,34 @@ begin
 rescue LoadError
   desc "rspec is not installed, this task is disabled"
   task :spec do
-    abort "rspec is not installed. `(sudo) gem install rspec` to run unit tests"
+    abort "rspec is not installed. bundle install first to make sure all dependencies are installed."
   end
 end
 
-task default: :spec
-
-require "chefstyle"
-require "rubocop/rake_task"
-RuboCop::RakeTask.new(:style) do |task|
-  task.options += ["--display-cop-names", "--no-color"]
+begin
+  require "chefstyle"
+  require "rubocop/rake_task"
+  desc "Run Chefstyle tests"
+  RuboCop::RakeTask.new(:style) do |task|
+    task.options += ["--display-cop-names", "--no-color"]
+  end
+rescue LoadError
+  puts "chefstyle gem is not installed. bundle install first to make sure all dependencies are installed."
 end
+
+begin
+  require "yard"
+  YARD::Rake::YardocTask.new(:docs)
+rescue LoadError
+  puts "yard is not available. bundle install first to make sure all dependencies are installed."
+end
+
+task :console do
+  require "irb"
+  require "irb/completion"
+  require "ohai"
+  ARGV.clear
+  IRB.start
+end
+
+task default: [:style, :spec]


### PR DESCRIPTION
Remove the old requires for the github changelog generator
Add the console task
Provide better error handling / messages when the gems aren't there
Make style/specs default and just run the default in Travis

Signed-off-by: Tim Smith <tsmith@chef.io>