### PR TITLE
Fix provided relative paths to the config file

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -66,14 +66,6 @@ class Ohai::Application
     :proc         => lambda { |v| puts "Ohai: #{::Ohai::VERSION}" },
     :exit         => 0
 
-  def initialize
-    super
-
-    # Always switch to a readable directory. Keeps subsequent Dir.chdir() {}
-    # from failing due to permissions when launched as a less privileged user.
-    Dir.chdir("/")
-  end
-
   def run
     elapsed = Benchmark.measure do
       configure_ohai
@@ -92,6 +84,10 @@ class Ohai::Application
   end
 
   def run_application
+    # Always switch to a readable directory. Keeps subsequent Dir.chdir() {}
+    # from failing due to permissions when launched as a less privileged user.
+    Dir.chdir("/")
+
     config[:invoked_from_cli] = true
     ohai = Ohai::System.new(config)
     ohai.all_plugins(@attributes)


### PR DESCRIPTION
We do an expand_path on the passed config value and we use Dir.pwd with the expand, but before we ever get here we change the directory to /, which means specifying a file in the working directory results in something like /client.rb. This isn't what the user wants. Instead change the working directory right before we run the application instead of before we work out the config situation.

Signed-off-by: Tim Smith <tsmith@chef.io>