### PR TITLE
Connect to GCE metadata by IP not name

### DIFF
--- a/lib/ohai/mixin/gce_metadata.rb
+++ b/lib/ohai/mixin/gce_metadata.rb
@@ -20,8 +20,7 @@ module Ohai
   module Mixin
     module GCEMetadata
 
-      # Trailing dot to host is added to avoid DNS search path
-      GCE_METADATA_ADDR = "metadata.google.internal.".freeze unless defined?(GCE_METADATA_ADDR)
+      GCE_METADATA_ADDR = "169.254.169.254".freeze unless defined?(GCE_METADATA_ADDR)
       GCE_METADATA_URL = "/computeMetadata/v1/?recursive=true".freeze unless defined?(GCE_METADATA_URL)
 
       # fetch the meta content with a timeout and the required header


### PR DESCRIPTION
If you're using a non-GCE nameserver you won't be able to resolve the name. This aligns GCE with other clouds in Ohai.

Signed-off-by: Tim Smith <tsmith@chef.io>