### PR TITLE
Deprecate the system_profile plugin

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## New Deprecations
+
+### system_profile plugin
+
+The system_profile plugin will be removed from Chef/Ohai 15 in April 2019. This plugin does not correctly return data on modern Mac systems. Additionally the same data is provided by the hardware plugin, which has a format that is simpler to consume. Removing this plugin will reduce Ohai return by ~3 seconds and greatly reduce the size of the node object on the Chef server.
+
 # Ohai Release Notes 14.5
 
 ## Windows Improvements


### PR DESCRIPTION
1) It's broken
2) It's a huge amount of data on the node
3) It takes 3 seconds to run
4) Hardware plugin does the same thing, but better

Signed-off-by: Tim Smith <tsmith@chef.io>