### PR TITLE
Add missing require ffi_yajl in System class

### DIFF
--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -29,6 +29,7 @@ require "ohai/provides_map"
 require "ohai/hints"
 require "mixlib/shellout"
 require "ohai/config"
+require "ffi_yajl"
 
 module Ohai
   class System


### PR DESCRIPTION
This is used several times in this class, but not required.

Signed-off-by: Tim Smith <tsmith@chef.io>