### PR TITLE
Skip appveyor on docs/version bump commits

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,17 @@ environment:
 
 clone_folder: c:\projects\ohai
 clone_depth: 1
+
+skip_commits:
+  # version bumps by Expeditor happen as a separate commit after the merge, we can skip
+  author: Chef Expeditor
+  # if ONLY the files listed below are changed in a commit, skip
+  files:
+    - MAINTAINERS.md
+    - MAINTAINERS.toml
+    - CHANGELOG.md
+    - RELEASE_NOTES.md
+
 skip_tags: true
 branches:
   only:


### PR DESCRIPTION
This will skip commits that only change docs as well as the Expeditor
commits that only change the version (which cause a second identical
test to run).

Signed-off-by: Bryan McLellan <btm@loftninjas.org>
