### PR TITLE
Require Ruby 2.5 or later

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.5
   Exclude:
     - "spec/data/**/*"
     - "vendor/**/*"
@@ -10,5 +11,6 @@ Layout/Tab:
     - "lib/ohai/plugins/mono.rb"
     - "lib/ohai/plugins/darwin/hardware.rb"
 
-Performance/UnneededSort:
-  Enabled: true
+# this can cause failures that we need to look at one by one
+Performance/RegexpMatch:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
   - bundle --version
   - rm -f .bundle/config
 rvm:
-  - 2.4.4
   - 2.5.1
+  - 2.6
   - ruby-head
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "24"  
+    - ruby_version: "25"
 
 clone_folder: c:\projects\ohai
 clone_depth: 1

--- a/lib/ohai/plugins/elixir.rb
+++ b/lib/ohai/plugins/elixir.rb
@@ -18,19 +18,19 @@ Ohai.plugin(:Elixir) do
   depends "languages"
 
   collect_data do
-    begin
-      so = shell_out("elixir -v")
-      # Sample output:
-      # Erlang/OTP 18 [erts-7.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
-      #
-      # Elixir 1.2.4
-      if so.exitstatus == 0 && so.stdout =~ /^Elixir (\S*)/
-        elixir = Mash.new
-        elixir[:version] = $1
-        languages[:elixir] = elixir
-      end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Elixir: Could not shell_out "elixir -v". Skipping plugin')
+
+    so = shell_out("elixir -v")
+    # Sample output:
+    # Erlang/OTP 18 [erts-7.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
+    #
+    # Elixir 1.2.4
+    if so.exitstatus == 0 && so.stdout =~ /^Elixir (\S*)/
+      elixir = Mash.new
+      elixir[:version] = $1
+      languages[:elixir] = elixir
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Elixir: Could not shell_out "elixir -v". Skipping plugin')
+
   end
 end

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -250,16 +250,16 @@ Ohai.plugin(:Filesystem) do
       # we have to non-block read dev files. Ew.
       f = File.open("/proc/mounts")
       loop do
-        begin
-          data = f.read_nonblock(4096)
-          mounts << data
-        # We should just catch EOFError, but the kernel had a period of
-        # bugginess with reading virtual files, so we're being extra
-        # cautious here, catching all exceptions, and then we'll read
-        # whatever data we might have
-        rescue Exception
-          break
-        end
+
+        data = f.read_nonblock(4096)
+        mounts << data
+      # We should just catch EOFError, but the kernel had a period of
+      # bugginess with reading virtual files, so we're being extra
+      # cautious here, catching all exceptions, and then we'll read
+      # whatever data we might have
+      rescue Exception
+        break
+
       end
       f.close
       mounts.each_line do |line|

--- a/lib/ohai/plugins/go.rb
+++ b/lib/ohai/plugins/go.rb
@@ -18,17 +18,17 @@ Ohai.plugin(:Go) do
   depends "languages"
 
   collect_data do
-    begin
-      so = shell_out("go version")
-      # Sample output:
-      # go version go1.6.1 darwin/amd64
-      if so.exitstatus == 0 && so.stdout =~ /go(\S+)/
-        go = Mash.new
-        go[:version] = $1
-        languages[:go] = go
-      end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Go: Could not shell_out "go version". Skipping plugin')
+
+    so = shell_out("go version")
+    # Sample output:
+    # go version go1.6.1 darwin/amd64
+    if so.exitstatus == 0 && so.stdout =~ /go(\S+)/
+      go = Mash.new
+      go[:version] = $1
+      languages[:go] = go
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Go: Could not shell_out "go version". Skipping plugin')
+
   end
 end

--- a/lib/ohai/plugins/groovy.rb
+++ b/lib/ohai/plugins/groovy.rb
@@ -21,18 +21,18 @@ Ohai.plugin(:Groovy) do
   depends "languages"
 
   collect_data do
-    begin
-      so = shell_out("groovy -v")
-      # Sample output:
-      # Groovy Version: 2.4.6 JVM: 1.8.0_60 Vendor: Oracle Corporation OS: Mac OS X
-      if so.exitstatus == 0 && so.stdout =~ /Groovy Version: (\S+).*JVM: (\S+)/
-        groovy = Mash.new
-        groovy[:version] = $1
-        groovy[:jvm] = $2
-        languages[:groovy] = groovy
-      end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Groovy: Could not shell_out "groovy -v". Skipping plugin')
+
+    so = shell_out("groovy -v")
+    # Sample output:
+    # Groovy Version: 2.4.6 JVM: 1.8.0_60 Vendor: Oracle Corporation OS: Mac OS X
+    if so.exitstatus == 0 && so.stdout =~ /Groovy Version: (\S+).*JVM: (\S+)/
+      groovy = Mash.new
+      groovy[:version] = $1
+      groovy[:jvm] = $2
+      languages[:groovy] = groovy
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Groovy: Could not shell_out "groovy -v". Skipping plugin')
+
   end
 end

--- a/lib/ohai/plugins/linux/fips.rb
+++ b/lib/ohai/plugins/linux/fips.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Matt Wrock (<matt@mattwrock.com>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,18 +28,11 @@ Ohai.plugin(:Fips) do
   collect_data(:linux) do
     fips Mash.new
 
-    # Check for new fips_mode method added in Ruby 2.5. After we drop support
-    # for Ruby 2.4, clean up everything after this and collapse the FIPS plugins.
     require "openssl"
     if defined?(OpenSSL.fips_mode) && OpenSSL.fips_mode && !$FIPS_TEST_MODE
       fips["kernel"] = { "enabled" => true }
     else
-      begin
-        enabled = File.read("/proc/sys/crypto/fips_enabled").chomp
-        fips["kernel"] = { "enabled" => enabled == "0" ? false : true }
-      rescue Errno::ENOENT
-        fips["kernel"] = { "enabled" => false }
-      end
+      fips["kernel"] = { "enabled" => false }
     end
   end
 end

--- a/lib/ohai/plugins/lua.rb
+++ b/lib/ohai/plugins/lua.rb
@@ -21,19 +21,19 @@ Ohai.plugin(:Lua) do
   depends "languages"
 
   collect_data do
-    begin
-      so = shell_out("lua -v")
-      # Sample output:
-      # Lua 5.2.4  Copyright (C) 1994-2015 Lua.org, PUC-Rio
-      if so.exitstatus == 0
-        lua = Mash.new
-        # at some point in lua's history they went from outputting the version
-        # on stderr to doing it on stdout. This handles old / new versions
-        lua[:version] = so.stdout.empty? ? so.stderr.split[1] : so.stdout.split[1]
-        languages[:lua] = lua if lua[:version]
-      end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Lua: Could not shell_out "lua -v". Skipping plugin')
+
+    so = shell_out("lua -v")
+    # Sample output:
+    # Lua 5.2.4  Copyright (C) 1994-2015 Lua.org, PUC-Rio
+    if so.exitstatus == 0
+      lua = Mash.new
+      # at some point in lua's history they went from outputting the version
+      # on stderr to doing it on stdout. This handles old / new versions
+      lua[:version] = so.stdout.empty? ? so.stderr.split[1] : so.stdout.split[1]
+      languages[:lua] = lua if lua[:version]
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Lua: Could not shell_out "lua -v". Skipping plugin')
+
   end
 end

--- a/lib/ohai/plugins/mono.rb
+++ b/lib/ohai/plugins/mono.rb
@@ -21,30 +21,30 @@ Ohai.plugin(:Mono) do
   depends "languages"
 
   collect_data do
-    begin
-      so = shell_out("mono -V")
-      # Sample output:
-      # Mono JIT compiler version 4.2.3 (Stable 4.2.3.4/832de4b Wed Mar 30 13:57:48 PDT 2016)
-      # Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
-      # 	TLS:           normal
-      # 	SIGSEGV:       altstack
-      # 	Notification:  kqueue
-      # 	Architecture:  amd64
-      # 	Disabled:      none
-      # 	Misc:          softtrace
-      # 	LLVM:          supported, not enabled.
-      # 	GC:            sgen
-      if so.exitstatus == 0
-        mono = Mash.new
-        output = so.stdout.split
-        mono[:version] = output[4] unless output[4].nil?
-        if output.length >= 12
-          mono[:builddate] = "%s %s %s %s %s %s" % [output[7], output[8], output[9], output[10], output[11], output[12].delete!(")")]
-        end
-        languages[:mono] = mono unless mono.empty?
+
+    so = shell_out("mono -V")
+    # Sample output:
+    # Mono JIT compiler version 4.2.3 (Stable 4.2.3.4/832de4b Wed Mar 30 13:57:48 PDT 2016)
+    # Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
+    # 	TLS:           normal
+    # 	SIGSEGV:       altstack
+    # 	Notification:  kqueue
+    # 	Architecture:  amd64
+    # 	Disabled:      none
+    # 	Misc:          softtrace
+    # 	LLVM:          supported, not enabled.
+    # 	GC:            sgen
+    if so.exitstatus == 0
+      mono = Mash.new
+      output = so.stdout.split
+      mono[:version] = output[4] unless output[4].nil?
+      if output.length >= 12
+        mono[:builddate] = "%s %s %s %s %s %s" % [output[7], output[8], output[9], output[10], output[11], output[12].delete!(")")]
       end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Mono: Could not shell_out "mono -V". Skipping plugin')
+      languages[:mono] = mono unless mono.empty?
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Mono: Could not shell_out "mono -V". Skipping plugin')
+
   end
 end

--- a/lib/ohai/plugins/nodejs.rb
+++ b/lib/ohai/plugins/nodejs.rb
@@ -21,20 +21,20 @@ Ohai.plugin(:Nodejs) do
   depends "languages"
 
   collect_data do
-    begin
-      so = shell_out("node -v")
-      # Sample output:
-      # v5.10.1
-      if so.exitstatus == 0
-        nodejs = Mash.new
-        output = so.stdout.split
-        if output.length >= 1
-          nodejs[:version] = output[0][1..output[0].length]
-        end
-        languages[:nodejs] = nodejs if nodejs[:version]
+
+    so = shell_out("node -v")
+    # Sample output:
+    # v5.10.1
+    if so.exitstatus == 0
+      nodejs = Mash.new
+      output = so.stdout.split
+      if output.length >= 1
+        nodejs[:version] = output[0][1..output[0].length]
       end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Nodejs: Could not shell_out "node -v". Skipping plugin')
+      languages[:nodejs] = nodejs if nodejs[:version]
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Nodejs: Could not shell_out "node -v". Skipping plugin')
+
   end
 end

--- a/lib/ohai/plugins/perl.rb
+++ b/lib/ohai/plugins/perl.rb
@@ -21,25 +21,25 @@ Ohai.plugin(:Perl) do
   depends "languages"
 
   collect_data do
-    begin
-      so = shell_out("perl -V:version -V:archname")
-      # Sample output:
-      # version='5.18.2';
-      # archname='darwin-thread-multi-2level';
-      if so.exitstatus == 0
-        perl = Mash.new
-        so.stdout.split(/\r?\n/).each do |line|
-          case line
-          when /^version=\'(.+)\';$/
-            perl[:version] = $1
-          when /^archname=\'(.+)\';$/
-            perl[:archname] = $1
-          end
+
+    so = shell_out("perl -V:version -V:archname")
+    # Sample output:
+    # version='5.18.2';
+    # archname='darwin-thread-multi-2level';
+    if so.exitstatus == 0
+      perl = Mash.new
+      so.stdout.split(/\r?\n/).each do |line|
+        case line
+        when /^version=\'(.+)\';$/
+          perl[:version] = $1
+        when /^archname=\'(.+)\';$/
+          perl[:archname] = $1
         end
-        languages[:perl] = perl unless perl.empty?
       end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Perl: Could not shell_out "perl -V:version -V:archname". Skipping plugin')
+      languages[:perl] = perl unless perl.empty?
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Perl: Could not shell_out "perl -V:version -V:archname". Skipping plugin')
+
   end
 end

--- a/lib/ohai/plugins/php.rb
+++ b/lib/ohai/plugins/php.rb
@@ -23,30 +23,30 @@ Ohai.plugin(:PHP) do
   depends "languages"
 
   collect_data do
-    begin
-      so = shell_out("php -v")
-      # Sample output:
-      # PHP 5.5.31 (cli) (built: Feb 20 2016 20:33:10)
-      # Copyright (c) 1997-2015 The PHP Group
-      # Zend Engine v2.5.0, Copyright (c) 1998-2015 Zend Technologies
-      if so.exitstatus == 0
-        php = Mash.new
-        so.stdout.each_line do |line|
-          case line
-          when /^PHP (\S+)(?:.*built: ([^)]+))?/
-            php[:version] = $1
-            php[:builddate] = $2
-          when /Zend Engine v([^\s]+),/
-            php[:zend_engine_version] = $1
-          when /Zend OPcache v([^\s]+),/
-            php[:zend_opcache_version] = $1
-          end
-        end
 
-        languages[:php] = php unless php.empty?
+    so = shell_out("php -v")
+    # Sample output:
+    # PHP 5.5.31 (cli) (built: Feb 20 2016 20:33:10)
+    # Copyright (c) 1997-2015 The PHP Group
+    # Zend Engine v2.5.0, Copyright (c) 1998-2015 Zend Technologies
+    if so.exitstatus == 0
+      php = Mash.new
+      so.stdout.each_line do |line|
+        case line
+        when /^PHP (\S+)(?:.*built: ([^)]+))?/
+          php[:version] = $1
+          php[:builddate] = $2
+        when /Zend Engine v([^\s]+),/
+          php[:zend_engine_version] = $1
+        when /Zend OPcache v([^\s]+),/
+          php[:zend_opcache_version] = $1
+        end
       end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Php: Could not shell_out "php -v". Skipping plugin')
+
+      languages[:php] = php unless php.empty?
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Php: Could not shell_out "php -v". Skipping plugin')
+
   end
 end

--- a/lib/ohai/plugins/powershell.rb
+++ b/lib/ohai/plugins/powershell.rb
@@ -20,39 +20,39 @@ Ohai.plugin(:Powershell) do
   depends "languages"
 
   collect_data(:windows) do
-    begin
-      so = shell_out("powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable")
-      # Sample output:
-      #
-      # Name                           Value
-      # ----                           -----
-      # PSVersion                      4.0
-      # WSManStackVersion              3.0
-      # SerializationVersion           1.1.0.1
-      # CLRVersion                     4.0.30319.34014
-      # BuildVersion                   6.3.9600.16394
-      # PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0}
-      # PSRemotingProtocolVersion      2.2
 
-      if so.exitstatus == 0
-        powershell = Mash.new
-        version_info = {}
-        so.stdout.strip.each_line do |line|
-          kv = line.strip.split(/\s+/, 2)
-          version_info[kv[0]] = kv[1] if kv.length == 2
-        end
-        powershell[:version] = version_info["PSVersion"]
-        powershell[:ws_man_stack_version] = version_info["WSManStackVersion"]
-        powershell[:serialization_version] = version_info["SerializationVersion"]
-        powershell[:clr_version] = version_info["CLRVersion"]
-        powershell[:build_version] = version_info["BuildVersion"]
-        powershell[:compatible_versions] = parse_compatible_versions
-        powershell[:remoting_protocol_version] = version_info["PSRemotingProtocolVersion"]
-        languages[:powershell] = powershell unless powershell.empty?
+    so = shell_out("powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable")
+    # Sample output:
+    #
+    # Name                           Value
+    # ----                           -----
+    # PSVersion                      4.0
+    # WSManStackVersion              3.0
+    # SerializationVersion           1.1.0.1
+    # CLRVersion                     4.0.30319.34014
+    # BuildVersion                   6.3.9600.16394
+    # PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0}
+    # PSRemotingProtocolVersion      2.2
+
+    if so.exitstatus == 0
+      powershell = Mash.new
+      version_info = {}
+      so.stdout.strip.each_line do |line|
+        kv = line.strip.split(/\s+/, 2)
+        version_info[kv[0]] = kv[1] if kv.length == 2
       end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Powershell: Could not shell_out "powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable". Skipping plugin')
+      powershell[:version] = version_info["PSVersion"]
+      powershell[:ws_man_stack_version] = version_info["WSManStackVersion"]
+      powershell[:serialization_version] = version_info["SerializationVersion"]
+      powershell[:clr_version] = version_info["CLRVersion"]
+      powershell[:build_version] = version_info["BuildVersion"]
+      powershell[:compatible_versions] = parse_compatible_versions
+      powershell[:remoting_protocol_version] = version_info["PSRemotingProtocolVersion"]
+      languages[:powershell] = powershell unless powershell.empty?
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Powershell: Could not shell_out "powershell.exe -NoLogo -NonInteractive -NoProfile -command $PSVersionTable". Skipping plugin')
+
   end
 
   def version_command

--- a/lib/ohai/plugins/python.rb
+++ b/lib/ohai/plugins/python.rb
@@ -22,22 +22,22 @@ Ohai.plugin(:Python) do
   depends "languages"
 
   collect_data do
-    begin
-      so = shell_out("python -c \"import sys; print (sys.version)\"")
-      # Sample output:
-      # 2.7.11 (default, Dec 26 2015, 17:47:53)
-      # [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
-      if so.exitstatus == 0
-        python = Mash.new
-        output = so.stdout.split
-        python[:version] = output[0]
-        if output.length >= 6
-          python[:builddate] = "%s %s %s %s" % [output[2], output[3], output[4], output[5].delete!(")")]
-        end
-        languages[:python] = python unless python.empty?
+
+    so = shell_out("python -c \"import sys; print (sys.version)\"")
+    # Sample output:
+    # 2.7.11 (default, Dec 26 2015, 17:47:53)
+    # [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
+    if so.exitstatus == 0
+      python = Mash.new
+      output = so.stdout.split
+      python[:version] = output[0]
+      if output.length >= 6
+        python[:builddate] = "%s %s %s %s" % [output[2], output[3], output[4], output[5].delete!(")")]
       end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Python: Could not shell_out "python -c "import sys; print (sys.version)"". Skipping plugin')
+      languages[:python] = python unless python.empty?
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Python: Could not shell_out "python -c "import sys; print (sys.version)"". Skipping plugin')
+
   end
 end

--- a/lib/ohai/plugins/rust.rb
+++ b/lib/ohai/plugins/rust.rb
@@ -18,17 +18,17 @@ Ohai.plugin(:Rust) do
   depends "languages"
 
   collect_data do
-    begin
-      so = shell_out("rustc --version")
-      # Sample output:
-      # rustc 1.7.0
-      if so.exitstatus == 0
-        rust = Mash.new
-        rust[:version] = so.stdout.split[1]
-        languages[:rust] = rust if rust[:version]
-      end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Rust: Could not shell_out "rustc --version". Skipping plugin')
+
+    so = shell_out("rustc --version")
+    # Sample output:
+    # rustc 1.7.0
+    if so.exitstatus == 0
+      rust = Mash.new
+      rust[:version] = so.stdout.split[1]
+      languages[:rust] = rust if rust[:version]
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Rust: Could not shell_out "rustc --version". Skipping plugin')
+
   end
 end

--- a/lib/ohai/plugins/virtualbox.rb
+++ b/lib/ohai/plugins/virtualbox.rb
@@ -20,30 +20,30 @@ Ohai.plugin(:Virtualbox) do
   provides "virtualbox"
 
   collect_data do
-    begin
-      so = shell_out("VBoxControl guestproperty enumerate")
 
-      if so.exitstatus == 0
-        virtualbox Mash.new
-        virtualbox[:host] = Mash.new
-        virtualbox[:guest] = Mash.new
-        so.stdout.lines.each do |line|
-          case line
-          when /LanguageID, value: (\S*),/
-            virtualbox[:host][:language] = Regexp.last_match(1)
-          when /VBoxVer, value: (\S*),/
-            virtualbox[:host][:version] = Regexp.last_match(1)
-          when /VBoxRev, value: (\S*),/
-            virtualbox[:host][:revision] = Regexp.last_match(1)
-          when /GuestAdd\/VersionExt, value: (\S*),/
-            virtualbox[:guest][:guest_additions_version] = Regexp.last_match(1)
-          when /GuestAdd\/Revision, value: (\S*),/
-            virtualbox[:guest][:guest_additions_revision] = Regexp.last_match(1)
-          end
+    so = shell_out("VBoxControl guestproperty enumerate")
+
+    if so.exitstatus == 0
+      virtualbox Mash.new
+      virtualbox[:host] = Mash.new
+      virtualbox[:guest] = Mash.new
+      so.stdout.lines.each do |line|
+        case line
+        when /LanguageID, value: (\S*),/
+          virtualbox[:host][:language] = Regexp.last_match(1)
+        when /VBoxVer, value: (\S*),/
+          virtualbox[:host][:version] = Regexp.last_match(1)
+        when /VBoxRev, value: (\S*),/
+          virtualbox[:host][:revision] = Regexp.last_match(1)
+        when /GuestAdd\/VersionExt, value: (\S*),/
+          virtualbox[:guest][:guest_additions_version] = Regexp.last_match(1)
+        when /GuestAdd\/Revision, value: (\S*),/
+          virtualbox[:guest][:guest_additions_revision] = Regexp.last_match(1)
         end
       end
-    rescue Ohai::Exceptions::Exec
-      logger.trace('Plugin Virtualbox: Could not execute "VBoxControl guestproperty enumerate". Skipping data')
     end
+  rescue Ohai::Exceptions::Exec
+    logger.trace('Plugin Virtualbox: Could not execute "VBoxControl guestproperty enumerate". Skipping data')
+
   end
 end

--- a/lib/ohai/plugins/windows/fips.rb
+++ b/lib/ohai/plugins/windows/fips.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Matt Wrock (<matt@mattwrock.com>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,30 +28,11 @@ Ohai.plugin(:Fips) do
   collect_data(:windows) do
     fips Mash.new
 
-    # Check for new fips_mode method added in Ruby 2.5. After we drop support
-    # for Ruby 2.4, clean up everything after this and collapse the FIPS plugins.
     require "openssl"
     if defined?(OpenSSL.fips_mode) && OpenSSL.fips_mode && !$FIPS_TEST_MODE
       fips["kernel"] = { "enabled" => true }
     else
-      require "win32/registry"
-      # from http://msdn.microsoft.com/en-us/library/windows/desktop/aa384129(v=vs.85).aspx
-      if ::RbConfig::CONFIG["target_cpu"] == "i386"
-        reg_type = Win32::Registry::KEY_READ | 0x100
-      elsif ::RbConfig::CONFIG["target_cpu"] == "x86_64"
-        reg_type = Win32::Registry::KEY_READ | 0x200
-      else
-        reg_type = Win32::Registry::KEY_READ
-      end
-
-      begin
-        Win32::Registry::HKEY_LOCAL_MACHINE.open('System\CurrentControlSet\Control\Lsa\FIPSAlgorithmPolicy', reg_type) do |policy|
-          enabled = policy["Enabled"]
-          fips["kernel"] = { "enabled" => enabled == 0 ? false : true }
-        end
-      rescue Win32::Registry::Error
-        fips["kernel"] = { "enabled" => false }
-      end
+      fips["kernel"] = { "enabled" => false }
     end
   end
 end

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://docs.chef.io/ohai.html"
 
-  s.required_ruby_version = ">= 2.4"
+  s.required_ruby_version = ">= 2.5"
 
   s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "ffi-yajl", "~> 2.2"

--- a/spec/unit/plugins/abort_spec.rb
+++ b/spec/unit/plugins/abort_spec.rb
@@ -31,11 +31,11 @@ EOF
 
 describe "a plug-in that aborts execution" do
   before(:all) do
-    begin
-      Dir.mkdir("#{tmp}/plugins")
-    rescue Errno::EEXIST
+
+    Dir.mkdir("#{tmp}/plugins")
+  rescue Errno::EEXIST
       # ignore
-    end
+
   end
 
   before(:each) do
@@ -49,11 +49,11 @@ describe "a plug-in that aborts execution" do
   end
 
   after(:all) do
-    begin
-      Dir.delete("#{tmp}/plugins")
-    rescue
+
+    Dir.delete("#{tmp}/plugins")
+  rescue
       # ignore
-    end
+
   end
 
   before(:each) do

--- a/spec/unit/plugins/fail_spec.rb
+++ b/spec/unit/plugins/fail_spec.rb
@@ -23,11 +23,11 @@ tmp = ENV["TMPDIR"] || ENV["TMP"] || ENV["TEMP"] || "/tmp"
 
 shared_examples "a v7 loading failure" do
   before(:all) do
-    begin
-      Dir.mkdir("#{tmp}/plugins")
-    rescue Errno::EEXIST
+
+    Dir.mkdir("#{tmp}/plugins")
+  rescue Errno::EEXIST
       # ignore
-    end
+
   end
 
   before(:each) do
@@ -41,11 +41,11 @@ shared_examples "a v7 loading failure" do
   end
 
   after(:all) do
-    begin
-      Dir.delete("#{tmp}/plugins")
-    rescue
+
+    Dir.delete("#{tmp}/plugins")
+  rescue
       # ignore
-    end
+
   end
 
   before(:each) do
@@ -67,11 +67,11 @@ end
 
 shared_examples "a v7 loading success" do
   before(:all) do
-    begin
-      Dir.mkdir("#{tmp}/plugins")
-    rescue Errno::EEXIST
+
+    Dir.mkdir("#{tmp}/plugins")
+  rescue Errno::EEXIST
       # ignore
-    end
+
   end
 
   before(:each) do
@@ -85,11 +85,11 @@ shared_examples "a v7 loading success" do
   end
 
   after(:all) do
-    begin
-      Dir.delete("#{tmp}/plugins")
-    rescue
+
+    Dir.delete("#{tmp}/plugins")
+  rescue
       # ignore
-    end
+
   end
 
   before(:each) do
@@ -110,11 +110,11 @@ end
 
 shared_examples "a v7 run failure" do
   before(:all) do
-    begin
-      Dir.mkdir("#{tmp}/plugins")
-    rescue Errno::EEXIST
+
+    Dir.mkdir("#{tmp}/plugins")
+  rescue Errno::EEXIST
       # ignore
-    end
+
   end
 
   before(:each) do
@@ -128,11 +128,11 @@ shared_examples "a v7 run failure" do
   end
 
   after(:all) do
-    begin
-      Dir.delete("#{tmp}/plugins")
-    rescue
+
+    Dir.delete("#{tmp}/plugins")
+  rescue
       # ignore
-    end
+
   end
 
   before(:each) do

--- a/spec/unit/plugins/linux/cpu_spec.rb
+++ b/spec/unit/plugins/linux/cpu_spec.rb
@@ -92,12 +92,12 @@ describe Ohai::System, "General Linux cpu plugin" do
   end
 
   after(:each) do
-    begin
-      tempfile.close
-      tempfile.unlink
-    rescue
+
+    tempfile.close
+    tempfile.unlink
+  rescue
       # really do not care
-    end
+
   end
 
   context "with old kernel that doesn't include cores in /proc/cpuinfo" do

--- a/spec/unit/plugins/linux/fips_spec.rb
+++ b/spec/unit/plugins/linux/fips_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Matt Wrock (<matt@mattwrock.com>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,7 @@ require "openssl"
 describe Ohai::System, "plugin fips" do
   let(:enabled) { "0" }
   let(:plugin) { get_plugin("linux/fips") }
-  let(:fips_path) { "/proc/sys/crypto/fips_enabled" }
-  let(:openssl_test_mode) { true }
+  let(:openssl_test_mode) { false }
 
   subject do
     plugin.run
@@ -32,7 +31,6 @@ describe Ohai::System, "plugin fips" do
 
   before(:each) do
     allow(plugin).to receive(:collect_os).and_return(:linux)
-    allow(::File).to receive(:read).with(fips_path).and_return(enabled)
   end
 
   around do |ex|
@@ -44,47 +42,17 @@ describe Ohai::System, "plugin fips" do
 
   end
 
-  context "fips file is present and contains 1" do
-    let(:enabled) { "1" }
+  context "with OpenSSL.fips_mode == false" do
+    before { allow(OpenSSL).to receive(:fips_mode).and_return(false) }
+    it "does not set fips plugin" do
+      expect(subject).to be(false)
+    end
+  end
 
+  context "with OpenSSL.fips_mode == true" do
+    before { allow(OpenSSL).to receive(:fips_mode).and_return(true) }
     it "sets fips plugin" do
       expect(subject).to be(true)
-    end
-  end
-
-  context "fips file does not contain 1" do
-    let(:enabled) { "0" }
-
-    it "does not set fips plugin" do
-      expect(subject).to be(false)
-    end
-  end
-
-  context "fips file is not present" do
-    before do
-      allow(::File).to receive(:read).and_raise(Errno::ENOENT, "bibbleboop")
-    end
-
-    it "does not set fips plugin" do
-      expect(subject).to be(false)
-    end
-  end
-
-  context "with Ruby 2.5 or newer", if: defined?(OpenSSL.fips_mode) do
-    let(:openssl_test_mode) { false }
-
-    context "with OpenSSL.fips_mode == false" do
-      before { allow(OpenSSL).to receive(:fips_mode).and_return(false) }
-      it "does not set fips plugin" do
-        expect(subject).to be(false)
-      end
-    end
-
-    context "with OpenSSL.fips_mode == true" do
-      before { allow(OpenSSL).to receive(:fips_mode).and_return(true) }
-      it "sets fips plugin" do
-        expect(subject).to be(true)
-      end
     end
   end
 end

--- a/spec/unit/plugins/linux/fips_spec.rb
+++ b/spec/unit/plugins/linux/fips_spec.rb
@@ -36,12 +36,12 @@ describe Ohai::System, "plugin fips" do
   end
 
   around do |ex|
-    begin
-      $FIPS_TEST_MODE = openssl_test_mode
-      ex.run
-    ensure
-      $FIPS_TEST_MODE = false
-    end
+
+    $FIPS_TEST_MODE = openssl_test_mode
+    ex.run
+  ensure
+    $FIPS_TEST_MODE = false
+
   end
 
   context "fips file is present and contains 1" do

--- a/spec/unit/plugins/network_spec.rb
+++ b/spec/unit/plugins/network_spec.rb
@@ -31,17 +31,17 @@ def it_populates_ipaddress_attributes
   source = caller[0]
 
   it "populates ipaddress, macaddress and ip6address" do
-    begin
-      allow(@plugin.logger).to receive(:warn)
-      expect(@plugin.logger).not_to receive(:trace).with(/^Plugin network threw exception/)
-      @plugin.run
-      %w{ ipaddress macaddress ip6address }.each do |attribute|
-        expect(@plugin).to have_key(attribute)
-      end
-    rescue Exception
-      puts "RSpec context: #{source}"
-      raise
+
+    allow(@plugin.logger).to receive(:warn)
+    expect(@plugin.logger).not_to receive(:trace).with(/^Plugin network threw exception/)
+    @plugin.run
+    %w{ ipaddress macaddress ip6address }.each do |attribute|
+      expect(@plugin).to have_key(attribute)
     end
+  rescue Exception
+    puts "RSpec context: #{source}"
+    raise
+
   end
 end
 

--- a/spec/unit/plugins/windows/fips_spec.rb
+++ b/spec/unit/plugins/windows/fips_spec.rb
@@ -37,12 +37,12 @@ describe Ohai::System, "plugin fips", :windows_only do
   end
 
   around do |ex|
-    begin
-      $FIPS_TEST_MODE = openssl_test_mode
-      ex.run
-    ensure
-      $FIPS_TEST_MODE = false
-    end
+
+    $FIPS_TEST_MODE = openssl_test_mode
+    ex.run
+  ensure
+    $FIPS_TEST_MODE = false
+
   end
 
   shared_examples "fips_plugin" do

--- a/spec/unit/plugins/windows/fips_spec.rb
+++ b/spec/unit/plugins/windows/fips_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Matt Wrock (<matt@mattwrock.com>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,9 +22,7 @@ require "openssl"
 describe Ohai::System, "plugin fips", :windows_only do
   let(:enabled) { 0 }
   let(:plugin) { get_plugin("windows/fips") }
-  let(:fips_key) { 'System\CurrentControlSet\Control\Lsa\FIPSAlgorithmPolicy' }
-  let(:win_reg_entry) { { "Enabled" => enabled } }
-  let(:openssl_test_mode) { true }
+  let(:openssl_test_mode) { false }
 
   subject do
     plugin.run
@@ -33,7 +31,6 @@ describe Ohai::System, "plugin fips", :windows_only do
 
   before(:each) do
     allow(plugin).to receive(:collect_os).and_return(:windows)
-    allow(Win32::Registry::HKEY_LOCAL_MACHINE).to receive(:open).with(fips_key, arch).and_yield(win_reg_entry)
   end
 
   around do |ex|
@@ -45,73 +42,17 @@ describe Ohai::System, "plugin fips", :windows_only do
 
   end
 
-  shared_examples "fips_plugin" do
-    context "fips enabled key is set to 1" do
-      let(:enabled) { 1 }
-
-      it "sets fips plugin" do
-        expect(subject).to be(true)
-      end
-    end
-
-    context "fips enabled key is set to 0" do
-      let(:enabled) { 0 }
-
-      it "does not set fips plugin" do
-        expect(subject).to be(false)
-      end
-    end
-
-    context "fips key does not exist" do
-      before do
-        allow(Win32::Registry::HKEY_LOCAL_MACHINE).to receive(:open).and_raise(Win32::Registry::Error, 50)
-      end
-
-      it "does not set fips plugin" do
-        expect(subject).to be(false)
-      end
+  context "with OpenSSL.fips_mode == false" do
+    before { allow(OpenSSL).to receive(:fips_mode).and_return(false) }
+    it "does not set fips plugin" do
+      expect(subject).to be(false)
     end
   end
 
-  context "on 32 bit ruby" do
-    let(:arch) { Win32::Registry::KEY_READ | 0x100 }
-
-    before { stub_const("::RbConfig::CONFIG", { "target_cpu" => "i386" } ) }
-
-    it_behaves_like "fips_plugin"
-  end
-
-  context "on 64 bit ruby" do
-    let(:arch) { Win32::Registry::KEY_READ | 0x200 }
-
-    before { stub_const("::RbConfig::CONFIG", { "target_cpu" => "x86_64" } ) }
-
-    it_behaves_like "fips_plugin"
-  end
-
-  context "on unknown ruby" do
-    let(:arch) { Win32::Registry::KEY_READ }
-
-    before { stub_const("::RbConfig::CONFIG", { "target_cpu" => nil } ) }
-
-    it_behaves_like "fips_plugin"
-  end
-
-  context "with Ruby 2.5 or newer", if: defined?(OpenSSL.fips_mode) do
-    let(:openssl_test_mode) { false }
-
-    context "with OpenSSL.fips_mode == false" do
-      before { allow(OpenSSL).to receive(:fips_mode).and_return(false) }
-      it "does not set fips plugin" do
-        expect(subject).to be(false)
-      end
-    end
-
-    context "with OpenSSL.fips_mode == true" do
-      before { allow(OpenSSL).to receive(:fips_mode).and_return(true) }
-      it "sets fips plugin" do
-        expect(subject).to be(true)
-      end
+  context "with OpenSSL.fips_mode == true" do
+    before { allow(OpenSSL).to receive(:fips_mode).and_return(true) }
+    it "sets fips plugin" do
+      expect(subject).to be(true)
     end
   end
 end

--- a/spec/unit/plugins/windows/fips_spec.rb
+++ b/spec/unit/plugins/windows/fips_spec.rb
@@ -19,7 +19,7 @@
 require_relative "../../../spec_helper.rb"
 require "openssl"
 
-describe Ohai::System, "plugin fips", :windows_only do
+describe Ohai::System, "plugin fips" do
   let(:enabled) { 0 }
   let(:plugin) { get_plugin("windows/fips") }
   let(:openssl_test_mode) { false }


### PR DESCRIPTION
As we do every year Ohai 15 will drop support for the N-2 support of Ruby. In the ~5 weeks Ruby 2.6 comes out so by the time we release this new version of Ohai N-2 will be Ruby 2.4.

Also while we're at it get rid of the begins in rescue blocks. Ruby 2.5 doesn't require this and it's on the path to ruby throwing errors eventually. It's a Ruby < 2.4-ism.

Signed-off-by: Tim Smith <tsmith@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
