### PR TITLE
Remove circa ~2005 virtualization hypervisor detection

### DIFF
--- a/lib/ohai/mixin/dmi_decode.rb
+++ b/lib/ohai/mixin/dmi_decode.rb
@@ -21,15 +21,7 @@ module ::Ohai::Mixin::DmiDecode
     dmi_data.each_line do |line|
       case line
       when /Manufacturer: Microsoft/
-        if dmi_data =~ /Product.*: Virtual Machine/
-          if dmi_data =~ /Version: (7.0|Hyper-V)/
-            return "hyperv"
-          elsif dmi_data =~ /Version: (VS2005R2|6.0)/
-            return "virtualpc"
-          elsif dmi_data =~ /Version: 5.0/
-            return "virtualserver"
-          end
-        end
+        return "hyperv" if dmi_data =~ /Version: (7.0|Hyper-V)/
       when /Manufacturer: VMware/
         return "vmware"
       when /Manufacturer: Xen/

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -192,23 +192,6 @@ describe Ohai::System, "Linux virtualization platform" do
       expect(File).to receive(:exist?).with("/usr/sbin/dmidecode").and_return(true)
     end
 
-    it "sets virtualpc guest if dmidecode detects Microsoft Virtual Machine" do
-      ms_vpc_dmidecode = <<~MSVPC
-        System Information
-          Manufacturer: Microsoft Corporation
-          Product Name: Virtual Machine
-          Version: VS2005R2
-          Serial Number: 1688-7189-5337-7903-2297-1012-52
-          UUID: D29974A4-BE51-044C-BDC6-EFBC4B87A8E9
-          Wake-up Type: Power Switch
-MSVPC
-      allow(plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, ms_vpc_dmidecode, ""))
-      plugin.run
-      expect(plugin[:virtualization][:system]).to eq("virtualpc")
-      expect(plugin[:virtualization][:role]).to eq("guest")
-      expect(plugin[:virtualization][:systems][:virtualpc]).to eq("guest")
-    end
-
     it "sets hyperv guest if dmidecode detects Hyper-V or version 7.0" do
       ms_hv_dmidecode = <<~MSHV
         System Information
@@ -224,23 +207,6 @@ MSHV
       expect(plugin[:virtualization][:system]).to eq("hyperv")
       expect(plugin[:virtualization][:role]).to eq("guest")
       expect(plugin[:virtualization][:systems][:hyperv]).to eq("guest")
-    end
-
-    it "sets virtualserver guest if dmidecode detects version 5.0" do
-      ms_vs_dmidecode = <<~MSVS
-        System Information
-          Manufacturer: Microsoft Corporation
-          Product Name: Virtual Machine
-          Version: 5.0
-          Serial Number: 1688-7189-5337-7903-2297-1012-52
-          UUID: D29974A4-BE51-044C-BDC6-EFBC4B87A8E9
-          Wake-up Type: Power Switch
-MSVS
-      allow(plugin).to receive(:shell_out).with("dmidecode").and_return(mock_shell_out(0, ms_vs_dmidecode, ""))
-      plugin.run
-      expect(plugin[:virtualization][:system]).to eq("virtualserver")
-      expect(plugin[:virtualization][:role]).to eq("guest")
-      expect(plugin[:virtualization][:systems][:virtualserver]).to eq("guest")
     end
 
     it "sets vmware guest if dmidecode detects VMware" do

--- a/spec/unit/plugins/solaris2/virtualization_spec.rb
+++ b/spec/unit/plugins/solaris2/virtualization_spec.rb
@@ -72,25 +72,6 @@ PSRINFO_PV
       @plugin.run
     end
 
-    it "should set virtualpc guest if smbios detects Microsoft Virtual Machine" do
-      ms_vpc_smbios = <<~MSVPC
-        ID    SIZE TYPE
-        1     72   SMB_TYPE_SYSTEM (system information)
-
-          Manufacturer: Microsoft Corporation
-          Product: Virtual Machine
-          Version: VS2005R2
-          Serial Number: 1688-7189-5337-7903-2297-1012-52
-
-          UUID: D29974A4-BE51-044C-BDC6-EFBC4B87A8E9
-          Wake-Up Event: 0x6 (power switch)
-MSVPC
-      allow(@plugin).to receive(:shell_out).with("/usr/sbin/smbios").and_return(mock_shell_out(0, ms_vpc_smbios, ""))
-      @plugin.run
-      expect(@plugin[:virtualization][:system]).to eq("virtualpc")
-      expect(@plugin[:virtualization][:role]).to eq("guest")
-    end
-
     it "should set vmware guest if smbios detects VMware Virtual Platform" do
       vmware_smbios = <<~VMWARE
         ID    SIZE TYPE


### PR DESCRIPTION
This removes support for the following legacy virtualization hypervisors that were based on the VirtualPC tech that Microsoft bought from Connectix and then rebranded. It never worked on Windows 2008 / 7 or later. It's just dead tech that no one is using at this point.

See for release details:

https://en.wikipedia.org/wiki/Microsoft_Virtual_Server

Signed-off-by: Tim Smith <tsmith@chef.io>