### PR TITLE
Plugin to load hyper_v hostname from guest

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -158,7 +158,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "hyperv"
       virtualization[:role] = "guest"
       virtualization[:systems][:hyperv] = "guest"
-      virtualization[:host] = hyperv_host
+      virtualization[:hypervisor_host] = hyperv_host
     end
 
     # Detect Linux-VServer

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -152,12 +152,12 @@ Ohai.plugin(:Virtualization) do
 
     # Detect Hyper-V gest and host hostname
     if File.exist?("/var/lib/hyperv/.kvp_pool_3")
-      logger.trace('Plugin Virtualization: /var/lib/hyperv/.kvp_pool_3 contains string indicating Hyper-V guest')
+      logger.trace("Plugin Virtualization: /var/lib/hyperv/.kvp_pool_3 contains string indicating Hyper-V guest")
       data = File.read("/var/lib/hyperv/.kvp_pool_3")
       hyperv_host = data[/\HostName(.*?)HostingSystemEditionId/, 1].scan(/[[:print:]]/).join.downcase
-      virtualization[:system] = 'hyperv'
-      virtualization[:role] = 'guest'
-      virtualization[:systems][:hyperv] = 'guest'
+      virtualization[:system] = "hyperv"
+      virtualization[:role] = "guest"
+      virtualization[:systems][:hyperv] = "guest"
       virtualization[:host] = hyperv_host
     end
 

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -150,6 +150,17 @@ Ohai.plugin(:Virtualization) do
       end
     end
 
+    # Detect Hyper-V gest and host hostname
+    if File.exist?("/var/lib/hyperv/.kvp_pool_3")
+      logger.trace('Plugin Virtualization: /var/lib/hyperv/.kvp_pool_3 contains string indicating Hyper-V guest')
+      data = File.read("/var/lib/hyperv/.kvp_pool_3")
+      hyperv_host = data[/\HostName(.*?)HostingSystemEditionId/, 1].scan(/[[:print:]]/).join.downcase
+      virtualization[:system] = 'hyperv'
+      virtualization[:role] = 'guest'
+      virtualization[:systems][:hyperv] = 'guest'
+      virtualization[:host] = hyperv_host
+    end
+
     # Detect Linux-VServer
     if File.exist?("/proc/self/status")
       proc_self_status = File.read("/proc/self/status")

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -150,7 +150,7 @@ Ohai.plugin(:Virtualization) do
       end
     end
 
-    # Detect Hyper-V gest and host hostname
+    # Detect Hyper-V guest and the hostname of the host
     if File.exist?("/var/lib/hyperv/.kvp_pool_3")
       logger.trace("Plugin Virtualization: /var/lib/hyperv/.kvp_pool_3 contains string indicating Hyper-V guest")
       data = File.read("/var/lib/hyperv/.kvp_pool_3")

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -393,7 +393,7 @@ VEERTU
       expect(plugin[:virtualization][:system]).to eq("hyperv")
       expect(plugin[:virtualization][:role]).to eq("guest")
       expect(plugin[:virtualization][:systems]["hyperv"]).to eq("guest")
-      expect(plugin[:virtualization]["host"]).to eq("hyper_v.example.com")
+      expect(plugin[:virtualization]["hypervisor_host"]).to eq("hyper_v.example.com")
     end
   end
 

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -30,6 +30,7 @@ describe Ohai::System, "Linux virtualization platform" do
     allow(File).to receive(:exist?).with("/proc/modules").and_return(false)
     allow(File).to receive(:exist?).with("/proc/cpuinfo").and_return(false)
     allow(File).to receive(:exist?).with("/usr/sbin/dmidecode").and_return(false)
+    allow(File).to receive(:exist?).with("/var/lib/hyperv/.kvp_pool_3").and_return(false)
     allow(File).to receive(:exist?).with("/proc/self/status").and_return(false)
     allow(File).to receive(:exist?).with("/proc/bc/0").and_return(false)
     allow(File).to receive(:exist?).with("/proc/vz").and_return(false)
@@ -381,6 +382,18 @@ VEERTU
       allow(plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, "", ""))
       plugin.run
       expect(plugin[:virtualization]).to eq({ "systems" => {} })
+    end
+  end
+
+  describe "when we are checking for Hyper-V guest and host hostname" do
+    it "sets Hyper-V guest if /var/lib/hyperv/.kvp_pool_3 contains hyper_v.example.com" do
+      expect(File).to receive(:exist?).with("/var/lib/hyperv/.kvp_pool_3").and_return(true)
+      allow(File).to receive(:read).with("/var/lib/hyperv/.kvp_pool_3").and_return("HostNamehyper_v.example.comHostingSystemEditionId")
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("hyperv")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+      expect(plugin[:virtualization][:systems]["hyperv"]).to eq("guest")
+      expect(plugin[:virtualization]["host"]).to eq("hyper_v.example.com")
     end
   end
 

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -385,7 +385,7 @@ VEERTU
     end
   end
 
-  describe "when we are checking for Hyper-V guest and host hostname" do
+  describe "when we are checking for Hyper-V guest and the hostname of the host" do
     it "sets Hyper-V guest if /var/lib/hyperv/.kvp_pool_3 contains hyper_v.example.com" do
       expect(File).to receive(:exist?).with("/var/lib/hyperv/.kvp_pool_3").and_return(true)
       allow(File).to receive(:read).with("/var/lib/hyperv/.kvp_pool_3").and_return("HostNamehyper_v.example.comHostingSystemEditionId")


### PR DESCRIPTION
### Description

Plugin to load hyper_v hostname from guest, to see on which node the guest is running.

### Issues Resolved

- Issue #1302

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
