### PR TITLE
Avoid gathering all data with sysctl which seems to hang

### DIFF
--- a/lib/ohai/plugins/darwin/cpu.rb
+++ b/lib/ohai/plugins/darwin/cpu.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Nathan L Smith (<nlloyds@gmail.com>)
 # Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: Copyright (c) 2013-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ Ohai.plugin(:CPU) do
 
   collect_data(:darwin) do
     cpu Mash.new
-    shell_out("sysctl -a").stdout.lines.each do |line|
+    shell_out("sysctl hw machdep").stdout.lines.each do |line|
       case line
       when /^hw.packages: (.*)$/
         cpu[:real] = Regexp.last_match[1].to_i

--- a/spec/unit/plugins/darwin/cpu_spec.rb
+++ b/spec/unit/plugins/darwin/cpu_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nathan L Smith (<nlloyds@gmail.com>)
-# Copyright:: Copyright (c) 2013-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,7 +78,7 @@ machdep.cpu.max_basic: 13
 CTL
 
     allow(@plugin).to receive(:collect_os).and_return(:darwin)
-    allow(@plugin).to receive(:shell_out).with("sysctl -a").and_return(mock_shell_out(0, @stdout, ""))
+    allow(@plugin).to receive(:shell_out).with("sysctl hw machdep").and_return(mock_shell_out(0, @stdout, ""))
     @plugin.run
   end
 


### PR DESCRIPTION
While it works fine for me @bdausses was seeing chef-client hang
forever. It turns out running sysctl -a on his host was causing the
system to hang. Besides this crash it actually takes about 2x longer to
gather the additional data. This shaves a whole 0.033255 seconds from
the total runtime.

Signed-off-by: Tim Smith <tsmith@chef.io>