### PR TITLE
Ignore empty metadata openstack

### DIFF
--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -69,7 +69,7 @@ Ohai.plugin(:Openstack) do
       # fetch the metadata if we can do a simple socket connect first
       if can_socket_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, timeout)
         fetch_metadata.each do |k, v|
-          openstack[k] = v
+          openstack[k] = v unless v.empty?
         end
         logger.trace("Plugin Openstack: Successfully fetched Openstack metadata from the metadata endpoint")
       else

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -156,7 +156,8 @@ EOM
           "public-keys/0/" => "openssh-key",
           "public-keys/0/openssh-key" => "SSH KEY DATA",
           "security-groups" => "default",
-          "public-ipv4" => "",
+          "public-ipv4" => "172.31.7.2",
+          "public-ipv6" => "",
           "ami-manifest-path" => "FIXME",
           "instance-type" => "opc-tester",
           "instance-id" => "i-0000162a",
@@ -246,7 +247,10 @@ EOM
         expect(plugin["openstack"]["security_groups"]).to eq(["default"])
       end
       it "reads the public_ipv4 from the metadata service" do
-        expect(plugin["openstack"]["public_ipv4"]).to eq("")
+        expect(plugin["openstack"]["public_ipv4"]).to eq("172.31.7.2")
+      end
+      it "ignore the public_ipv6 from the metadata service when empty" do
+        expect(plugin["openstack"]).not_to have_key("public_ipv6")
       end
       it "reads the ami_manifest_path from the metadata service" do
         expect(plugin["openstack"]["ami_manifest_path"]).to eq("FIXME")


### PR DESCRIPTION
Signed-off-by: sawanoboly <sawanoboriyu@higanworks.com>

### Description

Due to the handling of OpenStack metadata, the Cloud plugin may crash.

Reproduction procedure

There is no `public-ipv4` key for metadata until Floating IPaddress is given.

1. Give virtualmachine a floating IPaddress
1. Remove the Floating IPaddress.
1. `"public-ipv4"=> ""` remains in the virtualmachine metadata, so crashing with IP address verification.


```
> Ohai::NamedPlugin::Cloud.new(ohai.data, ohai.logger).run
RuntimeError: ERROR: the ohai 'cloud' plugin failed with an IP address of '' : invalid address
from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/ohai-14.6.2/lib/ohai/plugins/cloud.rb:111:in `rescue in validate_ip_addr'
Caused by IPAddr::InvalidAddressError: invalid address
from /opt/chef/embedded/lib/ruby/2.5.0/ipaddr.rb:649:in `in6_addr'
```

### Issues Resolved



### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>