### PR TITLE
Fix arista platform detection

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -209,6 +209,9 @@ Ohai.plugin(:Platform) do
       contents = File.read("/etc/parallels-release").chomp
       platform get_redhatish_platform(contents)
       platform_version contents.match(/(\d\.\d\.\d)/)[0]
+    elsif File.exist?("/etc/Eos-release")
+      platform "arista_eos"
+      platform_version File.read("/etc/Eos-release").strip.split[-1]
     elsif File.exist?("/etc/redhat-release")
       contents = File.read("/etc/redhat-release").chomp
       platform get_redhatish_platform(contents)
@@ -232,9 +235,6 @@ Ohai.plugin(:Platform) do
       else
         platform "suse"
       end
-    elsif File.exist?("/etc/Eos-release")
-      platform "arista_eos"
-      platform_version File.read("/etc/Eos-release").strip.split[-1]
     elsif os_release_file_is_cisco?
       raise "unknown Cisco /etc/os-release or /etc/cisco-release ID_LIKE field" if
         os_release_info["ID_LIKE"].nil? || !os_release_info["ID_LIKE"].include?("wrlinux")

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -445,6 +445,8 @@ OS_DATA
 
     describe "on arista eos" do
 
+      let(:have_system_release) { true }
+      let(:have_redhat_release) { true }
       let(:have_eos_release) { true }
 
       before(:each) do
@@ -452,11 +454,11 @@ OS_DATA
       end
 
       it "should set platform to arista_eos" do
-        expect(File).to receive(:read).with("/etc/Eos-release").and_return("Arista Networks EOS 4.16.7M")
+        expect(File).to receive(:read).with("/etc/Eos-release").and_return("Arista Networks EOS 4.21.1.1F")
         plugin.run
         expect(plugin[:platform]).to eq("arista_eos")
         expect(plugin[:platform_family]).to eq("fedora")
-        expect(plugin[:platform_version]).to eq("4.16.7M")
+        expect(plugin[:platform_version]).to eq("4.21.1.1F")
       end
     end
 


### PR DESCRIPTION
Modern arista systems include not only /etc/Eos-release, but also /etc/redhat-release and /etc/system-release. Due to the order we did detection with this meant we read /etc/redhat-release first and identified arista as being fedora. Correct the order and wire things up in a way that will fail if we try to refactor the code back in the future.

Signed-off-by: Tim Smith <tsmith@chef.io>