### PR TITLE
Correctly detect openSUSE leap 15+

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -291,7 +291,14 @@ Ohai.plugin(:Platform) do
     # We have to do this for compatibility reasons, or older OS releases might get different
     # "platform" or "platform_version" attributes (e.g. SLES12, RHEL7).
     elsif File.exist?("/etc/os-release")
-      platform os_release_info["ID"] == "sles" ? "suse" : os_release_info["ID"] # SLES is wrong. We call it SUSE
+      case os_release_info["ID"]
+      when "sles"
+        platform "suse" # SLES is wrong. We call it SUSE
+      when "opensuse-leap"
+        platform "opensuseleap"
+      else
+        platform os_release_info["ID"]
+      end
       platform_version os_release_info["VERSION_ID"]
       # platform_family also does not need to be hardcoded anymore.
       # This would be the correct way, but we stick with "determine_platform_family" for compatibility reasons.

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -701,8 +701,39 @@ CISCO_RELEASE
   end
 
   describe "on suse" do
+    context "on openSUSE 15+" do
 
-    context "on versions that have /etc/os-release and no /etc/SuSE-release (e.g. SLES15)" do
+      let(:have_suse_release) { false }
+      let(:have_os_release) { true }
+
+      let(:os_release_content) do
+        <<~OS_RELEASE
+          NAME="openSUSE Leap"
+          VERSION="15.0"
+          ID="opensuse-leap"
+          ID_LIKE="suse opensuse"
+          VERSION_ID="15.0"
+          PRETTY_NAME="openSUSE Leap 15.0"
+          ANSI_COLOR="0;32"
+          CPE_NAME="cpe:/o:opensuse:leap:15.0"
+OS_RELEASE
+      end
+
+      before do
+        expect(File).to_not receive(:read).with("/etc/SuSE-release")
+        expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
+      end
+
+      it "correctly detects opensuseleap 15" do
+        @plugin.run
+        expect(@plugin[:platform]).to eq("opensuseleap")
+        expect(@plugin[:platform_version]).to eq("15.0")
+        expect(@plugin[:platform_family]).to eq("suse")
+      end
+
+    end
+
+    context "on SLES 15+" do
 
       let(:have_suse_release) { false }
       let(:have_os_release) { true }
@@ -732,7 +763,6 @@ OS_RELEASE
         expect(@plugin[:platform_version]).to eq("15")
         expect(@plugin[:platform_family]).to eq("suse")
       end
-
     end
 
     context "on versions that have both /etc/os-release and /etc/SuSE-release (e.g. SLES12)" do


### PR DESCRIPTION
We need to correctly read in the data in /etc/os-release and do the right thing. We already did this for SLES 15.

Signed-off-by: Tim Smith <tsmith@chef.io>