### PR TITLE
/etc/os-release based OS detection

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -327,6 +327,8 @@ Ohai.plugin(:Platform) do
       "opensuseleap"
     when "xenenterprise"
       "xenserver"
+    when "cumulus-linux"
+      "cumulus"
     else
       id
     end

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -291,7 +291,14 @@ Ohai.plugin(:Platform) do
     # We have to do this for compatibility reasons, or older OS releases might get different
     # "platform" or "platform_version" attributes (e.g. SLES12, RHEL7).
     elsif File.exist?("/etc/os-release")
-      platform os_release_info["ID"] == "sles" ? "suse" : os_release_info["ID"] # SLES is wrong. We call it SUSE
+      case os_release_info["ID"]
+      when "sles"
+        platform "suse" # SLES is wrong. We call it SUSE
+      when "opensuse-leap"
+        platform "opensuseleap"
+      else
+        platform os_release_info["ID"]
+      end
       platform_version os_release_info["VERSION_ID"]
       # platform_family also does not need to be hardcoded anymore.
       # This would be the correct way, but we stick with "determine_platform_family" for compatibility reasons.

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -32,7 +32,6 @@ Ohai.plugin(:Platform) do
       "opensuse-leap" => "opensuseleap",
       "xenenterprise" => "xenserver",
       "cumulus-linux" => "cumulus",
-      "clear-linux-os" => "clearlinux",
     }.freeze
   end
 
@@ -260,7 +259,7 @@ Ohai.plugin(:Platform) do
       platform_version shell_out("/bin/uname -r").stdout.strip
     elsif File.exist?("/usr/lib/os-release")
       contents = File.read("/usr/lib/os-release")
-      if /Clear Linux/ =~ contents
+      if /clear-linux-os/ =~ contents # Clear Linux https://clearlinux.org/
         platform "clearlinux"
         platform_version contents[/VERSION_ID=(\d+)/, 1]
       end

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -47,7 +47,10 @@ Ohai.plugin(:Platform) do
   # CentOS release 6.7 (Final)
   # Red Hat Enterprise Linux Server release 7.5 (Maipo)
   #
-  # @deprecated
+  # @param contents [String] the contents of /etc/redhat-release
+  #
+  # @returns [String] the version string
+  #
   def get_redhatish_version(contents)
     contents[/Rawhide/i] ? contents[/((\d+) \(Rawhide\))/i, 1].downcase : contents[/(release)? ([\d\.]+)/, 2]
   end
@@ -289,7 +292,12 @@ Ohai.plugin(:Platform) do
   # where we've traditionally used the kernel as the version
   # @return String the OS version
   def determine_os_version
-    os_release_info["VERSION_ID"] || `/bin/uname -r`.strip
+    # centos only includes the major version in os-release for some reason
+    if os_release_info['ID'] == 'centos'
+      get_redhatish_version
+    else
+      os_release_info["VERSION_ID"] || `/bin/uname -r`.strip
+    end
   end
 
   collect_data(:linux) do

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -193,15 +193,8 @@ Ohai.plugin(:Platform) do
       if lsb[:id] =~ /Ubuntu/i
         platform "ubuntu"
         platform_version lsb[:release]
-      elsif lsb[:id] =~ /LinuxMint/i
-        platform "linuxmint"
-        platform_version lsb[:release]
       else
-        if File.exist?("/usr/bin/raspi-config")
-          platform "raspbian"
-        else
-          platform "debian"
-        end
+        platform "debian"
         platform_version File.read("/etc/debian_version").chomp
       end
     elsif File.exist?("/etc/parallels-release")

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -30,7 +30,6 @@ Ohai.plugin(:Platform) do
       "opensuse-leap" => "opensuseleap",
       "xenenterprise" => "xenserver",
       "cumulus-linux" => "cumulus",
-      "nexus" => "nexus_centos",
       "clear-linux-os" => "clearlinux",
     }.freeze
   end
@@ -124,6 +123,10 @@ Ohai.plugin(:Platform) do
   # @returns [String] the platform name to use in Ohai
   #
   def platform_id_remap(id)
+    # this catches the centos guest shell in the nexus switch which identifies itself as centos
+    return "nexus_centos" if id == "centos" && os_release_file_is_cisco?
+
+    # remap based on the hash of platforms
     PLATFORM_MAPPINGS[id] || id
   end
 
@@ -294,8 +297,8 @@ Ohai.plugin(:Platform) do
   # @return String the OS version
   def determine_os_version
     # centos only includes the major version in os-release for some reason
-    if os_release_info['ID'] == 'centos'
-      get_redhatish_version
+    if os_release_info["ID"] == "centos"
+      get_redhatish_version(File.read("/etc/redhat-release").chomp)
     else
       os_release_info["VERSION_ID"] || `/bin/uname -r`.strip
     end

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -31,6 +31,7 @@ Ohai.plugin(:Platform) do
       "xenenterprise" => "xenserver",
       "cumulus-linux" => "cumulus",
       "nexus" => "nexus_centos",
+      "clear-linux-os" => "clearlinux",
     }.freeze
   end
 

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -151,7 +151,7 @@ Ohai.plugin(:Platform) do
       "amazon"
     when /suse/, /sles/, /opensuse/
       "suse"
-    when /fedora/, /pidora/, /arista_eos/, /arista_eos/
+    when /fedora/, /pidora/, /arista_eos/
       # In the broadest sense:  RPM-based, fedora-derived distributions which are not strictly re-compiled RHEL (if it uses RPMs, and smells more like redhat and less like
       # SuSE it probably goes here).
       "fedora"

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -83,21 +83,6 @@ Ohai.plugin(:Platform) do
   end
 
   #
-  # Determines the platform version for Cumulus Linux systems
-  #
-  # @deprecated
-  #
-  # @returns [String] cumulus Linux version from /etc/cumulus/etc.replace/os-release
-  #
-  def cumulus_version
-    release_contents = File.read("/etc/cumulus/etc.replace/os-release")
-    release_contents.match(/VERSION_ID=(.*)/)[1]
-  rescue NoMethodError, Errno::ENOENT, Errno::EACCES # rescue regex failure, file missing, or permission denied
-    logger.warn("Detected Cumulus Linux, but /etc/cumulus/etc/replace/os-release could not be parsed to determine platform_version")
-    nil
-  end
-
-  #
   # Determines the platform version for F5 Big-IP systems
   #
   # @deprecated
@@ -110,21 +95,6 @@ Ohai.plugin(:Platform) do
   rescue NoMethodError, Errno::ENOENT, Errno::EACCES # rescue regex failure, file missing, or permission denied
     logger.warn("Detected F5 Big-IP, but /etc/f5-release could not be parsed to determine platform_version")
     nil
-  end
-
-  #
-  # Determines the platform version for Debian based systems
-  #
-  # @deprecated
-  #
-  # @returns [String] version of the platform
-  #
-  def debian_platform_version
-    if platform == "cumulus"
-      cumulus_version
-    else # not cumulus
-      File.read("/etc/debian_version").chomp
-    end
   end
 
   #
@@ -203,12 +173,10 @@ Ohai.plugin(:Platform) do
       else
         if File.exist?("/usr/bin/raspi-config")
           platform "raspbian"
-        elsif Dir.exist?("/etc/cumulus")
-          platform "cumulus"
         else
           platform "debian"
         end
-        platform_version debian_platform_version
+        platform_version File.read("/etc/debian_version").chomp
       end
     elsif File.exist?("/etc/parallels-release")
       contents = File.read("/etc/parallels-release").chomp

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -253,12 +253,6 @@ Ohai.plugin(:Platform) do
       end
 
       platform_version os_release_info["VERSION"]
-    elsif File.exist?("/etc/gentoo-release")
-      platform "gentoo"
-      # the gentoo release version is the base version used to bootstrap
-      # a node and doesn't have a lot of meaning in a rolling release distro
-      # kernel release will be used - ex. 3.18.7-gentoo
-      platform_version `/bin/uname -r`.strip
     elsif File.exist?("/etc/slackware-version")
       platform "slackware"
       platform_version File.read("/etc/slackware-version").scan(/(\d+|\.+)/).join

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -297,6 +297,8 @@ Ohai.plugin(:Platform) do
       "xenserver"
     when "cumulus-linux"
       "cumulus"
+    when "nexus"
+      "nexus_centos"
     else
       id
     end

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -211,14 +211,9 @@ Ohai.plugin(:Platform) do
       platform get_redhatish_platform(contents)
       platform_version contents.match(/(\d\.\d\.\d)/)[0]
     elsif File.exist?("/etc/redhat-release")
-      if os_release_file_is_cisco? # Cisco guestshell
-        platform "nexus_centos"
-        platform_version os_release_info["VERSION"]
-      else
-        contents = File.read("/etc/redhat-release").chomp
-        platform get_redhatish_platform(contents)
-        platform_version get_redhatish_version(contents)
-      end
+      contents = File.read("/etc/redhat-release").chomp
+      platform get_redhatish_platform(contents)
+      platform_version get_redhatish_version(contents)
     elsif File.exist?("/etc/system-release")
       contents = File.read("/etc/system-release").chomp
       platform get_redhatish_platform(contents)

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -262,19 +262,11 @@ Ohai.plugin(:Platform) do
     elsif File.exist?("/etc/slackware-version")
       platform "slackware"
       platform_version File.read("/etc/slackware-version").scan(/(\d+|\.+)/).join
-    elsif File.exist?("/etc/arch-release")
-      platform "arch"
-      # no way to determine platform_version in a rolling release distribution
-      # kernel release will be used - ex. 2.6.32-ARCH
-      platform_version `/bin/uname -r`.strip
     elsif File.exist?("/etc/exherbo-release")
       platform "exherbo"
       # no way to determine platform_version in a rolling release distribution
       # kernel release will be used - ex. 3.13
       platform_version `/bin/uname -r`.strip
-    elsif File.exist?("/etc/alpine-release")
-      platform "alpine"
-      platform_version File.read("/etc/alpine-release").strip
     elsif File.exist?("/usr/lib/os-release")
       contents = File.read("/usr/lib/os-release")
       if /Clear Linux/ =~ contents

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -20,7 +20,9 @@ Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_family"
   depends "lsb"
 
-  # the platform mappings between /etc/os-release values and ohai platforms
+  # the platform mappings between the 'ID' field in /etc/os-release and the value
+  # ohai uses. If you're adding a new platform here and you want to change the name
+  # you'll want to add it here and then add a spec for the platform_id_remap method
   unless defined?(PLATFORM_MAPPINGS)
     PLATFORM_MAPPINGS = {
       "rhel" => "redhat",
@@ -260,7 +262,7 @@ Ohai.plugin(:Platform) do
       platform "exherbo"
       # no way to determine platform_version in a rolling release distribution
       # kernel release will be used - ex. 3.13
-      platform_version `/bin/uname -r`.strip
+      platform_version shell_out("/bin/uname -r").stdout.strip
     elsif File.exist?("/usr/lib/os-release")
       contents = File.read("/usr/lib/os-release")
       if /Clear Linux/ =~ contents
@@ -294,7 +296,7 @@ Ohai.plugin(:Platform) do
     if os_release_info["ID"] == "centos"
       get_redhatish_version(File.read("/etc/redhat-release").chomp)
     else
-      os_release_info["VERSION_ID"] || `/bin/uname -r`.strip
+      os_release_info["VERSION_ID"] || shell_out("/bin/uname -r").stdout.strip
     end
   end
 

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -264,7 +264,7 @@ Ohai.plugin(:Platform) do
       # the gentoo release version is the base version used to bootstrap
       # a node and doesn't have a lot of meaning in a rolling release distro
       # kernel release will be used - ex. 3.18.7-gentoo
-      platform_version `uname -r`.strip
+      platform_version `/bin/uname -r`.strip
     elsif File.exist?("/etc/slackware-version")
       platform "slackware"
       platform_version File.read("/etc/slackware-version").scan(/(\d+|\.+)/).join
@@ -272,12 +272,12 @@ Ohai.plugin(:Platform) do
       platform "arch"
       # no way to determine platform_version in a rolling release distribution
       # kernel release will be used - ex. 2.6.32-ARCH
-      platform_version `uname -r`.strip
+      platform_version `/bin/uname -r`.strip
     elsif File.exist?("/etc/exherbo-release")
       platform "exherbo"
       # no way to determine platform_version in a rolling release distribution
       # kernel release will be used - ex. 3.13
-      platform_version `uname -r`.strip
+      platform_version `/bin/uname -r`.strip
     elsif File.exist?("/etc/alpine-release")
       platform "alpine"
       platform_version File.read("/etc/alpine-release").strip
@@ -339,7 +339,7 @@ Ohai.plugin(:Platform) do
   # where we've traditionally used the kernel as the version
   # @return String the OS version
   def determine_os_version
-    os_release_info["VERSION_ID"] || `uname -r`.strip
+    os_release_info["VERSION_ID"] || `/bin/uname -r`.strip
   end
 
   collect_data(:linux) do

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -312,7 +312,6 @@ OS_DATA
     let(:have_usr_lib_os_release) { false }
     let(:have_cisco_release) { false }
     let(:have_f5_release) { false }
-    let(:have_cumulus_dir) { false }
 
     before(:each) do
       allow(plugin).to receive(:collect_os).and_return(:linux)
@@ -331,7 +330,6 @@ OS_DATA
       allow(File).to receive(:exist?).with("/etc/f5-release").and_return(have_f5_release)
       allow(File).to receive(:exist?).with("/usr/lib/os-release").and_return(have_usr_lib_os_release)
       allow(File).to receive(:exist?).with("/etc/shared/os-release").and_return(have_cisco_release)
-      allow(Dir).to receive(:exist?).with("/etc/cumulus").and_return(have_cumulus_dir)
 
       allow(File).to receive(:read).with("PLEASE STUB ALL File.read CALLS")
     end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -564,36 +564,6 @@ OS_DATA
           expect(plugin[:platform_version]).to eq("5.4")
           expect(plugin[:platform_family]).to eq("rhel")
         end
-
-        it "should set the platform_family to rhel if the LSB name is oracle-ish" do
-          plugin[:lsb][:id] = "EnterpriseEnterpriseServer"
-          plugin.run
-          expect(plugin[:platform_family]).to eq("rhel")
-        end
-
-        it "should set the platform_family to rhel if the LSB name is amazon-ish" do
-          plugin[:lsb][:id] = "Amazon"
-          plugin.run
-          expect(plugin[:platform_family]).to eq("amazon")
-        end
-
-        it "should set the platform_family to fedora if the LSB name is fedora-ish" do
-          plugin[:lsb][:id] = "Fedora"
-          plugin.run
-          expect(plugin[:platform_family]).to eq("fedora")
-        end
-
-        it "should set the platform_family to redhat if the LSB name is scientific-ish" do
-          plugin[:lsb][:id] = "Scientific"
-          plugin.run
-          expect(plugin[:platform_family]).to eq("rhel")
-        end
-
-        it "should set the platform_family to redhat if the LSB name is ibm-ish" do
-          plugin[:lsb][:id] = "IBM_PowerKVM"
-          plugin.run
-          expect(plugin[:platform_family]).to eq("rhel")
-        end
       end
 
       describe "without lsb_release results" do

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -82,76 +82,75 @@ describe Ohai::System, "Linux plugin platform" do
 
   describe "#platform_id_remap" do
     it "returns redhat for rhel os-release id" do
-      expect(plugin.platform_id_remap('rhel')).to eq('redhat')
+      expect(plugin.platform_id_remap("rhel")).to eq("redhat")
     end
 
     it "returns amazon for amzn os-release id" do
-      expect(plugin.platform_id_remap('amzn')).to eq('amazon')
+      expect(plugin.platform_id_remap("amzn")).to eq("amazon")
     end
 
     it "returns oracle for ol os-release id" do
-      expect(plugin.platform_id_remap('ol')).to eq('oracle')
+      expect(plugin.platform_id_remap("ol")).to eq("oracle")
     end
 
     it "returns suse for sles os-release id" do
-      expect(plugin.platform_id_remap('sles')).to eq('suse')
+      expect(plugin.platform_id_remap("sles")).to eq("suse")
     end
 
     it "returns opensuseleap for opensuse-leap os-release id" do
-      expect(plugin.platform_id_remap('opensuse-leap')).to eq('opensuseleap')
+      expect(plugin.platform_id_remap("opensuse-leap")).to eq("opensuseleap")
     end
 
     it "returns xenserver for xenenterprise os-release id" do
-      expect(plugin.platform_id_remap('xenenterprise')).to eq('xenserver')
+      expect(plugin.platform_id_remap("xenenterprise")).to eq("xenserver")
     end
 
     it "returns cumulus for cumulus-linux os-release id" do
-      expect(plugin.platform_id_remap('cumulus-linux')).to eq('cumulus')
+      expect(plugin.platform_id_remap("cumulus-linux")).to eq("cumulus")
     end
 
     it "does not transformation for any other platform" do
-      expect(plugin.platform_id_remap('ubuntu')).to eq('ubuntu')
+      expect(plugin.platform_id_remap("ubuntu")).to eq("ubuntu")
     end
   end
 
   describe "#platform_family_from_platform" do
-    %w(oracle centos redhat scientific enterpriseenterprise xenserver cloudlinux ibm_powerkvm parallels nexus_centos clearos bigip).each do |p|
+    %w{oracle centos redhat scientific enterpriseenterprise xenserver cloudlinux ibm_powerkvm parallels nexus_centos clearos bigip}.each do |p|
       it "returns rhel for #{p} platform" do
-        expect(plugin.platform_family_from_platform(p)).to eq('rhel')
+        expect(plugin.platform_family_from_platform(p)).to eq("rhel")
       end
     end
 
-    %w(suse sles opensuse).each do |p|
+    %w{suse sles opensuse}.each do |p|
       it "returns suse for #{p} platform" do
-        expect(plugin.platform_family_from_platform(p)).to eq('suse')
+        expect(plugin.platform_family_from_platform(p)).to eq("suse")
       end
     end
 
-    %w(fedora pidora arista_eos).each do |p|
+    %w{fedora pidora arista_eos}.each do |p|
       it "returns fedora for #{p} platform" do
-        expect(plugin.platform_family_from_platform(p)).to eq('fedora')
+        expect(plugin.platform_family_from_platform(p)).to eq("fedora")
       end
     end
 
-    %w(nexus ios_xr).each do |p|
+    %w{nexus ios_xr}.each do |p|
       it "returns wrlinux for #{p} platform" do
-        expect(plugin.platform_family_from_platform(p)).to eq('wrlinux')
+        expect(plugin.platform_family_from_platform(p)).to eq("wrlinux")
       end
     end
 
-    %w(arch manjaro).each do |p|
+    %w{arch manjaro}.each do |p|
       it "returns arch for #{p} platform" do
-        expect(plugin.platform_family_from_platform(p)).to eq('arch')
+        expect(plugin.platform_family_from_platform(p)).to eq("arch")
       end
     end
 
-    %w(amazon slackware gentoo exherbo alpine clearlinux).each do |same_name|
+    %w{amazon slackware gentoo exherbo alpine clearlinux}.each do |same_name|
       it "returns #{same_name} for #{same_name} platform" do
         expect(plugin.platform_family_from_platform(same_name)).to eq(same_name)
       end
     end
   end
-
 
   describe "on system with /etc/os-release" do
     before(:each) do

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -470,23 +470,6 @@ OS_DATA
       end
     end
 
-    describe "on alpine" do
-
-      let(:have_alpine_release) { true }
-
-      before(:each) do
-        plugin.lsb = nil
-      end
-
-      it "should set platform and platform_family to alpine" do
-        expect(File).to receive(:read).with("/etc/alpine-release").and_return("3.2.3")
-        plugin.run
-        expect(plugin[:platform]).to eq("alpine")
-        expect(plugin[:platform_family]).to eq("alpine")
-        expect(plugin[:platform_version]).to eq("3.2.3")
-      end
-    end
-
     describe "on arista eos" do
 
       let(:have_eos_release) { true }

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -238,7 +238,7 @@ OS_DATA
       end
 
       it "should set platform_version using kernel version from uname" do
-        expect(plugin).to receive(:`).with("/bin/uname -r").and_return("3.18.2-2-ARCH")
+        allow(plugin).to receive(:shell_out).with("/bin/uname -r").and_return(mock_shell_out(0, "3.18.2-2-ARCH\n", ""))
         plugin.run
         expect(plugin[:platform]).to eq("arch")
         expect(plugin[:platform_family]).to eq("arch")
@@ -273,12 +273,12 @@ OS_DATA
     context "when on centos where version data in os-release is wrong" do
       let(:os_data) do
         <<~OS_DATA
-        NAME="CentOS Linux"
-        VERSION="7 (Core)"
-        ID="centos"
-        ID_LIKE="rhel fedora"
-        VERSION_ID="7"
-        PRETTY_NAME="CentOS Linux 7 (Core)"
+          NAME="CentOS Linux"
+          VERSION="7 (Core)"
+          ID="centos"
+          ID_LIKE="rhel fedora"
+          VERSION_ID="7"
+          PRETTY_NAME="CentOS Linux 7 (Core)"
 OS_DATA
       end
 
@@ -541,6 +541,7 @@ OS_DATA
       let(:have_exherbo_release) { true }
 
       before(:each) do
+        allow(plugin).to receive(:shell_out).with("/bin/uname -r").and_return(mock_shell_out(0, "3.18.2-2-ARCH\n", ""))
         plugin.lsb = nil
       end
 
@@ -551,7 +552,6 @@ OS_DATA
       end
 
       it "should set platform_version to kernel release" do
-        expect(plugin).to receive(:`).with("/bin/uname -r").and_return("3.18.2-2-ARCH")
         plugin.run
         expect(plugin[:platform_version]).to eq("3.18.2-2-ARCH")
       end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -271,7 +271,6 @@ OS_DATA
       allow(File).to receive(:exist?).with("/etc/enterprise-release").and_return(have_enterprise_release)
       allow(File).to receive(:exist?).with("/etc/oracle-release").and_return(have_oracle_release)
       allow(File).to receive(:exist?).with("/etc/parallels-release").and_return(have_parallels_release)
-      allow(File).to receive(:exist?).with("/usr/bin/raspi-config").and_return(have_raspi_config)
       allow(File).to receive(:exist?).with("/etc/os-release").and_return(have_os_release)
       allow(File).to receive(:exist?).with("/etc/f5-release").and_return(have_f5_release)
       allow(File).to receive(:exist?).with("/usr/lib/os-release").and_return(have_usr_lib_os_release)

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2017, Chef Software Inc.
+# Copyright:: Copyright (c) 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,866 +19,17 @@
 require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Linux plugin platform" do
-
-  let(:have_debian_version) { false }
-  let(:have_redhat_release) { false }
-  let(:have_gentoo_release) { false }
-  let(:have_exherbo_release) { false }
-  let(:have_alpine_release) { false }
-  let(:have_eos_release) { false }
-  let(:have_suse_release) { false }
-  let(:have_arch_release) { false }
-  let(:have_system_release) { false }
-  let(:have_slackware_version) { false }
-  let(:have_enterprise_release) { false }
-  let(:have_oracle_release) { false }
-  let(:have_parallels_release) { false }
-  let(:have_raspi_config) { false }
-  let(:have_os_release) { false }
-  let(:have_usr_lib_os_release) { false }
-  let(:have_cisco_release) { false }
-  let(:have_f5_release) { false }
-  let(:have_cumulus_dir) { false }
-
-  before(:each) do
-    @plugin = get_plugin("linux/platform")
-    allow(@plugin).to receive(:collect_os).and_return(:linux)
-    @plugin[:lsb] = Mash.new
-    allow(File).to receive(:exist?).with("/etc/debian_version").and_return(have_debian_version)
-    allow(File).to receive(:exist?).with("/etc/redhat-release").and_return(have_redhat_release)
-    allow(File).to receive(:exist?).with("/etc/gentoo-release").and_return(have_gentoo_release)
-    allow(File).to receive(:exist?).with("/etc/exherbo-release").and_return(have_exherbo_release)
-    allow(File).to receive(:exist?).with("/etc/alpine-release").and_return(have_alpine_release)
-    allow(File).to receive(:exist?).with("/etc/Eos-release").and_return(have_eos_release)
-    allow(File).to receive(:exist?).with("/etc/SuSE-release").and_return(have_suse_release)
-    allow(File).to receive(:exist?).with("/etc/arch-release").and_return(have_arch_release)
-    allow(File).to receive(:exist?).with("/etc/system-release").and_return(have_system_release)
-    allow(File).to receive(:exist?).with("/etc/slackware-version").and_return(have_slackware_version)
-    allow(File).to receive(:exist?).with("/etc/enterprise-release").and_return(have_enterprise_release)
-    allow(File).to receive(:exist?).with("/etc/oracle-release").and_return(have_oracle_release)
-    allow(File).to receive(:exist?).with("/etc/parallels-release").and_return(have_parallels_release)
-    allow(File).to receive(:exist?).with("/usr/bin/raspi-config").and_return(have_raspi_config)
-    allow(File).to receive(:exist?).with("/etc/os-release").and_return(have_os_release)
-    allow(File).to receive(:exist?).with("/etc/f5-release").and_return(have_f5_release)
-    allow(File).to receive(:exist?).with("/usr/lib/os-release").and_return(have_usr_lib_os_release)
-    allow(File).to receive(:exist?).with("/etc/shared/os-release").and_return(have_cisco_release)
-    allow(Dir).to receive(:exist?).with("/etc/cumulus").and_return(have_cumulus_dir)
-
-    allow(File).to receive(:read).with("PLEASE STUB ALL File.read CALLS")
-  end
-
-  describe "on lsb compliant distributions" do
-    before(:each) do
-      @plugin[:lsb][:id] = "Ubuntu"
-      @plugin[:lsb][:release] = "8.04"
-    end
-
-    it "should set platform to lowercased lsb[:id]" do
-      @plugin.run
-      expect(@plugin[:platform]).to eq("ubuntu")
-    end
-
-    it "should set platform_version to lsb[:release]" do
-      @plugin.run
-      expect(@plugin[:platform_version]).to eq("8.04")
-    end
-
-    it "should set platform to ubuntu and platform_family to debian [:lsb][:id] contains Ubuntu" do
-      @plugin[:lsb][:id] = "Ubuntu"
-      @plugin.run
-      expect(@plugin[:platform]).to eq("ubuntu")
-      expect(@plugin[:platform_family]).to eq("debian")
-    end
-
-    it "should set platform to linuxmint and platform_family to debian [:lsb][:id] contains LinuxMint" do
-      @plugin[:lsb][:id] = "LinuxMint"
-      @plugin.run
-      expect(@plugin[:platform]).to eq("linuxmint")
-      expect(@plugin[:platform_family]).to eq("debian")
-    end
-
-    it "should set platform to debian and platform_family to debian [:lsb][:id] contains Debian" do
-      @plugin[:lsb][:id] = "Debian"
-      @plugin.run
-      expect(@plugin[:platform]).to eq("debian")
-      expect(@plugin[:platform_family]).to eq("debian")
-    end
-
-    it "should set platform to redhat and platform_family to rhel when [:lsb][:id] contains Redhat" do
-      @plugin[:lsb][:id] = "RedHatEnterpriseServer"
-      @plugin[:lsb][:release] = "5.7"
-      @plugin.run
-      expect(@plugin[:platform]).to eq("redhat")
-      expect(@plugin[:platform_family]).to eq("rhel")
-    end
-
-    it "should set platform to amazon and platform_family to rhel when [:lsb][:id] contains Amazon" do
-      @plugin[:lsb][:id] = "AmazonAMI"
-      @plugin[:lsb][:release] = "2011.09"
-      @plugin.run
-      expect(@plugin[:platform]).to eq("amazon")
-      expect(@plugin[:platform_family]).to eq("amazon")
-    end
-
-    it "should set platform to scientific when [:lsb][:id] contains ScientificSL" do
-      @plugin[:lsb][:id] = "ScientificSL"
-      @plugin[:lsb][:release] = "5.7"
-      @plugin.run
-      expect(@plugin[:platform]).to eq("scientific")
-    end
-
-    it "should set platform to ibm_powerkvm and platform_family to rhel when [:lsb][:id] contains IBM_PowerKVM" do
-      @plugin[:lsb][:id] = "IBM_PowerKVM"
-      @plugin[:lsb][:release] = "2.1"
-      @plugin.run
-      expect(@plugin[:platform]).to eq("ibm_powerkvm")
-      expect(@plugin[:platform_family]).to eq("rhel")
-    end
-  end
-
-  describe "on debian" do
-
-    let(:have_debian_version) { true }
-
-    before(:each) do
-      @plugin.lsb = nil
-    end
-
-    it "should read the version from /etc/debian_version" do
-      expect(File).to receive(:read).with("/etc/debian_version").and_return("5.0")
-      @plugin.run
-      expect(@plugin[:platform_version]).to eq("5.0")
-    end
-
-    it "should correctly strip any newlines" do
-      expect(File).to receive(:read).with("/etc/debian_version").and_return("5.0\n")
-      @plugin.run
-      expect(@plugin[:platform_version]).to eq("5.0")
-    end
-
-    # Ubuntu has /etc/debian_version as well
-    it "should detect Ubuntu as itself rather than debian" do
-      @plugin[:lsb][:id] = "Ubuntu"
-      @plugin[:lsb][:release] = "8.04"
-      @plugin.run
-      expect(@plugin[:platform]).to eq("ubuntu")
-    end
-
-    context "on raspbian" do
-
-      let(:have_raspi_config) { true }
-
-      # Raspbian is a debian clone
-      it "should detect Raspbian as itself with debian as the family" do
-        expect(File).to receive(:read).with("/etc/debian_version").and_return("wheezy/sid")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("raspbian")
-        expect(@plugin[:platform_family]).to eq("debian")
-      end
-    end
-
-    context "on cumulus" do
-
-      let(:have_cumulus_dir) { true }
-      let(:cumulus_release_content) do
-        <<~OS_RELEASE
-          NAME="Cumulus Linux"
-          VERSION_ID=3.1.2
-          VERSION="Cumulus Linux 3.1.2"
-          PRETTY_NAME="Cumulus Linux"
-          ID=cumulus-linux
-          ID_LIKE=debian
-          CPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:3.1.2
-          HOME_URL="http://www.cumulusnetworks.com/"
-          SUPPORT_URL="http://support.cumulusnetworks.com/"
-
-OS_RELEASE
-      end
-
-      before(:each) do
-        expect(File).to receive(:read).with("/etc/cumulus/etc.replace/os-release").and_return(cumulus_release_content)
-      end
-
-      # Cumulus is a debian derivative
-      it "should detect Cumulus as itself with debian as the family" do
-        @plugin.run
-        expect(@plugin[:platform]).to eq("cumulus")
-        expect(@plugin[:platform_family]).to eq("debian")
-      end
-
-      it "should detect Cumulus platform_version" do
-        @plugin.run
-        expect(@plugin[:platform_version]).to eq("3.1.2")
-      end
-    end
-  end
-
-  describe "on slackware" do
-
-    let(:have_slackware_version) { true }
-
-    before(:each) do
-      @plugin.lsb = nil
-    end
-
-    it "should set platform and platform_family to slackware" do
-      expect(File).to receive(:read).with("/etc/slackware-version").and_return("Slackware 12.0.0")
-      @plugin.run
-      expect(@plugin[:platform]).to eq("slackware")
-      expect(@plugin[:platform_family]).to eq("slackware")
-    end
-
-    it "should set platform_version on slackware" do
-      expect(File).to receive(:read).with("/etc/slackware-version").and_return("Slackware 12.0.0")
-      @plugin.run
-      expect(@plugin[:platform_version]).to eq("12.0.0")
-    end
-  end
-
-  describe "on arch" do
-
-    let(:have_arch_release) { true }
-
-    before(:each) do
-      @plugin.lsb = nil
-    end
-
-    it "should set platform to arch and platform_family to arch" do
-      @plugin.run
-      expect(@plugin[:platform]).to eq("arch")
-      expect(@plugin[:platform_family]).to eq("arch")
-    end
-
-    it "should set platform_version to kernel release" do
-      expect(@plugin).to receive(:`).with("uname -r").and_return("3.18.2-2-ARCH")
-      @plugin.run
-      expect(@plugin[:platform_version]).to eq("3.18.2-2-ARCH")
-    end
-  end
-
-  describe "on gentoo" do
-
-    let(:have_gentoo_release) { true }
-
-    before(:each) do
-      @plugin.lsb = nil
-    end
-
-    it "should set platform and platform_family to gentoo" do
-      @plugin.run
-      expect(@plugin[:platform]).to eq("gentoo")
-      expect(@plugin[:platform_family]).to eq("gentoo")
-    end
-
-    it "should set platform_version to kernel release" do
-      expect(@plugin).to receive(:`).with("uname -r").and_return("3.18.7-gentoo")
-      @plugin.run
-      expect(@plugin[:platform_version]).to eq("3.18.7-gentoo")
-    end
-  end
-
-  describe "on alpine" do
-
-    let(:have_alpine_release) { true }
-
-    before(:each) do
-      @plugin.lsb = nil
-    end
-
-    it "should set platform and platform_family to alpine" do
-      expect(File).to receive(:read).with("/etc/alpine-release").and_return("3.2.3")
-      @plugin.run
-      expect(@plugin[:platform]).to eq("alpine")
-      expect(@plugin[:platform_family]).to eq("alpine")
-      expect(@plugin[:platform_version]).to eq("3.2.3")
-    end
-  end
-
-  describe "on arista eos" do
-
-    let(:have_eos_release) { true }
-
-    before(:each) do
-      @plugin.lsb = nil
-    end
-
-    it "should set platform to arista_eos" do
-      expect(File).to receive(:read).with("/etc/Eos-release").and_return("Arista Networks EOS 4.16.7M")
-      @plugin.run
-      expect(@plugin[:platform]).to eq("arista_eos")
-      expect(@plugin[:platform_family]).to eq("fedora")
-      expect(@plugin[:platform_version]).to eq("4.16.7M")
-    end
-  end
-
-  describe "on f5 big-ip" do
-
-    let(:have_f5_release) { true }
-
-    before(:each) do
-      @plugin.lsb = nil
-    end
-
-    it "should set platform to bigip" do
-      expect(File).to receive(:read).with("/etc/f5-release").and_return("BIG-IP release 13.0.0 (Final)")
-      @plugin.run
-      expect(@plugin[:platform]).to eq("bigip")
-      expect(@plugin[:platform_family]).to eq("rhel")
-      expect(@plugin[:platform_version]).to eq("13.0.0")
-    end
-  end
-
-  describe "on exherbo" do
-
-    let(:have_exherbo_release) { true }
-
-    before(:each) do
-      @plugin.lsb = nil
-    end
-
-    it "should set platform and platform_family to exherbo" do
-      @plugin.run
-      expect(@plugin[:platform]).to eq("exherbo")
-      expect(@plugin[:platform_family]).to eq("exherbo")
-    end
-
-    it "should set platform_version to kernel release" do
-      expect(@plugin).to receive(:`).with("uname -r").and_return("3.18.2-2-ARCH")
-      @plugin.run
-      expect(@plugin[:platform_version]).to eq("3.18.2-2-ARCH")
-    end
-
-  end
-
-  describe "on redhat breeds" do
-    describe "with lsb_release results" do
-      it "should set the platform to redhat and platform_family to rhel even if the LSB name is something absurd but redhat like" do
-        @plugin[:lsb][:id] = "RedHatEnterpriseServer"
-        @plugin[:lsb][:release] = "6.1"
-        @plugin.run
-        expect(@plugin[:platform]).to eq("redhat")
-        expect(@plugin[:platform_version]).to eq("6.1")
-        expect(@plugin[:platform_family]).to eq("rhel")
-      end
-
-      it "should set the platform to centos and platform_family to rhel" do
-        @plugin[:lsb][:id] = "CentOS"
-        @plugin[:lsb][:release] = "5.4"
-        @plugin.run
-        expect(@plugin[:platform]).to eq("centos")
-        expect(@plugin[:platform_version]).to eq("5.4")
-        expect(@plugin[:platform_family]).to eq("rhel")
-      end
-
-      it "should set the platform_family to rhel if the LSB name is oracle-ish" do
-        @plugin[:lsb][:id] = "EnterpriseEnterpriseServer"
-        @plugin.run
-        expect(@plugin[:platform_family]).to eq("rhel")
-      end
-
-      it "should set the platform_family to rhel if the LSB name is amazon-ish" do
-        @plugin[:lsb][:id] = "Amazon"
-        @plugin.run
-        expect(@plugin[:platform_family]).to eq("amazon")
-      end
-
-      it "should set the platform_family to fedora if the LSB name is fedora-ish" do
-        @plugin[:lsb][:id] = "Fedora"
-        @plugin.run
-        expect(@plugin[:platform_family]).to eq("fedora")
-      end
-
-      it "should set the platform_family to redhat if the LSB name is scientific-ish" do
-        @plugin[:lsb][:id] = "Scientific"
-        @plugin.run
-        expect(@plugin[:platform_family]).to eq("rhel")
-      end
-
-      it "should set the platform_family to redhat if the LSB name is ibm-ish" do
-        @plugin[:lsb][:id] = "IBM_PowerKVM"
-        @plugin.run
-        expect(@plugin[:platform_family]).to eq("rhel")
-      end
-    end
-
-    describe "without lsb_release results" do
-
-      let(:have_redhat_release) { true }
-
-      before(:each) do
-        @plugin.lsb = nil
-      end
-
-      it "should read the platform as centos and version as 5.3" do
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("CentOS release 5.3")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("centos")
-      end
-
-      it "may be that someone munged Red Hat to be RedHat" do
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("RedHat release 5.3")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("redhat")
-        expect(@plugin[:platform_version]).to eq("5.3")
-      end
-
-      it "should read the platform as redhat and version as 5.3" do
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat release 5.3")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("redhat")
-        expect(@plugin[:platform_version]).to eq("5.3")
-      end
-
-      it "should read the platform as fedora and version as 13 (rawhide)" do
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("Fedora release 13 (Rawhide)")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("fedora")
-        expect(@plugin[:platform_version]).to eq("13 (rawhide)")
-      end
-
-      it "should read the platform as fedora and version as 10" do
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("Fedora release 10")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("fedora")
-        expect(@plugin[:platform_version]).to eq("10")
-      end
-
-      it "should read the platform as fedora and version as 13 using to_i" do
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("Fedora release 13 (Rawhide)")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("fedora")
-        expect(@plugin[:platform_version].to_i).to eq(13)
-      end
-
-      it "should read the platform as clearos and version as 7.3" do
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("ClearOS release 7.3.0 (Final)")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("clearos")
-        expect(@plugin[:platform_family]).to eq("rhel")
-        expect(@plugin[:platform_version].to_f).to eq(7.3)
-      end
-
-      it "should read the platform as amazon and version as 2 on the RC release" do
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("Amazon Linux release 2 (2017.12) LTS Release Candidate")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("amazon")
-        expect(@plugin[:platform_family]).to eq("amazon")
-        expect(@plugin[:platform_version].to_f).to eq(2)
-      end
-
-      it "should read the platform as amazon and version as 2 on the final release" do
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("Amazon Linux 2")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("amazon")
-        expect(@plugin[:platform_family]).to eq("amazon")
-        expect(@plugin[:platform_version].to_f).to eq(2)
-      end
-
-      it "should read the platform as amazon and version as 2 when codename is in the release string" do
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("Amazon Linux release 2 (Karoo)")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("amazon")
-        expect(@plugin[:platform_family]).to eq("amazon")
-        expect(@plugin[:platform_version].to_f).to eq(2)
-      end
-
-      # https://github.com/chef/ohai/issues/560
-      # Issue is seen on EL7, so that's what we're testing.
-      context "on versions that have /etc/os-release" do
-
-        let(:have_os_release) { true }
-
-        let(:os_release_content) do
-          <<~OS_RELEASE
-            NAME="CentOS Linux"
-            VERSION="7 (Core)"
-            ID="centos"
-            ID_LIKE="rhel fedora"
-            VERSION_ID="7"
-            PRETTY_NAME="CentOS Linux 7 (Core)"
-            ANSI_COLOR="0;31"
-            CPE_NAME="cpe:/o:centos:centos:7"
-            HOME_URL="https://www.centos.org/"
-            BUG_REPORT_URL="https://bugs.centos.org/"
-
-OS_RELEASE
-        end
-
-        before do
-          expect(File).to receive(:read).with("/etc/redhat-release").and_return("CentOS release 7.1")
-          expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
-        end
-
-        it "correctly detects EL7" do
-          @plugin.run
-          expect(@plugin[:platform]).to eq("centos")
-          expect(@plugin[:platform_version]).to eq("7.1")
-        end
-
-      end
-
-      context "on 'guestshell' with /etc/os-release and overrides for Cisco Nexus" do
-
-        let(:have_os_release) { true }
-
-        let(:os_release_content) do
-          <<~OS_RELEASE
-            NAME="CentOS Linux"
-            VERSION="7 (Core)"
-            ID="centos"
-            ID_LIKE="rhel fedora"
-            VERSION_ID="7"
-            PRETTY_NAME="CentOS Linux 7 (Core)"
-            ANSI_COLOR="0;31"
-            CPE_NAME="cpe:/o:centos:centos:7"
-            HOME_URL="https://www.centos.org/"
-            BUG_REPORT_URL="https://bugs.centos.org/"
-
-            CENTOS_MANTISBT_PROJECT="CentOS-7"
-            CENTOS_MANTISBT_PROJECT_VERSION="7"
-            REDHAT_SUPPORT_PRODUCT="centos"
-            REDHAT_SUPPORT_PRODUCT_VERSION="7"
-
-            CISCO_RELEASE_INFO=/etc/shared/os-release
-OS_RELEASE
-        end
-
-        let(:have_cisco_release) { true }
-
-        let(:cisco_release_content) do
-          <<~CISCO_RELEASE
-            ID=nexus
-            ID_LIKE=wrlinux
-            NAME=Nexus
-            VERSION="7.0(3)I2(0.475E.6)"
-            VERSION_ID="7.0(3)I2"
-            PRETTY_NAME="Nexus 7.0(3)I2"
-            HOME_URL=http://www.cisco.com
-            BUILD_ID=6
-            CISCO_RELEASE_INFO=/etc/os-release
-CISCO_RELEASE
-        end
-
-        before do
-          expect(File).to receive(:read).at_least(:once).with("/etc/os-release").and_return(os_release_content)
-          expect(File).to receive(:read).with("/etc/shared/os-release").and_return(cisco_release_content)
-        end
-
-        it "should set platform to nexus_guestshell and platform_family to rhel" do
-          @plugin.run
-          expect(@plugin[:platform]).to start_with("nexus")
-          expect(@plugin[:platform]).to eq("nexus_centos")
-          expect(@plugin[:platform_family]).to eq("rhel")
-          expect(@plugin[:platform_version]).to eq("7.0(3)I2(0.475E.6)")
-        end
-      end
-    end
-
-  end
-
-  describe "on pcs linux" do
-
-    let(:have_redhat_release) { true }
-    let(:have_parallels_release) { true }
-
-    describe "with lsb_result" do
-
-      it "should read the platform as parallels and version as 6.0.5" do
-        @plugin[:lsb][:id] = "CloudLinuxServer"
-        @plugin[:lsb][:release] = "6.5"
-        allow(File).to receive(:read).with("/etc/redhat-release").and_return("CloudLinux Server release 6.5 (Pavel Popovich)")
-        expect(File).to receive(:read).with("/etc/parallels-release").and_return("Parallels Cloud Server 6.0.5 (20007)")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("parallels")
-        expect(@plugin[:platform_version]).to eq("6.0.5")
-        expect(@plugin[:platform_family]).to eq("rhel")
-      end
-    end
-
-    describe "without lsb_results" do
-
-      before(:each) do
-        @plugin.lsb = nil
-      end
-
-      it "should read the platform as parallels and version as 6.0.5" do
-        allow(File).to receive(:read).with("/etc/redhat-release").and_return("CloudLinux Server release 6.5 (Pavel Popovich)")
-        expect(File).to receive(:read).with("/etc/parallels-release").and_return("Parallels Cloud Server 6.0.5 (20007)")
-        @plugin.run
-        expect(@plugin[:platform]).to eq("parallels")
-        expect(@plugin[:platform_version]).to eq("6.0.5")
-        expect(@plugin[:platform_family]).to eq("rhel")
-      end
-    end
-  end
-
-  describe "on oracle enterprise linux" do
-
-    let(:have_redhat_release) { true }
-
-    context "with lsb_results" do
-
-      context "on version 5.x" do
-
-        let(:have_enterprise_release) { true }
-
-        it "should read the platform as oracle and version as 5.7" do
-          @plugin[:lsb][:id] = "EnterpriseEnterpriseServer"
-          @plugin[:lsb][:release] = "5.7"
-          allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 5.7 (Tikanga)")
-          expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.7 (Carthage)")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("oracle")
-          expect(@plugin[:platform_version]).to eq("5.7")
-        end
-      end
-
-      context "on version 6.x" do
-
-        let(:have_oracle_release) { true }
-
-        it "should read the platform as oracle and version as 6.1" do
-          @plugin[:lsb][:id] = "OracleServer"
-          @plugin[:lsb][:release] = "6.1"
-          allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.1 (Santiago)")
-          expect(File).to receive(:read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.1")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("oracle")
-          expect(@plugin[:platform_version]).to eq("6.1")
-        end
-
-      end
-    end
-
-    context "without lsb_results" do
-      before(:each) do
-        @plugin.lsb = nil
-      end
-
-      context "on version 5.x" do
-
-        let(:have_enterprise_release) { true }
-
-        it "should read the platform as oracle and version as 5" do
-          allow(File).to receive(:read).with("/etc/redhat-release").and_return("Enterprise Linux Enterprise Linux Server release 5 (Carthage)")
-          expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5 (Carthage)")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("oracle")
-          expect(@plugin[:platform_version]).to eq("5")
-        end
-
-        it "should read the platform as oracle and version as 5.1" do
-          allow(File).to receive(:read).with("/etc/redhat-release").and_return("Enterprise Linux Enterprise Linux Server release 5.1 (Carthage)")
-          expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.1 (Carthage)")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("oracle")
-          expect(@plugin[:platform_version]).to eq("5.1")
-        end
-
-        it "should read the platform as oracle and version as 5.7" do
-          allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 5.7 (Tikanga)")
-          expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.7 (Carthage)")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("oracle")
-          expect(@plugin[:platform_version]).to eq("5.7")
-        end
-
-      end
-
-      context "on version 6.x" do
-
-        let(:have_oracle_release) { true }
-
-        it "should read the platform as oracle and version as 6.0" do
-          allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.0 (Santiago)")
-          expect(File).to receive(:read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.0")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("oracle")
-          expect(@plugin[:platform_version]).to eq("6.0")
-        end
-
-        it "should read the platform as oracle and version as 6.1" do
-          allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.1 (Santiago)")
-          expect(File).to receive(:read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.1")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("oracle")
-          expect(@plugin[:platform_version]).to eq("6.1")
-        end
-      end
-    end
-  end
-
-  describe "on suse" do
-    context "on openSUSE 15+" do
-
-      let(:have_suse_release) { false }
-      let(:have_os_release) { true }
-
-      let(:os_release_content) do
-        <<~OS_RELEASE
-          NAME="openSUSE Leap"
-          VERSION="15.0"
-          ID="opensuse-leap"
-          ID_LIKE="suse opensuse"
-          VERSION_ID="15.0"
-          PRETTY_NAME="openSUSE Leap 15.0"
-          ANSI_COLOR="0;32"
-          CPE_NAME="cpe:/o:opensuse:leap:15.0"
-OS_RELEASE
-      end
-
-      before do
-        expect(File).to_not receive(:read).with("/etc/SuSE-release")
-        expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
-      end
-
-      it "correctly detects opensuseleap 15" do
-        @plugin.run
-        expect(@plugin[:platform]).to eq("opensuseleap")
-        expect(@plugin[:platform_version]).to eq("15.0")
-        expect(@plugin[:platform_family]).to eq("suse")
-      end
-
-    end
-
-    context "on SLES 15+" do
-
-      let(:have_suse_release) { false }
-      let(:have_os_release) { true }
-
-      let(:os_release_content) do
-        <<~OS_RELEASE
-          NAME="SLES"
-          VERSION="15"
-          VERSION_ID="15"
-          PRETTY_NAME="SUSE Linux Enterprise Server 15"
-          ID="sles"
-          ID_LIKE="suse"
-          ANSI_COLOR="0;32"
-          CPE_NAME="cpe:/o:suse:sles:15"
-
-OS_RELEASE
-      end
-
-      before do
-        expect(File).to_not receive(:read).with("/etc/SuSE-release")
-        expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
-      end
-
-      it "correctly detects SLES15" do
-        @plugin.run
-        expect(@plugin[:platform]).to eq("suse")
-        expect(@plugin[:platform_version]).to eq("15")
-        expect(@plugin[:platform_family]).to eq("suse")
-      end
-    end
-
-    context "on versions that have both /etc/os-release and /etc/SuSE-release (e.g. SLES12)" do
-      let(:have_suse_release) { true }
-      let(:have_os_release) { true }
-
-      describe "with lsb_release results" do
-        before(:each) do
-          @plugin[:lsb][:id] = "SUSE LINUX"
-        end
-
-        it "should read the platform as opensuse on openSUSE" do
-          @plugin[:lsb][:release] = "12.1"
-          expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 12.1 (x86_64)\nVERSION = 12.1\nCODENAME = Asparagus\n")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("opensuse")
-          expect(@plugin[:platform_family]).to eq("suse")
-        end
-      end
-    end
-
-    context "on versions that have no /etc/os-release but /etc/SuSE-release (e.g. SLES11)" do
-      let(:have_suse_release) { true }
-      let(:have_os_release) { false }
-
-      describe "with lsb_release results" do
-        before(:each) do
-          @plugin[:lsb][:id] = "SUSE LINUX"
-        end
-
-        it "should read the platform as opensuse on openSUSE" do
-          @plugin[:lsb][:release] = "12.1"
-          expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 12.1 (x86_64)\nVERSION = 12.1\nCODENAME = Asparagus\n")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("opensuse")
-          expect(@plugin[:platform_family]).to eq("suse")
-        end
-      end
-    end
-
-    context "on openSUSE and older SLES versions" do
-      let(:have_suse_release) { true }
-      let(:have_os_release) { true }
-
-      describe "without lsb_release results" do
-        before(:each) do
-          @plugin.lsb = nil
-        end
-
-        it "should set platform and platform_family to suse and bogus verion to 10.0" do
-          expect(File).to receive(:read).with("/etc/SuSE-release").at_least(:once).and_return("VERSION = 10.0")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("suse")
-          expect(@plugin[:platform_family]).to eq("suse")
-        end
-
-        it "should read the version as 11.2" do
-          expect(File).to receive(:read).with("/etc/SuSE-release").and_return("SUSE Linux Enterprise Server 11.2 (i586)\nVERSION = 11\nPATCHLEVEL = 2\n")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("suse")
-          expect(@plugin[:platform_version]).to eq("11.2")
-          expect(@plugin[:platform_family]).to eq("suse")
-        end
-
-        it "[OHAI-272] should read the version as 11.3" do
-          expect(File).to receive(:read).with("/etc/SuSE-release").exactly(1).times.and_return("openSUSE 11.3 (x86_64)\nVERSION = 11.3")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("opensuse")
-          expect(@plugin[:platform_version]).to eq("11.3")
-          expect(@plugin[:platform_family]).to eq("suse")
-        end
-
-        it "[OHAI-272] should read the version as 11.4" do
-          expect(File).to receive(:read).with("/etc/SuSE-release").exactly(1).times.and_return("openSUSE 11.4 (i586)\nVERSION = 11.4\nCODENAME = Celadon")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("opensuse")
-          expect(@plugin[:platform_version]).to eq("11.4")
-          expect(@plugin[:platform_family]).to eq("suse")
-        end
-
-        it "should read the platform as opensuse on openSUSE" do
-          expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 12.2 (x86_64)\nVERSION = 12.2\nCODENAME = Mantis\n")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("opensuse")
-          expect(@plugin[:platform_family]).to eq("suse")
-        end
-
-        it "should read the platform as opensuseleap on openSUSE Leap" do
-          expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 42.1 (x86_64)\nVERSION = 42.1\nCODENAME = Malachite\n")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("opensuseleap")
-          expect(@plugin[:platform_family]).to eq("suse")
-        end
-      end
-    end
-  end
-
   describe "#read_os_release_info" do
     let(:file_contents) { "COW=MOO\nDOG=\"BARK\"" }
     it "returns nil if the file does not exist" do
       allow(File).to receive(:exist?).with("/etc/test-release").and_return(false)
-      expect(@plugin.read_os_release_info("/etc/test-release")).to be nil
+      expect(plugin.read_os_release_info("/etc/test-release")).to be nil
     end
 
     it "returns a hash of expected contents" do
       allow(File).to receive(:exist?).with("/etc/test-release").and_return(true)
       allow(File).to receive(:read).with("/etc/test-release").and_return(file_contents)
-      release_info = @plugin.read_os_release_info("/etc/test-release")
+      release_info = plugin.read_os_release_info("/etc/test-release")
 
       expect(release_info["COW"]).to eq("MOO")
       expect(release_info["DOG"]).to eq("BARK")
@@ -891,16 +42,16 @@ OS_RELEASE
 
       before do
         allow(File).to receive(:exist?).with("/etc/os-release").and_return(true)
-        allow(@plugin).to receive(:read_os_release_info).with("/etc/os-release").and_return(release_info)
+        allow(plugin).to receive(:read_os_release_info).with("/etc/os-release").and_return(release_info)
       end
 
       it "reads the os-release file" do
-        expect(@plugin).to receive(:read_os_release_info).with("/etc/os-release").and_return(release_info)
-        @plugin.os_release_info
+        expect(plugin).to receive(:read_os_release_info).with("/etc/os-release").and_return(release_info)
+        plugin.os_release_info
       end
 
       it "returns a hash of expected contents" do
-        expect(@plugin.os_release_info["ID"]).to eq("os_id")
+        expect(plugin.os_release_info["ID"]).to eq("os_id")
       end
     end
 
@@ -911,104 +62,958 @@ OS_RELEASE
       before do
         allow(File).to receive(:exist?).with("/etc/os-release").and_return(true)
         allow(File).to receive(:exist?).with("/etc/cisco-release").and_return(true)
-        allow(@plugin).to receive(:read_os_release_info).with("/etc/os-release").and_return(release_info)
-        allow(@plugin).to receive(:read_os_release_info).with("/etc/cisco-release").and_return(cisco_release_info)
+        allow(plugin).to receive(:read_os_release_info).with("/etc/os-release").and_return(release_info)
+        allow(plugin).to receive(:read_os_release_info).with("/etc/cisco-release").and_return(cisco_release_info)
       end
 
       it "reads the os-release AND the cisco-release file" do
-        expect(@plugin).to receive(:read_os_release_info).with("/etc/os-release").and_return(release_info)
-        expect(@plugin).to receive(:read_os_release_info).with("/etc/cisco-release").and_return(release_info)
-        @plugin.os_release_info
+        expect(plugin).to receive(:read_os_release_info).with("/etc/os-release").and_return(release_info)
+        expect(plugin).to receive(:read_os_release_info).with("/etc/cisco-release").and_return(release_info)
+        plugin.os_release_info
       end
 
       it "returns the ID from the cisco-release file instead of the os-release file" do
-        expect(@plugin.os_release_info["ID"]).to eq("cisco_id")
+        expect(plugin.os_release_info["ID"]).to eq("cisco_id")
       end
     end
   end
 
-  describe "on Wind River Linux 5 for Cisco Nexus" do
-    let(:have_os_release) { true }
-    let(:os_release_info) do
-      {
-        "ID"                 => "nexus",
-        "ID_LIKE"            => "wrlinux",
-        "NAME"               => "Nexus",
-        "VERSION"            => "7.0(3)I2(0.475E.6)",
-        "VERSION_ID"         => "7.0(3)I2",
-        "PRETTY_NAME"        => "Nexus 7.0(3)I2",
-        "HOME_URL"           => "http://www.cisco.com",
-        "BUILD_ID"           => "6",
-        "CISCO_RELEASE_INFO" => "/etc/os-release",
-      }
-    end
+  context "on system with /etc/os-release" do
 
-    it "should set platform to nexus and platform_family to wrlinux" do
-      allow(@plugin).to receive(:os_release_info).and_return(os_release_info)
-      @plugin.lsb = nil
-      @plugin.run
-
-      expect(@plugin[:platform]).to eq("nexus")
-      expect(@plugin[:platform_family]).to eq("wrlinux")
-      expect(@plugin[:platform_version]).to eq("7.0(3)I2(0.475E.6)")
-    end
   end
 
-  describe "on Wind River Linux 7 for Cisco IOS-XR" do
-    let(:have_os_release) { true }
-    let(:os_release_info) do
-      {
-        "ID"          => "ios_xr",
-        "ID_LIKE"     => "cisco-wrlinux wrlinux",
-        "NAME"        => "IOS XR",
-        "VERSION"     => "6.0.0.14I",
-        "VERSION_ID"  => "6.0.0.14I",
-        "PRETTY_NAME" => "Cisco IOS XR Software, Version 6.0.0.14I",
-        "BUILD_ID"    => "2015-09-10-15-50-17",
-        "HOME_URL"    => "http://www.cisco.com",
-        "CISCO_RELEASE_INFO" => "/etc/os-release",
-      }
+  context "on system without /etc/os-release (legacy)" do
+    let(:plugin) { get_plugin("linux/platform") }
+    let(:have_debian_version) { false }
+    let(:have_redhat_release) { false }
+    let(:have_gentoo_release) { false }
+    let(:have_exherbo_release) { false }
+    let(:have_alpine_release) { false }
+    let(:have_eos_release) { false }
+    let(:have_suse_release) { false }
+    let(:have_arch_release) { false }
+    let(:have_system_release) { false }
+    let(:have_slackware_version) { false }
+    let(:have_enterprise_release) { false }
+    let(:have_oracle_release) { false }
+    let(:have_parallels_release) { false }
+    let(:have_raspi_config) { false }
+    let(:have_os_release) { false }
+    let(:have_usr_lib_os_release) { false }
+    let(:have_cisco_release) { false }
+    let(:have_f5_release) { false }
+    let(:have_cumulus_dir) { false }
+
+    before(:each) do
+      allow(plugin).to receive(:collect_os).and_return(:linux)
+      plugin[:lsb] = Mash.new
+      allow(File).to receive(:exist?).with("/etc/debian_version").and_return(have_debian_version)
+      allow(File).to receive(:exist?).with("/etc/redhat-release").and_return(have_redhat_release)
+      allow(File).to receive(:exist?).with("/etc/gentoo-release").and_return(have_gentoo_release)
+      allow(File).to receive(:exist?).with("/etc/exherbo-release").and_return(have_exherbo_release)
+      allow(File).to receive(:exist?).with("/etc/alpine-release").and_return(have_alpine_release)
+      allow(File).to receive(:exist?).with("/etc/Eos-release").and_return(have_eos_release)
+      allow(File).to receive(:exist?).with("/etc/SuSE-release").and_return(have_suse_release)
+      allow(File).to receive(:exist?).with("/etc/arch-release").and_return(have_arch_release)
+      allow(File).to receive(:exist?).with("/etc/system-release").and_return(have_system_release)
+      allow(File).to receive(:exist?).with("/etc/slackware-version").and_return(have_slackware_version)
+      allow(File).to receive(:exist?).with("/etc/enterprise-release").and_return(have_enterprise_release)
+      allow(File).to receive(:exist?).with("/etc/oracle-release").and_return(have_oracle_release)
+      allow(File).to receive(:exist?).with("/etc/parallels-release").and_return(have_parallels_release)
+      allow(File).to receive(:exist?).with("/usr/bin/raspi-config").and_return(have_raspi_config)
+      allow(File).to receive(:exist?).with("/etc/os-release").and_return(have_os_release)
+      allow(File).to receive(:exist?).with("/etc/f5-release").and_return(have_f5_release)
+      allow(File).to receive(:exist?).with("/usr/lib/os-release").and_return(have_usr_lib_os_release)
+      allow(File).to receive(:exist?).with("/etc/shared/os-release").and_return(have_cisco_release)
+      allow(Dir).to receive(:exist?).with("/etc/cumulus").and_return(have_cumulus_dir)
+
+      allow(File).to receive(:read).with("PLEASE STUB ALL File.read CALLS")
     end
 
-    it "should set platform to ios_xr and platform_family to wrlinux" do
-      allow(@plugin).to receive(:os_release_info).and_return(os_release_info)
-      @plugin.lsb = nil
-      @plugin.run
+    describe "on lsb compliant distributions" do
+      before(:each) do
+        plugin[:lsb][:id] = "Ubuntu"
+        plugin[:lsb][:release] = "8.04"
+      end
 
-      expect(@plugin[:platform]).to eq("ios_xr")
-      expect(@plugin[:platform_family]).to eq("wrlinux")
-      expect(@plugin[:platform_version]).to eq("6.0.0.14I")
+      it "should set platform to lowercased lsb[:id]" do
+        plugin.run
+        expect(plugin[:platform]).to eq("ubuntu")
+      end
+
+      it "should set platform_version to lsb[:release]" do
+        plugin.run
+        expect(plugin[:platform_version]).to eq("8.04")
+      end
+
+      it "should set platform to ubuntu and platform_family to debian [:lsb][:id] contains Ubuntu" do
+        plugin[:lsb][:id] = "Ubuntu"
+        plugin.run
+        expect(plugin[:platform]).to eq("ubuntu")
+        expect(plugin[:platform_family]).to eq("debian")
+      end
+
+      it "should set platform to linuxmint and platform_family to debian [:lsb][:id] contains LinuxMint" do
+        plugin[:lsb][:id] = "LinuxMint"
+        plugin.run
+        expect(plugin[:platform]).to eq("linuxmint")
+        expect(plugin[:platform_family]).to eq("debian")
+      end
+
+      it "should set platform to debian and platform_family to debian [:lsb][:id] contains Debian" do
+        plugin[:lsb][:id] = "Debian"
+        plugin.run
+        expect(plugin[:platform]).to eq("debian")
+        expect(plugin[:platform_family]).to eq("debian")
+      end
+
+      it "should set platform to redhat and platform_family to rhel when [:lsb][:id] contains Redhat" do
+        plugin[:lsb][:id] = "RedHatEnterpriseServer"
+        plugin[:lsb][:release] = "5.7"
+        plugin.run
+        expect(plugin[:platform]).to eq("redhat")
+        expect(plugin[:platform_family]).to eq("rhel")
+      end
+
+      it "should set platform to amazon and platform_family to rhel when [:lsb][:id] contains Amazon" do
+        plugin[:lsb][:id] = "AmazonAMI"
+        plugin[:lsb][:release] = "2011.09"
+        plugin.run
+        expect(plugin[:platform]).to eq("amazon")
+        expect(plugin[:platform_family]).to eq("amazon")
+      end
+
+      it "should set platform to scientific when [:lsb][:id] contains ScientificSL" do
+        plugin[:lsb][:id] = "ScientificSL"
+        plugin[:lsb][:release] = "5.7"
+        plugin.run
+        expect(plugin[:platform]).to eq("scientific")
+      end
+
+      it "should set platform to ibm_powerkvm and platform_family to rhel when [:lsb][:id] contains IBM_PowerKVM" do
+        plugin[:lsb][:id] = "IBM_PowerKVM"
+        plugin[:lsb][:release] = "2.1"
+        plugin.run
+        expect(plugin[:platform]).to eq("ibm_powerkvm")
+        expect(plugin[:platform_family]).to eq("rhel")
+      end
     end
-  end
 
-  describe "on clearlinux" do
-    let(:have_usr_lib_os_release) { true }
-    let(:usr_lib_os_release_content) do
-      <<~CLEARLINUX_RELEASE
-        NAME="Clear Linux Software for Intel Architecture"
-        VERSION=1
-        ID=clear-linux-os
-        VERSION_ID=16140
-        PRETTY_NAME="Clear Linux OS for Intel Architecture"
-        ANSI_COLOR="1;35"
-        HOME_URL="https://clearlinux.org"
-        SUPPORT_URL="https://clearlinux.org"
-        BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"
-        PRIVACY_POLICY_URL="http://www.intel.com/privacy"
+    describe "on debian" do
+
+      let(:have_debian_version) { true }
+
+      before(:each) do
+        plugin.lsb = nil
+      end
+
+      it "should read the version from /etc/debian_version" do
+        expect(File).to receive(:read).with("/etc/debian_version").and_return("5.0")
+        plugin.run
+        expect(plugin[:platform_version]).to eq("5.0")
+      end
+
+      it "should correctly strip any newlines" do
+        expect(File).to receive(:read).with("/etc/debian_version").and_return("5.0\n")
+        plugin.run
+        expect(plugin[:platform_version]).to eq("5.0")
+      end
+
+      # Ubuntu has /etc/debian_version as well
+      it "should detect Ubuntu as itself rather than debian" do
+        plugin[:lsb][:id] = "Ubuntu"
+        plugin[:lsb][:release] = "8.04"
+        plugin.run
+        expect(plugin[:platform]).to eq("ubuntu")
+      end
+
+      context "on raspbian" do
+
+        let(:have_raspi_config) { true }
+
+        # Raspbian is a debian clone
+        it "should detect Raspbian as itself with debian as the family" do
+          expect(File).to receive(:read).with("/etc/debian_version").and_return("wheezy/sid")
+          plugin.run
+          expect(plugin[:platform]).to eq("raspbian")
+          expect(plugin[:platform_family]).to eq("debian")
+        end
+      end
+
+      context "on cumulus" do
+
+        let(:have_cumulus_dir) { true }
+        let(:cumulus_release_content) do
+          <<~OS_RELEASE
+            NAME="Cumulus Linux"
+            VERSION_ID=3.1.2
+            VERSION="Cumulus Linux 3.1.2"
+            PRETTY_NAME="Cumulus Linux"
+            ID=cumulus-linux
+            ID_LIKE=debian
+            CPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:3.1.2
+            HOME_URL="http://www.cumulusnetworks.com/"
+            SUPPORT_URL="http://support.cumulusnetworks.com/"
+
+  OS_RELEASE
+        end
+
+        before(:each) do
+          expect(File).to receive(:read).with("/etc/cumulus/etc.replace/os-release").and_return(cumulus_release_content)
+        end
+
+        # Cumulus is a debian derivative
+        it "should detect Cumulus as itself with debian as the family" do
+          plugin.run
+          expect(plugin[:platform]).to eq("cumulus")
+          expect(plugin[:platform_family]).to eq("debian")
+        end
+
+        it "should detect Cumulus platform_version" do
+          plugin.run
+          expect(plugin[:platform_version]).to eq("3.1.2")
+        end
+      end
+    end
+
+    describe "on slackware" do
+
+      let(:have_slackware_version) { true }
+
+      before(:each) do
+        plugin.lsb = nil
+      end
+
+      it "should set platform and platform_family to slackware" do
+        expect(File).to receive(:read).with("/etc/slackware-version").and_return("Slackware 12.0.0")
+        plugin.run
+        expect(plugin[:platform]).to eq("slackware")
+        expect(plugin[:platform_family]).to eq("slackware")
+      end
+
+      it "should set platform_version on slackware" do
+        expect(File).to receive(:read).with("/etc/slackware-version").and_return("Slackware 12.0.0")
+        plugin.run
+        expect(plugin[:platform_version]).to eq("12.0.0")
+      end
+    end
+
+    describe "on arch" do
+
+      let(:have_arch_release) { true }
+
+      before(:each) do
+        plugin.lsb = nil
+      end
+
+      it "should set platform to arch and platform_family to arch" do
+        plugin.run
+        expect(plugin[:platform]).to eq("arch")
+        expect(plugin[:platform_family]).to eq("arch")
+      end
+
+      it "should set platform_version to kernel release" do
+        expect(plugin).to receive(:`).with("uname -r").and_return("3.18.2-2-ARCH")
+        plugin.run
+        expect(plugin[:platform_version]).to eq("3.18.2-2-ARCH")
+      end
+    end
+
+    describe "on gentoo" do
+
+      let(:have_gentoo_release) { true }
+
+      before(:each) do
+        plugin.lsb = nil
+      end
+
+      it "should set platform and platform_family to gentoo" do
+        plugin.run
+        expect(plugin[:platform]).to eq("gentoo")
+        expect(plugin[:platform_family]).to eq("gentoo")
+      end
+
+      it "should set platform_version to kernel release" do
+        expect(plugin).to receive(:`).with("uname -r").and_return("3.18.7-gentoo")
+        plugin.run
+        expect(plugin[:platform_version]).to eq("3.18.7-gentoo")
+      end
+    end
+
+    describe "on alpine" do
+
+      let(:have_alpine_release) { true }
+
+      before(:each) do
+        plugin.lsb = nil
+      end
+
+      it "should set platform and platform_family to alpine" do
+        expect(File).to receive(:read).with("/etc/alpine-release").and_return("3.2.3")
+        plugin.run
+        expect(plugin[:platform]).to eq("alpine")
+        expect(plugin[:platform_family]).to eq("alpine")
+        expect(plugin[:platform_version]).to eq("3.2.3")
+      end
+    end
+
+    describe "on arista eos" do
+
+      let(:have_eos_release) { true }
+
+      before(:each) do
+        plugin.lsb = nil
+      end
+
+      it "should set platform to arista_eos" do
+        expect(File).to receive(:read).with("/etc/Eos-release").and_return("Arista Networks EOS 4.16.7M")
+        plugin.run
+        expect(plugin[:platform]).to eq("arista_eos")
+        expect(plugin[:platform_family]).to eq("fedora")
+        expect(plugin[:platform_version]).to eq("4.16.7M")
+      end
+    end
+
+    describe "on f5 big-ip" do
+
+      let(:have_f5_release) { true }
+
+      before(:each) do
+        plugin.lsb = nil
+      end
+
+      it "should set platform to bigip" do
+        expect(File).to receive(:read).with("/etc/f5-release").and_return("BIG-IP release 13.0.0 (Final)")
+        plugin.run
+        expect(plugin[:platform]).to eq("bigip")
+        expect(plugin[:platform_family]).to eq("rhel")
+        expect(plugin[:platform_version]).to eq("13.0.0")
+      end
+    end
+
+    describe "on exherbo" do
+
+      let(:have_exherbo_release) { true }
+
+      before(:each) do
+        plugin.lsb = nil
+      end
+
+      it "should set platform and platform_family to exherbo" do
+        plugin.run
+        expect(plugin[:platform]).to eq("exherbo")
+        expect(plugin[:platform_family]).to eq("exherbo")
+      end
+
+      it "should set platform_version to kernel release" do
+        expect(plugin).to receive(:`).with("uname -r").and_return("3.18.2-2-ARCH")
+        plugin.run
+        expect(plugin[:platform_version]).to eq("3.18.2-2-ARCH")
+      end
+
+    end
+
+    describe "on redhat breeds" do
+      describe "with lsb_release results" do
+        it "should set the platform to redhat and platform_family to rhel even if the LSB name is something absurd but redhat like" do
+          plugin[:lsb][:id] = "RedHatEnterpriseServer"
+          plugin[:lsb][:release] = "6.1"
+          plugin.run
+          expect(plugin[:platform]).to eq("redhat")
+          expect(plugin[:platform_version]).to eq("6.1")
+          expect(plugin[:platform_family]).to eq("rhel")
+        end
+
+        it "should set the platform to centos and platform_family to rhel" do
+          plugin[:lsb][:id] = "CentOS"
+          plugin[:lsb][:release] = "5.4"
+          plugin.run
+          expect(plugin[:platform]).to eq("centos")
+          expect(plugin[:platform_version]).to eq("5.4")
+          expect(plugin[:platform_family]).to eq("rhel")
+        end
+
+        it "should set the platform_family to rhel if the LSB name is oracle-ish" do
+          plugin[:lsb][:id] = "EnterpriseEnterpriseServer"
+          plugin.run
+          expect(plugin[:platform_family]).to eq("rhel")
+        end
+
+        it "should set the platform_family to rhel if the LSB name is amazon-ish" do
+          plugin[:lsb][:id] = "Amazon"
+          plugin.run
+          expect(plugin[:platform_family]).to eq("amazon")
+        end
+
+        it "should set the platform_family to fedora if the LSB name is fedora-ish" do
+          plugin[:lsb][:id] = "Fedora"
+          plugin.run
+          expect(plugin[:platform_family]).to eq("fedora")
+        end
+
+        it "should set the platform_family to redhat if the LSB name is scientific-ish" do
+          plugin[:lsb][:id] = "Scientific"
+          plugin.run
+          expect(plugin[:platform_family]).to eq("rhel")
+        end
+
+        it "should set the platform_family to redhat if the LSB name is ibm-ish" do
+          plugin[:lsb][:id] = "IBM_PowerKVM"
+          plugin.run
+          expect(plugin[:platform_family]).to eq("rhel")
+        end
+      end
+
+      describe "without lsb_release results" do
+
+        let(:have_redhat_release) { true }
+
+        before(:each) do
+          plugin.lsb = nil
+        end
+
+        it "should read the platform as centos and version as 5.3" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("CentOS release 5.3")
+          plugin.run
+          expect(plugin[:platform]).to eq("centos")
+        end
+
+        it "may be that someone munged Red Hat to be RedHat" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("RedHat release 5.3")
+          plugin.run
+          expect(plugin[:platform]).to eq("redhat")
+          expect(plugin[:platform_version]).to eq("5.3")
+        end
+
+        it "should read the platform as redhat and version as 5.3" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat release 5.3")
+          plugin.run
+          expect(plugin[:platform]).to eq("redhat")
+          expect(plugin[:platform_version]).to eq("5.3")
+        end
+
+        it "should read the platform as fedora and version as 13 (rawhide)" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("Fedora release 13 (Rawhide)")
+          plugin.run
+          expect(plugin[:platform]).to eq("fedora")
+          expect(plugin[:platform_version]).to eq("13 (rawhide)")
+        end
+
+        it "should read the platform as fedora and version as 10" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("Fedora release 10")
+          plugin.run
+          expect(plugin[:platform]).to eq("fedora")
+          expect(plugin[:platform_version]).to eq("10")
+        end
+
+        it "should read the platform as fedora and version as 13 using to_i" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("Fedora release 13 (Rawhide)")
+          plugin.run
+          expect(plugin[:platform]).to eq("fedora")
+          expect(plugin[:platform_version].to_i).to eq(13)
+        end
+
+        it "should read the platform as clearos and version as 7.3" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("ClearOS release 7.3.0 (Final)")
+          plugin.run
+          expect(plugin[:platform]).to eq("clearos")
+          expect(plugin[:platform_family]).to eq("rhel")
+          expect(plugin[:platform_version].to_f).to eq(7.3)
+        end
+
+        it "should read the platform as amazon and version as 2 on the RC release" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("Amazon Linux release 2 (2017.12) LTS Release Candidate")
+          plugin.run
+          expect(plugin[:platform]).to eq("amazon")
+          expect(plugin[:platform_family]).to eq("amazon")
+          expect(plugin[:platform_version].to_f).to eq(2)
+        end
+
+        it "should read the platform as amazon and version as 2 on the final release" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("Amazon Linux 2")
+          plugin.run
+          expect(plugin[:platform]).to eq("amazon")
+          expect(plugin[:platform_family]).to eq("amazon")
+          expect(plugin[:platform_version].to_f).to eq(2)
+        end
+
+        it "should read the platform as amazon and version as 2 when codename is in the release string" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("Amazon Linux release 2 (Karoo)")
+          plugin.run
+          expect(plugin[:platform]).to eq("amazon")
+          expect(plugin[:platform_family]).to eq("amazon")
+          expect(plugin[:platform_version].to_f).to eq(2)
+        end
+
+        # https://github.com/chef/ohai/issues/560
+        # Issue is seen on EL7, so that's what we're testing.
+        context "on versions that have /etc/os-release" do
+
+          let(:have_os_release) { true }
+
+          let(:os_release_content) do
+            <<~OS_RELEASE
+              NAME="CentOS Linux"
+              VERSION="7 (Core)"
+              ID="centos"
+              ID_LIKE="rhel fedora"
+              VERSION_ID="7"
+              PRETTY_NAME="CentOS Linux 7 (Core)"
+              ANSI_COLOR="0;31"
+              CPE_NAME="cpe:/o:centos:centos:7"
+              HOME_URL="https://www.centos.org/"
+              BUG_REPORT_URL="https://bugs.centos.org/"
+
+  OS_RELEASE
+          end
+
+          before do
+            expect(File).to receive(:read).with("/etc/redhat-release").and_return("CentOS release 7.1")
+            expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
+          end
+
+          it "correctly detects EL7" do
+            plugin.run
+            expect(plugin[:platform]).to eq("centos")
+            expect(plugin[:platform_version]).to eq("7.1")
+          end
+
+        end
+
+        context "on 'guestshell' with /etc/os-release and overrides for Cisco Nexus" do
+
+          let(:have_os_release) { true }
+
+          let(:os_release_content) do
+            <<~OS_RELEASE
+              NAME="CentOS Linux"
+              VERSION="7 (Core)"
+              ID="centos"
+              ID_LIKE="rhel fedora"
+              VERSION_ID="7"
+              PRETTY_NAME="CentOS Linux 7 (Core)"
+              ANSI_COLOR="0;31"
+              CPE_NAME="cpe:/o:centos:centos:7"
+              HOME_URL="https://www.centos.org/"
+              BUG_REPORT_URL="https://bugs.centos.org/"
+
+              CENTOS_MANTISBT_PROJECT="CentOS-7"
+              CENTOS_MANTISBT_PROJECT_VERSION="7"
+              REDHAT_SUPPORT_PRODUCT="centos"
+              REDHAT_SUPPORT_PRODUCT_VERSION="7"
+
+              CISCO_RELEASE_INFO=/etc/shared/os-release
+  OS_RELEASE
+          end
+
+          let(:have_cisco_release) { true }
+
+          let(:cisco_release_content) do
+            <<~CISCO_RELEASE
+              ID=nexus
+              ID_LIKE=wrlinux
+              NAME=Nexus
+              VERSION="7.0(3)I2(0.475E.6)"
+              VERSION_ID="7.0(3)I2"
+              PRETTY_NAME="Nexus 7.0(3)I2"
+              HOME_URL=http://www.cisco.com
+              BUILD_ID=6
+              CISCO_RELEASE_INFO=/etc/os-release
+  CISCO_RELEASE
+          end
+
+          before do
+            expect(File).to receive(:read).at_least(:once).with("/etc/os-release").and_return(os_release_content)
+            expect(File).to receive(:read).with("/etc/shared/os-release").and_return(cisco_release_content)
+          end
+
+          it "should set platform to nexus_guestshell and platform_family to rhel" do
+            plugin.run
+            expect(plugin[:platform]).to start_with("nexus")
+            expect(plugin[:platform]).to eq("nexus_centos")
+            expect(plugin[:platform_family]).to eq("rhel")
+            expect(plugin[:platform_version]).to eq("7.0(3)I2(0.475E.6)")
+          end
+        end
+      end
+
+    end
+
+    describe "on pcs linux" do
+
+      let(:have_redhat_release) { true }
+      let(:have_parallels_release) { true }
+
+      describe "with lsb_result" do
+
+        it "should read the platform as parallels and version as 6.0.5" do
+          plugin[:lsb][:id] = "CloudLinuxServer"
+          plugin[:lsb][:release] = "6.5"
+          allow(File).to receive(:read).with("/etc/redhat-release").and_return("CloudLinux Server release 6.5 (Pavel Popovich)")
+          expect(File).to receive(:read).with("/etc/parallels-release").and_return("Parallels Cloud Server 6.0.5 (20007)")
+          plugin.run
+          expect(plugin[:platform]).to eq("parallels")
+          expect(plugin[:platform_version]).to eq("6.0.5")
+          expect(plugin[:platform_family]).to eq("rhel")
+        end
+      end
+
+      describe "without lsb_results" do
+
+        before(:each) do
+          plugin.lsb = nil
+        end
+
+        it "should read the platform as parallels and version as 6.0.5" do
+          allow(File).to receive(:read).with("/etc/redhat-release").and_return("CloudLinux Server release 6.5 (Pavel Popovich)")
+          expect(File).to receive(:read).with("/etc/parallels-release").and_return("Parallels Cloud Server 6.0.5 (20007)")
+          plugin.run
+          expect(plugin[:platform]).to eq("parallels")
+          expect(plugin[:platform_version]).to eq("6.0.5")
+          expect(plugin[:platform_family]).to eq("rhel")
+        end
+      end
+    end
+
+    describe "on oracle enterprise linux" do
+
+      let(:have_redhat_release) { true }
+
+      context "with lsb_results" do
+
+        context "on version 5.x" do
+
+          let(:have_enterprise_release) { true }
+
+          it "should read the platform as oracle and version as 5.7" do
+            plugin[:lsb][:id] = "EnterpriseEnterpriseServer"
+            plugin[:lsb][:release] = "5.7"
+            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 5.7 (Tikanga)")
+            expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.7 (Carthage)")
+            plugin.run
+            expect(plugin[:platform]).to eq("oracle")
+            expect(plugin[:platform_version]).to eq("5.7")
+          end
+        end
+
+        context "on version 6.x" do
+
+          let(:have_oracle_release) { true }
+
+          it "should read the platform as oracle and version as 6.1" do
+            plugin[:lsb][:id] = "OracleServer"
+            plugin[:lsb][:release] = "6.1"
+            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.1 (Santiago)")
+            expect(File).to receive(:read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.1")
+            plugin.run
+            expect(plugin[:platform]).to eq("oracle")
+            expect(plugin[:platform_version]).to eq("6.1")
+          end
+
+        end
+      end
+
+      context "without lsb_results" do
+        before(:each) do
+          plugin.lsb = nil
+        end
+
+        context "on version 5.x" do
+
+          let(:have_enterprise_release) { true }
+
+          it "should read the platform as oracle and version as 5" do
+            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Enterprise Linux Enterprise Linux Server release 5 (Carthage)")
+            expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5 (Carthage)")
+            plugin.run
+            expect(plugin[:platform]).to eq("oracle")
+            expect(plugin[:platform_version]).to eq("5")
+          end
+
+          it "should read the platform as oracle and version as 5.1" do
+            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Enterprise Linux Enterprise Linux Server release 5.1 (Carthage)")
+            expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.1 (Carthage)")
+            plugin.run
+            expect(plugin[:platform]).to eq("oracle")
+            expect(plugin[:platform_version]).to eq("5.1")
+          end
+
+          it "should read the platform as oracle and version as 5.7" do
+            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 5.7 (Tikanga)")
+            expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.7 (Carthage)")
+            plugin.run
+            expect(plugin[:platform]).to eq("oracle")
+            expect(plugin[:platform_version]).to eq("5.7")
+          end
+
+        end
+
+        context "on version 6.x" do
+
+          let(:have_oracle_release) { true }
+
+          it "should read the platform as oracle and version as 6.0" do
+            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.0 (Santiago)")
+            expect(File).to receive(:read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.0")
+            plugin.run
+            expect(plugin[:platform]).to eq("oracle")
+            expect(plugin[:platform_version]).to eq("6.0")
+          end
+
+          it "should read the platform as oracle and version as 6.1" do
+            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.1 (Santiago)")
+            expect(File).to receive(:read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.1")
+            plugin.run
+            expect(plugin[:platform]).to eq("oracle")
+            expect(plugin[:platform_version]).to eq("6.1")
+          end
+        end
+      end
+    end
+
+    describe "on suse" do
+      context "on openSUSE 15+" do
+
+        let(:have_suse_release) { false }
+        let(:have_os_release) { true }
+
+        let(:os_release_content) do
+          <<~OS_RELEASE
+            NAME="openSUSE Leap"
+            VERSION="15.0"
+            ID="opensuse-leap"
+            ID_LIKE="suse opensuse"
+            VERSION_ID="15.0"
+            PRETTY_NAME="openSUSE Leap 15.0"
+            ANSI_COLOR="0;32"
+            CPE_NAME="cpe:/o:opensuse:leap:15.0"
+  OS_RELEASE
+        end
+
+        before do
+          expect(File).to_not receive(:read).with("/etc/SuSE-release")
+          expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
+        end
+
+        it "correctly detects opensuseleap 15" do
+          plugin.run
+          expect(plugin[:platform]).to eq("opensuseleap")
+          expect(plugin[:platform_version]).to eq("15.0")
+          expect(plugin[:platform_family]).to eq("suse")
+        end
+
+      end
+
+      context "on SLES 15+" do
+
+        let(:have_suse_release) { false }
+        let(:have_os_release) { true }
+
+        let(:os_release_content) do
+          <<~OS_RELEASE
+            NAME="SLES"
+            VERSION="15"
+            VERSION_ID="15"
+            PRETTY_NAME="SUSE Linux Enterprise Server 15"
+            ID="sles"
+            ID_LIKE="suse"
+            ANSI_COLOR="0;32"
+            CPE_NAME="cpe:/o:suse:sles:15"
+
+  OS_RELEASE
+        end
+
+        before do
+          expect(File).to_not receive(:read).with("/etc/SuSE-release")
+          expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
+        end
+
+        it "correctly detects SLES15" do
+          plugin.run
+          expect(plugin[:platform]).to eq("suse")
+          expect(plugin[:platform_version]).to eq("15")
+          expect(plugin[:platform_family]).to eq("suse")
+        end
+      end
+
+      context "on versions that have both /etc/os-release and /etc/SuSE-release (e.g. SLES12)" do
+        let(:have_suse_release) { true }
+        let(:have_os_release) { true }
+
+        describe "with lsb_release results" do
+          before(:each) do
+            plugin[:lsb][:id] = "SUSE LINUX"
+          end
+
+          it "should read the platform as opensuse on openSUSE" do
+            plugin[:lsb][:release] = "12.1"
+            expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 12.1 (x86_64)\nVERSION = 12.1\nCODENAME = Asparagus\n")
+            plugin.run
+            expect(plugin[:platform]).to eq("opensuse")
+            expect(plugin[:platform_family]).to eq("suse")
+          end
+        end
+      end
+
+      context "on versions that have no /etc/os-release but /etc/SuSE-release (e.g. SLES11)" do
+        let(:have_suse_release) { true }
+        let(:have_os_release) { false }
+
+        describe "with lsb_release results" do
+          before(:each) do
+            plugin[:lsb][:id] = "SUSE LINUX"
+          end
+
+          it "should read the platform as opensuse on openSUSE" do
+            plugin[:lsb][:release] = "12.1"
+            expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 12.1 (x86_64)\nVERSION = 12.1\nCODENAME = Asparagus\n")
+            plugin.run
+            expect(plugin[:platform]).to eq("opensuse")
+            expect(plugin[:platform_family]).to eq("suse")
+          end
+        end
+      end
+
+      context "on openSUSE and older SLES versions" do
+        let(:have_suse_release) { true }
+        let(:have_os_release) { true }
+
+        describe "without lsb_release results" do
+          before(:each) do
+            plugin.lsb = nil
+          end
+
+          it "should set platform and platform_family to suse and bogus verion to 10.0" do
+            expect(File).to receive(:read).with("/etc/SuSE-release").at_least(:once).and_return("VERSION = 10.0")
+            plugin.run
+            expect(plugin[:platform]).to eq("suse")
+            expect(plugin[:platform_family]).to eq("suse")
+          end
+
+          it "should read the version as 11.2" do
+            expect(File).to receive(:read).with("/etc/SuSE-release").and_return("SUSE Linux Enterprise Server 11.2 (i586)\nVERSION = 11\nPATCHLEVEL = 2\n")
+            plugin.run
+            expect(plugin[:platform]).to eq("suse")
+            expect(plugin[:platform_version]).to eq("11.2")
+            expect(plugin[:platform_family]).to eq("suse")
+          end
+
+          it "[OHAI-272] should read the version as 11.3" do
+            expect(File).to receive(:read).with("/etc/SuSE-release").exactly(1).times.and_return("openSUSE 11.3 (x86_64)\nVERSION = 11.3")
+            plugin.run
+            expect(plugin[:platform]).to eq("opensuse")
+            expect(plugin[:platform_version]).to eq("11.3")
+            expect(plugin[:platform_family]).to eq("suse")
+          end
+
+          it "[OHAI-272] should read the version as 11.4" do
+            expect(File).to receive(:read).with("/etc/SuSE-release").exactly(1).times.and_return("openSUSE 11.4 (i586)\nVERSION = 11.4\nCODENAME = Celadon")
+            plugin.run
+            expect(plugin[:platform]).to eq("opensuse")
+            expect(plugin[:platform_version]).to eq("11.4")
+            expect(plugin[:platform_family]).to eq("suse")
+          end
+
+          it "should read the platform as opensuse on openSUSE" do
+            expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 12.2 (x86_64)\nVERSION = 12.2\nCODENAME = Mantis\n")
+            plugin.run
+            expect(plugin[:platform]).to eq("opensuse")
+            expect(plugin[:platform_family]).to eq("suse")
+          end
+
+          it "should read the platform as opensuseleap on openSUSE Leap" do
+            expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 42.1 (x86_64)\nVERSION = 42.1\nCODENAME = Malachite\n")
+            plugin.run
+            expect(plugin[:platform]).to eq("opensuseleap")
+            expect(plugin[:platform_family]).to eq("suse")
+          end
+        end
+      end
+    end
+
+    describe "on Wind River Linux 5 for Cisco Nexus" do
+      let(:have_os_release) { true }
+      let(:os_release_info) do
+        {
+          "ID"                 => "nexus",
+          "ID_LIKE"            => "wrlinux",
+          "NAME"               => "Nexus",
+          "VERSION"            => "7.0(3)I2(0.475E.6)",
+          "VERSION_ID"         => "7.0(3)I2",
+          "PRETTY_NAME"        => "Nexus 7.0(3)I2",
+          "HOME_URL"           => "http://www.cisco.com",
+          "BUILD_ID"           => "6",
+          "CISCO_RELEASE_INFO" => "/etc/os-release",
+        }
+      end
+
+      it "should set platform to nexus and platform_family to wrlinux" do
+        allow(plugin).to receive(:os_release_info).and_return(os_release_info)
+        plugin.lsb = nil
+        plugin.run
+
+        expect(plugin[:platform]).to eq("nexus")
+        expect(plugin[:platform_family]).to eq("wrlinux")
+        expect(plugin[:platform_version]).to eq("7.0(3)I2(0.475E.6)")
+      end
+    end
+
+    describe "on Wind River Linux 7 for Cisco IOS-XR" do
+      let(:have_os_release) { true }
+      let(:os_release_info) do
+        {
+          "ID"          => "ios_xr",
+          "ID_LIKE"     => "cisco-wrlinux wrlinux",
+          "NAME"        => "IOS XR",
+          "VERSION"     => "6.0.0.14I",
+          "VERSION_ID"  => "6.0.0.14I",
+          "PRETTY_NAME" => "Cisco IOS XR Software, Version 6.0.0.14I",
+          "BUILD_ID"    => "2015-09-10-15-50-17",
+          "HOME_URL"    => "http://www.cisco.com",
+          "CISCO_RELEASE_INFO" => "/etc/os-release",
+        }
+      end
+
+      it "should set platform to ios_xr and platform_family to wrlinux" do
+        allow(plugin).to receive(:os_release_info).and_return(os_release_info)
+        plugin.lsb = nil
+        plugin.run
+
+        expect(plugin[:platform]).to eq("ios_xr")
+        expect(plugin[:platform_family]).to eq("wrlinux")
+        expect(plugin[:platform_version]).to eq("6.0.0.14I")
+      end
+    end
+
+    describe "on clearlinux" do
+      let(:have_usr_lib_os_release) { true }
+      let(:usr_lib_os_release_content) do
+        <<~CLEARLINUX_RELEASE
+          NAME="Clear Linux Software for Intel Architecture"
+          VERSION=1
+          ID=clear-linux-os
+          VERSION_ID=16140
+          PRETTY_NAME="Clear Linux OS for Intel Architecture"
+          ANSI_COLOR="1;35"
+          HOME_URL="https://clearlinux.org"
+          SUPPORT_URL="https://clearlinux.org"
+          BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"
+          PRIVACY_POLICY_URL="http://www.intel.com/privacy"
 CLEARLINUX_RELEASE
-    end
+      end
 
-    before do
-      expect(File).to receive(:read).with("/usr/lib/os-release").and_return(usr_lib_os_release_content)
-    end
+      before do
+        expect(File).to receive(:read).with("/usr/lib/os-release").and_return(usr_lib_os_release_content)
+      end
 
-    it "should set platform to clearlinux and platform_family to clearlinux" do
-      @plugin.lsb = nil
-      @plugin.run
+      it "should set platform to clearlinux and platform_family to clearlinux" do
+        plugin.lsb = nil
+        plugin.run
 
-      expect(@plugin[:platform]).to eq("clearlinux")
-      expect(@plugin[:platform_family]).to eq("clearlinux")
-      expect(@plugin[:platform_version]).to eq("16140")
+        expect(plugin[:platform]).to eq("clearlinux")
+        expect(plugin[:platform_family]).to eq("clearlinux")
+        expect(plugin[:platform_version]).to eq("16140")
+      end
     end
   end
 end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -922,36 +922,5 @@ OS_DATA
         expect(plugin[:platform_version]).to eq("6.0.0.14I")
       end
     end
-
-    describe "on clearlinux" do
-      let(:have_usr_lib_os_release) { true }
-      let(:usr_lib_os_release_content) do
-        <<~CLEARLINUX_RELEASE
-          NAME="Clear Linux Software for Intel Architecture"
-          VERSION=1
-          ID=clear-linux-os
-          VERSION_ID=16140
-          PRETTY_NAME="Clear Linux OS for Intel Architecture"
-          ANSI_COLOR="1;35"
-          HOME_URL="https://clearlinux.org"
-          SUPPORT_URL="https://clearlinux.org"
-          BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"
-          PRIVACY_POLICY_URL="http://www.intel.com/privacy"
-CLEARLINUX_RELEASE
-      end
-
-      before do
-        expect(File).to receive(:read).with("/usr/lib/os-release").and_return(usr_lib_os_release_content)
-      end
-
-      it "should set platform to clearlinux and platform_family to clearlinux" do
-        plugin.lsb = nil
-        plugin.run
-
-        expect(plugin[:platform]).to eq("clearlinux")
-        expect(plugin[:platform_family]).to eq("clearlinux")
-        expect(plugin[:platform_version]).to eq("16140")
-      end
-    end
   end
 end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -109,10 +109,6 @@ describe Ohai::System, "Linux plugin platform" do
       expect(plugin.platform_id_remap("cumulus-linux")).to eq("cumulus")
     end
 
-    it "returns clearlinux for clear-linux-os os-release id" do
-      expect(plugin.platform_id_remap("clear-linux-os")).to eq("clearlinux")
-    end
-
     it "does not transformation for any other platform" do
       expect(plugin.platform_id_remap("ubuntu")).to eq("ubuntu")
     end
@@ -688,38 +684,6 @@ OS_DATA
     end
 
     describe "on suse" do
-      context "on openSUSE 15+" do
-
-        let(:have_suse_release) { false }
-        let(:have_os_release) { true }
-
-        let(:os_release_content) do
-          <<~OS_RELEASE
-            NAME="openSUSE Leap"
-            VERSION="15.0"
-            ID="opensuse-leap"
-            ID_LIKE="suse opensuse"
-            VERSION_ID="15.0"
-            PRETTY_NAME="openSUSE Leap 15.0"
-            ANSI_COLOR="0;32"
-            CPE_NAME="cpe:/o:opensuse:leap:15.0"
-  OS_RELEASE
-        end
-
-        before do
-          expect(File).to_not receive(:read).with("/etc/SuSE-release")
-          expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
-        end
-
-        it "correctly detects opensuseleap 15" do
-          plugin.run
-          expect(plugin[:platform]).to eq("opensuseleap")
-          expect(plugin[:platform_version]).to eq("15.0")
-          expect(plugin[:platform_family]).to eq("suse")
-        end
-
-      end
-
       context "on versions that have no /etc/os-release but /etc/SuSE-release (e.g. SLES12.1)" do
         let(:have_suse_release) { true }
         let(:have_os_release) { false }
@@ -792,6 +756,30 @@ OS_DATA
             expect(plugin[:platform_family]).to eq("suse")
           end
         end
+      end
+    end
+
+    describe "on clearlinux" do
+      let(:have_usr_lib_os_release) { true }
+      let(:usr_lib_os_release_content) do
+        <<~CLEARLINUX_RELEASE
+          NAME="Clear Linux OS"
+          VERSION=1
+          ID=clear-linux-os
+          ID_LIKE=clear-linux-os
+          VERSION_ID=26290
+          PRETTY_NAME="Clear Linux OS"
+  CLEARLINUX_RELEASE
+      end
+      before do
+        expect(File).to receive(:read).with("/usr/lib/os-release").and_return(usr_lib_os_release_content)
+      end
+      it "should set platform to clearlinux and platform_family to clearlinux" do
+        plugin.lsb = nil
+        plugin.run
+        expect(plugin[:platform]).to eq("clearlinux")
+        expect(plugin[:platform_family]).to eq("clearlinux")
+        expect(plugin[:platform_version]).to eq("26290")
       end
     end
   end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -425,61 +425,6 @@ OS_DATA
       end
     end
 
-    describe "on 'guestshell' with /etc/os-release and overrides for Cisco Nexus" do
-
-      let(:have_os_release) { true }
-
-      let(:os_release_content) do
-        <<~OS_RELEASE
-          NAME="CentOS Linux"
-          VERSION="7 (Core)"
-          ID="centos"
-          ID_LIKE="rhel fedora"
-          VERSION_ID="7"
-          PRETTY_NAME="CentOS Linux 7 (Core)"
-          ANSI_COLOR="0;31"
-          CPE_NAME="cpe:/o:centos:centos:7"
-          HOME_URL="https://www.centos.org/"
-          BUG_REPORT_URL="https://bugs.centos.org/"
-
-          CENTOS_MANTISBT_PROJECT="CentOS-7"
-          CENTOS_MANTISBT_PROJECT_VERSION="7"
-          REDHAT_SUPPORT_PRODUCT="centos"
-          REDHAT_SUPPORT_PRODUCT_VERSION="7"
-
-          CISCO_RELEASE_INFO=/etc/shared/os-release
-  OS_RELEASE
-      end
-
-      let(:have_cisco_release) { true }
-
-      let(:cisco_release_content) do
-        <<~CISCO_RELEASE
-          ID=nexus
-          ID_LIKE=wrlinux
-          NAME=Nexus
-          VERSION="7.0(3)I2(0.475E.6)"
-          VERSION_ID="7.0(3)I2"
-          PRETTY_NAME="Nexus 7.0(3)I2"
-          HOME_URL=http://www.cisco.com
-          BUILD_ID=6
-          CISCO_RELEASE_INFO=/etc/shared/os-release
-  CISCO_RELEASE
-      end
-
-      before do
-        expect(File).to receive(:read).at_least(:once).with("/etc/os-release").and_return(os_release_content)
-        expect(File).to receive(:read).with("/etc/shared/os-release").and_return(cisco_release_content)
-      end
-
-      it "should set platform to nexus_guestshell and platform_family to rhel" do
-        plugin.run
-        expect(plugin[:platform]).to eq("nexus_centos")
-        expect(plugin[:platform_family]).to eq("rhel")
-        expect(plugin[:platform_version]).to eq("7.0(3)I2(0.475E.6)")
-      end
-    end
-
     describe "on slackware" do
 
       let(:have_slackware_version) { true }
@@ -775,58 +720,7 @@ OS_DATA
 
       end
 
-      context "on SLES 15+" do
-
-        let(:have_suse_release) { false }
-        let(:have_os_release) { true }
-
-        let(:os_release_content) do
-          <<~OS_RELEASE
-            NAME="SLES"
-            VERSION="15"
-            VERSION_ID="15"
-            PRETTY_NAME="SUSE Linux Enterprise Server 15"
-            ID="sles"
-            ID_LIKE="suse"
-            ANSI_COLOR="0;32"
-            CPE_NAME="cpe:/o:suse:sles:15"
-
-  OS_RELEASE
-        end
-
-        before do
-          expect(File).to_not receive(:read).with("/etc/SuSE-release")
-          expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
-        end
-
-        it "correctly detects SLES15" do
-          plugin.run
-          expect(plugin[:platform]).to eq("suse")
-          expect(plugin[:platform_version]).to eq("15")
-          expect(plugin[:platform_family]).to eq("suse")
-        end
-      end
-
-      context "on versions that have both /etc/os-release and /etc/SuSE-release (e.g. SLES12)" do
-        let(:have_suse_release) { true }
-        let(:have_os_release) { true }
-
-        describe "with lsb_release results" do
-          before(:each) do
-            plugin[:lsb][:id] = "SUSE LINUX"
-          end
-
-          it "should read the platform as opensuse on openSUSE" do
-            plugin[:lsb][:release] = "12.1"
-            expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 12.1 (x86_64)\nVERSION = 12.1\nCODENAME = Asparagus\n")
-            plugin.run
-            expect(plugin[:platform]).to eq("opensuse")
-            expect(plugin[:platform_family]).to eq("suse")
-          end
-        end
-      end
-
-      context "on versions that have no /etc/os-release but /etc/SuSE-release (e.g. SLES11)" do
+      context "on versions that have no /etc/os-release but /etc/SuSE-release (e.g. SLES12.1)" do
         let(:have_suse_release) { true }
         let(:have_os_release) { false }
 

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -109,6 +109,10 @@ describe Ohai::System, "Linux plugin platform" do
       expect(plugin.platform_id_remap("cumulus-linux")).to eq("cumulus")
     end
 
+    it "returns nexus_centos for nexus os-release id" do
+      expect(plugin.platform_id_remap("nexus")).to eq("nexus_centos")
+    end
+
     it "does not transformation for any other platform" do
       expect(plugin.platform_id_remap("ubuntu")).to eq("ubuntu")
     end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -247,6 +247,7 @@ OS_DATA
     let(:have_oracle_release) { false }
     let(:have_parallels_release) { false }
     let(:have_os_release) { false }
+    let(:have_os_release) { false }
     let(:have_usr_lib_os_release) { false }
     let(:have_cisco_release) { false }
     let(:have_f5_release) { false }
@@ -267,6 +268,7 @@ OS_DATA
       allow(File).to receive(:exist?).with("/etc/oracle-release").and_return(have_oracle_release)
       allow(File).to receive(:exist?).with("/etc/parallels-release").and_return(have_parallels_release)
       allow(File).to receive(:exist?).with("/usr/bin/raspi-config").and_return(have_raspi_config)
+      allow(File).to receive(:exist?).with("/etc/os-release").and_return(have_os_release)
       allow(File).to receive(:exist?).with("/etc/f5-release").and_return(have_f5_release)
       allow(File).to receive(:exist?).with("/usr/lib/os-release").and_return(have_usr_lib_os_release)
       allow(File).to receive(:exist?).with("/etc/shared/os-release").and_return(have_cisco_release)
@@ -417,41 +419,6 @@ OS_DATA
           expect(plugin[:platform]).to eq("nexus_centos")
           expect(plugin[:platform_family]).to eq("rhel")
           expect(plugin[:platform_version]).to eq("7.0(3)I2(0.475E.6)")
-        end
-      end
-
-      context "on cumulus" do
-
-        let(:have_cumulus_dir) { true }
-        let(:cumulus_release_content) do
-          <<~OS_RELEASE
-            NAME="Cumulus Linux"
-            VERSION_ID=3.1.2
-            VERSION="Cumulus Linux 3.1.2"
-            PRETTY_NAME="Cumulus Linux"
-            ID=cumulus-linux
-            ID_LIKE=debian
-            CPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:3.1.2
-            HOME_URL="http://www.cumulusnetworks.com/"
-            SUPPORT_URL="http://support.cumulusnetworks.com/"
-
-  OS_RELEASE
-        end
-
-        before(:each) do
-          expect(File).to receive(:read).with("/etc/cumulus/etc.replace/os-release").and_return(cumulus_release_content)
-        end
-
-        # Cumulus is a debian derivative
-        it "should detect Cumulus as itself with debian as the family" do
-          plugin.run
-          expect(plugin[:platform]).to eq("cumulus")
-          expect(plugin[:platform_family]).to eq("debian")
-        end
-
-        it "should detect Cumulus platform_version" do
-          plugin.run
-          expect(plugin[:platform_version]).to eq("3.1.2")
         end
       end
     end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -474,6 +474,14 @@ OS_RELEASE
         expect(@plugin[:platform_version].to_f).to eq(2)
       end
 
+      it "should read the platform as amazon and version as 2 when codename is in the release string" do
+        expect(File).to receive(:read).with("/etc/redhat-release").and_return("Amazon Linux release 2 (Karoo)")
+        @plugin.run
+        expect(@plugin[:platform]).to eq("amazon")
+        expect(@plugin[:platform_family]).to eq("amazon")
+        expect(@plugin[:platform_version].to_f).to eq(2)
+      end
+
       # https://github.com/chef/ohai/issues/560
       # Issue is seen on EL7, so that's what we're testing.
       context "on versions that have /etc/os-release" do
@@ -819,14 +827,6 @@ OS_RELEASE
           expect(@plugin[:platform_family]).to eq("suse")
         end
 
-        it "should read the version as 10.1 for bogus SLES 10" do
-          expect(File).to receive(:read).with("/etc/SuSE-release").and_return("SUSE Linux Enterprise Server 10 (i586)\nVERSION = 10\nPATCHLEVEL = 1\n")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("suse")
-          expect(@plugin[:platform_version]).to eq("10.1")
-          expect(@plugin[:platform_family]).to eq("suse")
-        end
-
         it "should read the version as 11.2" do
           expect(File).to receive(:read).with("/etc/SuSE-release").and_return("SUSE Linux Enterprise Server 11.2 (i586)\nVERSION = 11\nPATCHLEVEL = 2\n")
           @plugin.run
@@ -840,14 +840,6 @@ OS_RELEASE
           @plugin.run
           expect(@plugin[:platform]).to eq("opensuse")
           expect(@plugin[:platform_version]).to eq("11.3")
-          expect(@plugin[:platform_family]).to eq("suse")
-        end
-
-        it "[OHAI-272] should read the version as 9.1" do
-          expect(File).to receive(:read).with("/etc/SuSE-release").exactly(1).times.and_return("SuSE Linux 9.1 (i586)\nVERSION = 9.1")
-          @plugin.run
-          expect(@plugin[:platform]).to eq("suse")
-          expect(@plugin[:platform_version]).to eq("9.1")
           expect(@plugin[:platform_family]).to eq("suse")
         end
 

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -283,7 +283,7 @@ OS_DATA
     describe "on lsb compliant distributions" do
       before(:each) do
         plugin[:lsb][:id] = "Ubuntu"
-        plugin[:lsb][:release] = "8.04"
+        plugin[:lsb][:release] = "18.04"
       end
 
       it "should set platform to lowercased lsb[:id]" do
@@ -293,7 +293,7 @@ OS_DATA
 
       it "should set platform_version to lsb[:release]" do
         plugin.run
-        expect(plugin[:platform_version]).to eq("8.04")
+        expect(plugin[:platform_version]).to eq("18.04")
       end
 
       it "should set platform to ubuntu and platform_family to debian [:lsb][:id] contains Ubuntu" do
@@ -312,7 +312,7 @@ OS_DATA
 
       it "should set platform to redhat and platform_family to rhel when [:lsb][:id] contains Redhat" do
         plugin[:lsb][:id] = "RedHatEnterpriseServer"
-        plugin[:lsb][:release] = "5.7"
+        plugin[:lsb][:release] = "7.5"
         plugin.run
         expect(plugin[:platform]).to eq("redhat")
         expect(plugin[:platform_family]).to eq("rhel")
@@ -320,7 +320,7 @@ OS_DATA
 
       it "should set platform to amazon and platform_family to rhel when [:lsb][:id] contains Amazon" do
         plugin[:lsb][:id] = "AmazonAMI"
-        plugin[:lsb][:release] = "2011.09"
+        plugin[:lsb][:release] = "2018.03"
         plugin.run
         expect(plugin[:platform]).to eq("amazon")
         expect(plugin[:platform_family]).to eq("amazon")
@@ -328,7 +328,7 @@ OS_DATA
 
       it "should set platform to scientific when [:lsb][:id] contains ScientificSL" do
         plugin[:lsb][:id] = "ScientificSL"
-        plugin[:lsb][:release] = "5.7"
+        plugin[:lsb][:release] = "7.5"
         plugin.run
         expect(plugin[:platform]).to eq("scientific")
       end
@@ -351,26 +351,26 @@ OS_DATA
       end
 
       it "should read the version from /etc/debian_version" do
-        expect(File).to receive(:read).with("/etc/debian_version").and_return("5.0")
+        expect(File).to receive(:read).with("/etc/debian_version").and_return("9.5")
         plugin.run
-        expect(plugin[:platform_version]).to eq("5.0")
+        expect(plugin[:platform_version]).to eq("9.5")
       end
 
       it "should correctly strip any newlines" do
-        expect(File).to receive(:read).with("/etc/debian_version").and_return("5.0\n")
+        expect(File).to receive(:read).with("/etc/debian_version").and_return("9.5\n")
         plugin.run
-        expect(plugin[:platform_version]).to eq("5.0")
+        expect(plugin[:platform_version]).to eq("9.5")
       end
 
       # Ubuntu has /etc/debian_version as well
       it "should detect Ubuntu as itself rather than debian" do
         plugin[:lsb][:id] = "Ubuntu"
-        plugin[:lsb][:release] = "8.04"
+        plugin[:lsb][:release] = "18.04"
         plugin.run
         expect(plugin[:platform]).to eq("ubuntu")
       end
 
-      context "on 'guestshell' with /etc/os-release and overrides for Cisco Nexus" do
+      describe "on 'guestshell' with /etc/os-release and overrides for Cisco Nexus" do
 
         let(:have_os_release) { true }
 
@@ -408,7 +408,7 @@ OS_DATA
             PRETTY_NAME="Nexus 7.0(3)I2"
             HOME_URL=http://www.cisco.com
             BUILD_ID=6
-            CISCO_RELEASE_INFO=/etc/os-release
+            CISCO_RELEASE_INFO=/etc/shared/os-release
     CISCO_RELEASE
         end
 
@@ -529,19 +529,19 @@ OS_DATA
       describe "with lsb_release results" do
         it "should set the platform to redhat and platform_family to rhel even if the LSB name is something absurd but redhat like" do
           plugin[:lsb][:id] = "RedHatEnterpriseServer"
-          plugin[:lsb][:release] = "6.1"
+          plugin[:lsb][:release] = "7.5"
           plugin.run
           expect(plugin[:platform]).to eq("redhat")
-          expect(plugin[:platform_version]).to eq("6.1")
+          expect(plugin[:platform_version]).to eq("7.5")
           expect(plugin[:platform_family]).to eq("rhel")
         end
 
         it "should set the platform to centos and platform_family to rhel" do
           plugin[:lsb][:id] = "CentOS"
-          plugin[:lsb][:release] = "5.4"
+          plugin[:lsb][:release] = "7.5"
           plugin.run
           expect(plugin[:platform]).to eq("centos")
-          expect(plugin[:platform_version]).to eq("5.4")
+          expect(plugin[:platform_version]).to eq("7.5")
           expect(plugin[:platform_family]).to eq("rhel")
         end
       end
@@ -554,21 +554,21 @@ OS_DATA
           plugin.lsb = nil
         end
 
-        it "should read the platform as centos and version as 5.3" do
-          expect(File).to receive(:read).with("/etc/redhat-release").and_return("CentOS release 5.3")
+        it "should read the platform as centos and version as 7.5" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("CentOS Linux release 7.5.1804 (Core)")
           plugin.run
           expect(plugin[:platform]).to eq("centos")
+          expect(plugin[:platform_version]).to eq("7.5.1804")
         end
 
-        it "may be that someone munged Red Hat to be RedHat" do
-          expect(File).to receive(:read).with("/etc/redhat-release").and_return("RedHat release 5.3")
+        it "reads platform of Red Hat with a space" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.5 (Santiago)")
           plugin.run
           expect(plugin[:platform]).to eq("redhat")
-          expect(plugin[:platform_version]).to eq("5.3")
         end
 
-        it "should read the platform as redhat and version as 5.3" do
-          expect(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat release 5.3")
+        it "should read the platform as redhat without a space" do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("RedHat release 5.3")
           plugin.run
           expect(plugin[:platform]).to eq("redhat")
           expect(plugin[:platform_version]).to eq("5.3")

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -701,8 +701,39 @@ CISCO_RELEASE
   end
 
   describe "on suse" do
+    context "on openSUSE 15+" do
 
-    context "on versions that have /etc/os-release and no /etc/SuSE-release (e.g. SLES15)" do
+      let(:have_suse_release) { false }
+      let(:have_os_release) { true }
+
+      let(:os_release_content) do
+        <<~OS_RELEASE
+          NAME="openSUSE Leap"
+          VERSION="15.0"
+          ID="opensuse-leap"
+          ID_LIKE="suse opensuse"
+          VERSION_ID="15.0"
+          PRETTY_NAME="openSUSE Leap 15.0"
+          ANSI_COLOR="0;32"
+          CPE_NAME="cpe:/o:opensuse:leap:15.0"
+OS_RELEASE
+      end
+
+      before do
+        expect(File).to_not receive(:read).with("/etc/SuSE-release")
+        expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
+      end
+
+      it "correctly detects opensuseleap 15" do
+        @plugin.run
+        expect(@plugin[:platform]).to eq("opensuseleap")
+        expect(@plugin[:platform_version]).to eq("15.0")
+        expect(@plugin[:platform_family]).to eq("suse")
+      end
+
+    end
+
+    context "on SLES 15+" do
 
       let(:have_suse_release) { false }
       let(:have_os_release) { true }
@@ -732,7 +763,6 @@ OS_RELEASE
         expect(@plugin[:platform_version]).to eq("15")
         expect(@plugin[:platform_family]).to eq("suse")
       end
-
     end
 
     context "on versions that have both /etc/os-release and /etc/SuSE-release (e.g. SLES12)" do


### PR DESCRIPTION
/etc/os-release is the modern way of identifying Linux platforms and versions. It's far more reliable than the brittle regex mess that we have built up over the last decade. It also allows us to easily detect unknown / obscure distros since they have platform IDs in the os-release file.

Changes to call out:
- Platform detection will now default to /etc/os-release if that file is present
- The majority of the legacy logic is retained within a legacy method
- Unless we override the value we just use the platform value from os-release. Going forward for new platforms we'll just use this value. The overrides are just to retain legacy compatibility
- Unless it's missing we just use the version found in the os-release file. If it's not found we grab the kernel version with uname as we did before (gentoo/arch/etc)
- Some platforms where we know users stay more up to date have been switched over to the os-release logic entirely: arch, alpine, and cumulus, mint, raspbian, and clearlinux. This also speeds up the remaining legacy platforms.
- Testing has been simplified and expanded since we're mostly testing the platform remapping method, and the platform to platform_family methods. There's no need to run the plugin for each possible platform when the logic is entirely identical sans the value in the os-release file now.
- The new logic should be faster as we don't have to check for the existence of a large number of files. We just read out a single file and then lookup a few things in a hash table. 
- Adds manjaro to the arch platform_family and kali to the debian platform_family.

Things that change:
- Nexus switch versions are now properly identified with the shorter version string such as 7.0(3)I2(2b) instead of 7.0(3)I2(0.475E.6) which includes the build number.
