### PR TITLE
Add mangeia platform with madriva platform_family

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -173,6 +173,8 @@ Ohai.plugin(:Platform) do
       "alpine"
     when /clearlinux/
       "clearlinux"
+    when /mangeia/
+      "mandriva"
     end
   end
 

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -187,6 +187,10 @@ describe Ohai::System, "Linux plugin platform" do
         expect(plugin.platform_family_from_platform(same_name)).to eq(same_name)
       end
     end
+
+    it "returns mandriva for mangeia platform" do
+      expect(plugin.platform_family_from_platform("mangeia")).to eq("mandriva")
+    end
   end
 
   describe "on system with /etc/os-release" do


### PR DESCRIPTION
mangeia is a popular OS in France. It's a fork of Mandriva which went out of business. There's a few other forks of mandriva so that should probably be the platform_family. It even identifies that as being similar in the os-release file.

Signed-off-by: Tim Smith <tsmith@chef.io>