### PR TITLE
Trim out bogus data in system_profile plugin

### DIFF
--- a/lib/ohai/plugins/darwin/hardware.rb
+++ b/lib/ohai/plugins/darwin/hardware.rb
@@ -34,13 +34,7 @@ Ohai.plugin(:Hardware) do
       next
     end
 
-    begin
-      require "plist"
-    rescue LoadError => e
-      # In case the plist gem isn't present, skip this plugin.
-      Ohai::Log.debug("Plugin Hardware: Can't load gem: #{e}. Cannot continue.")
-      next
-    end
+    require "plist"
 
     hw_hash = system_profiler("SPHardwareDataType")
     hw_hash[0]["_items"][0].delete("_name")


### PR DESCRIPTION
Also there's no need to rescue requiring plist since ohai depends on it. We don't do this for anything else in Ohai.

Signed-off-by: Tim Smith <tsmith@chef.io>