### PR TITLE
Set User-Agent in HTTP header for GCE plugin

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 This will be updated as the development of Ohai 15 progresses.
 
+## Cloud Plugin Improvements
+
+The Google Compute Engine (GCE) plugin now identifies `chef-ohai` as the User-Agent making requests to the Google Cloud metadata server (metadata.google.internal).
+
 # Ohai Release Notes 14.6
 
 ## Filesystem Plugin on AIX and Solaris

--- a/lib/ohai/mixin/gce_metadata.rb
+++ b/lib/ohai/mixin/gce_metadata.rb
@@ -28,7 +28,11 @@ module Ohai
       def http_get(uri)
         conn = Net::HTTP.start(GCE_METADATA_ADDR)
         conn.read_timeout = 6
-        conn.get(uri, { "Metadata-Flavor" => "Google" })
+        conn.get(uri, {
+                        "Metadata-Flavor" => "Google",
+                        "User-Agent" => "chef-ohai/#{Ohai::VERSION}",
+                      }
+                )
       end
 
       def fetch_metadata(id = "")


### PR DESCRIPTION
Setting the User-Agent to `chef-ohai/VERSION` will correctly identify ohai as the application making a request to metadata.google.internal.

The previous User-Agent header was defaulting to

`User-Agent: Ruby`

It is now set to

`chef-ohai/14.6.2` where `14.6.2` is the value of `Ohai::VERSION`

Signed-off-by: Nathen Harvey <nathenharvey@google.com>

- [ ] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
