### PR TITLE
Release Ohai 14.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Ohai will print out a JSON data blob for all the known data about your system. W
 Chef distributes ohai as a RubyGem. This README is for developers who want to modify the Ohai source code. For users who want to write plugins for Ohai, see the docs:
 
 - General documentation: <https://docs.chef.io/ohai.html>
-- Custom plugin documentation: <https://docs.chef.io/ohai_custom.html>
+- Writing Ohai Plugins documentation: <https://docs.chef.io/ohai_custom.html>
 
 ## Development Environment:
 
@@ -70,7 +70,7 @@ For information on contributing to this project see <https://github.com/chef/che
 Ohai - system information application
 
 - Author:: Adam Jacob ([adam@chef.io](mailto:adam@chef.io))
-- Copyright:: Copyright (c) 2008-2016 Chef Software, Inc.
+- Copyright:: Copyright (c) 2008-2018 Chef Software, Inc.
 - License:: Apache License, Version 2.0
 
 ```text

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+# Ohai Release Notes 14.5
+
+## Windows Improvements
+
+How we detect the `root_group` attribute on Windows has been simplified and improved to properly support non-English systems. With this change we've also deprecated the `Ohai::Util::Win32::GroupHelper` helper, which is no longer necessary. Thanks to @jugatsu for putting this together.
+
+We've also added a new `encryption_status` attribute to volumes on Windows. Thanks to @kmf for suggesting this new feature.
+
+## Configuration Improvements
+
+The timeout period for communicating with OpenStack metadata servers can now be configured with the `openstack_metadata_timeout` config option. Thanks to @sawanoboly for this improvement.
+
+Ohai now properly handles relative paths to config files when running on the command line. This means commands like `ohai -c ../client.rb` will now properly use your config values.
+
 # Ohai Release Notes 14.4
 
 ## Multiple plugin directories


### PR DESCRIPTION
Adds release note entries for 14.5 + minor readme updates.

Signed-off-by: Tim Smith <tsmith@chef.io>