### PR TITLE
Remove the chdir to / when running ohai

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -87,10 +87,6 @@ class Ohai::Application
   end
 
   def run_application
-    # Always switch to a readable directory. Keeps subsequent Dir.chdir() {}
-    # from failing due to permissions when launched as a less privileged user.
-    Dir.chdir("/")
-
     config[:invoked_from_cli] = true
     config[:logger] = Ohai::Log.with_child
     ohai = Ohai::System.new(config)


### PR DESCRIPTION
This is a legacy issue that doesn't seem to be a problem in the modern design of ohai. Additionally it's probably breaking minor / subtle things throughout plugins.

Signed-off-by: Tim Smith <tsmith@chef.io>