### PR TITLE
Revert "Connect to GCE metadata by IP not name"

### DIFF
--- a/lib/ohai/mixin/gce_metadata.rb
+++ b/lib/ohai/mixin/gce_metadata.rb
@@ -20,7 +20,8 @@ module Ohai
   module Mixin
     module GCEMetadata
 
-      GCE_METADATA_ADDR = "169.254.169.254".freeze unless defined?(GCE_METADATA_ADDR)
+      # Trailing dot to host is added to avoid DNS search path
+      GCE_METADATA_ADDR = "metadata.google.internal.".freeze unless defined?(GCE_METADATA_ADDR)
       GCE_METADATA_URL = "/computeMetadata/v1/?recursive=true".freeze unless defined?(GCE_METADATA_URL)
 
       # fetch the meta content with a timeout and the required header


### PR DESCRIPTION
This reverts commit 192f84944120bed9099a59e42b6fb43155cc0f6c.

Turns out we heavily relied on the DNS name resolving to determine if we were actually on GCE. We're going to need to figure out proper GCE detection before we can use the IP here or it will detect azure/ec2 as gce.