### PR TITLE
Trim out bogus data in system_profile plugin

### DIFF
--- a/lib/ohai/plugins/darwin/hardware.rb
+++ b/lib/ohai/plugins/darwin/hardware.rb
@@ -34,13 +34,7 @@ Ohai.plugin(:Hardware) do
       next
     end
 
-    begin
-      require "plist"
-    rescue LoadError => e
-      # In case the plist gem isn't present, skip this plugin.
-      logger.trace("Plugin Hardware: Can't load gem: #{e}. Cannot continue.")
-      next
-    end
+    require "plist"
 
     hw_hash = system_profiler("SPHardwareDataType")
     hw_hash[0]["_items"][0].delete("_name")

--- a/lib/ohai/plugins/darwin/system_profiler.rb
+++ b/lib/ohai/plugins/darwin/system_profiler.rb
@@ -20,13 +20,12 @@ Ohai.plugin(:SystemProfile) do
   provides "system_profile"
 
   collect_data(:darwin) do
-    begin
-      require "plist"
+    require "plist"
 
-      system_profile Array.new
-      items = Array.new
-      detail_level = {
-        "mini" => %w{
+    system_profile Array.new
+    items = Array.new
+    detail_level = {
+      "mini" => %w{
 SPParallelATAData
 SPAudioData
 SPBluetoothData
@@ -52,21 +51,22 @@ SPThunderboltData
 SPUSBData
 SPWWANData
 SPAirPortData},
-        "full" => [
-                   "SPHardwareDataType",
-                  ],
-      }
+      "full" => [
+                 "SPHardwareDataType",
+                ],
+    }
 
-      detail_level.each do |level, data_types|
-        so = shell_out("system_profiler -xml -detailLevel #{level} #{data_types.join(' ')}")
-        Plist.parse_xml(so.stdout).each do |e|
-          items << e
-        end
+    detail_level.each do |level, data_types|
+      so = shell_out("system_profiler -xml -detailLevel #{level} #{data_types.join(' ')}")
+      Plist.parse_xml(so.stdout).each do |e|
+        # delete some bogus timing data and then keep the rest
+        e.delete("_SPCompletionInterval")
+        e.delete("_SPResponseTime")
+        e.delete("_SPCommandLineArguments")
+        items << e
       end
-
-      system_profile ( items.sort_by { |h| h["_dataType"] } ) # rubocop: disable Lint/ParenthesesAsGroupedExpression
-    rescue LoadError => e
-      logger.trace("Can't load gem: #{e})")
     end
+
+    system_profile ( items.sort_by { |h| h["_dataType"] } ) # rubocop: disable Lint/ParenthesesAsGroupedExpression
   end
 end


### PR DESCRIPTION
Also there's no need to rescue requiring plist since ohai depends on it. We don't do this for anything else in Ohai. This shaves 8k from the node data. I'm also going to open a PR to deprecate this plugin so we can remove it in Chef 15 since it doesn't actually work on modern systems and we already collect the same data in the hardware plugin.

Signed-off-by: Tim Smith <tsmith@chef.io>