### PR TITLE
Correctly detect SLES 15 systems as "suse" platform

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -291,7 +291,7 @@ Ohai.plugin(:Platform) do
     # We have to do this for compatibility reasons, or older OS releases might get different
     # "platform" or "platform_version" attributes (e.g. SLES12, RHEL7).
     elsif File.exist?("/etc/os-release")
-      platform os_release_info["ID"]
+      platform os_release_info["ID"] == "sles" ? "suse" : os_release_info["ID"] # SLES is wrong. We call it SUSE
       platform_version os_release_info["VERSION_ID"]
       # platform_family also does not need to be hardcoded anymore.
       # This would be the correct way, but we stick with "determine_platform_family" for compatibility reasons.

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -709,6 +709,7 @@ CISCO_RELEASE
 
       let(:os_release_content) do
         <<~OS_RELEASE
+          NAME="SLES"
           VERSION="15"
           VERSION_ID="15"
           PRETTY_NAME="SUSE Linux Enterprise Server 15"
@@ -727,7 +728,7 @@ OS_RELEASE
 
       it "correctly detects SLES15" do
         @plugin.run
-        expect(@plugin[:platform]).to eq("sles")
+        expect(@plugin[:platform]).to eq("suse")
         expect(@plugin[:platform_version]).to eq("15")
         expect(@plugin[:platform_family]).to eq("suse")
       end


### PR DESCRIPTION
This was a mistake when we introduced it. The system self identifies as SLES, but we need to make that suse to align with SLES 11/12 detection in Ohai.

Signed-off-by: Tim Smith <tsmith@chef.io>