### PR TITLE
Unify virtualization detection on a single helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ branches:
 
 bundler_args: --jobs 7 --without docs debug
 
-before_install:
-  - gem --version
-  - rvm @global do gem uninstall bundler -a -x -I || true
-  - gem install bundler
-  - bundle --version
-  - rm -f .bundle/config
 rvm:
-  - 2.5.1
+  - 2.5.3
+    before_install:
+      - gem --version
+      - rvm @global do gem uninstall bundler -a -x -I || true
+      - gem install bundler --no-document
+      - bundle --version
+      - rm -f .bundle/config
   - 2.6
   - ruby-head
 

--- a/lib/ohai/mixin/dmi_decode.rb
+++ b/lib/ohai/mixin/dmi_decode.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tim Smith <tsmith@chef.io>
-# Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,29 +17,34 @@
 
 # http://www.dmo.ca/blog/detecting-virtualization-on-linux
 module ::Ohai::Mixin::DmiDecode
-  def guest_from_dmi(dmi_data)
-    dmi_data.each_line do |line|
-      case line
-      when /Manufacturer: Microsoft/
-        return "hyperv" if dmi_data =~ /Version: (7.0|Hyper-V)/
-      when /Manufacturer: VMware/
-        return "vmware"
-      when /Manufacturer: Xen/
-        return "xen"
-      when /Product.*: VirtualBox/
-        return "vbox"
-      when /Product.*: OpenStack/
-        return "openstack"
-      when /Manufacturer: QEMU|Product Name: (KVM|RHEV)/
-        return "kvm"
-      when /Product.*: BHYVE/
-        return "bhyve"
-      when /Manufacturer: Veertu/
-        return "veertu"
-      when /Manufacturer: Amazon EC2/
-        return "amazonec2"
-      end
+  def guest_from_dmi_data(manufacturer, product, version)
+    case manufacturer
+    when /Xen/
+      return "xen"
+    when /VMware/
+      return "vmware"
+    when /Microsoft/
+      return "hyperv" if product =~ /Virtual Machine/
+    when /Amazon EC2/
+      return "amazonec2"
+    when /QEMU/
+      return "kvm"
+    when /Veertu/
+      return "veertu"
+    when /Parallels/
+      return "parallels"
     end
-    nil
+
+    case product
+    when /VirtualBox/
+      return "vbox"
+    when /OpenStack/
+      return "openstack"
+    when /(KVM|RHEV)/
+      return "kvm"
+    when /BHYVE/
+      return "bhyve"
+    end
+    nil # doesn't look like a virt
   end
 end

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -19,6 +19,8 @@
 #
 
 Ohai.plugin(:Virtualization) do
+  require "ohai/mixin/dmi_decode"
+  include Ohai::Mixin::DmiDecode
   provides "virtualization"
   depends "dmi"
 
@@ -29,9 +31,6 @@ Ohai.plugin(:Virtualization) do
   end
 
   collect_data(:solaris2) do
-    require "ohai/mixin/dmi_decode"
-    include Ohai::Mixin::DmiDecode
-
     virtualization Mash.new
     virtualization[:systems] = Mash.new
 

--- a/spec/unit/mixin/dmi_decode.rb
+++ b/spec/unit/mixin/dmi_decode.rb
@@ -1,0 +1,68 @@
+#
+# Author:: Tim Smith (tsmith@chef.io)
+# Copyright:: Copyright (c) 2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../spec_helper.rb"
+require "ohai/mixin/dmi_decode"
+
+describe Ohai::Mixin::DmiDecode, "guest_from_dmi_data" do
+  let(:mixin) { Object.new.extend(Ohai::Mixin::DmiDecode) }
+
+  # for the full DMI data used in these tests see https://github.com/chef/dmidecode_collection
+  {
+    xen: ["Xen", "HVM domU", "4.2.amazon"],
+    vmware: ["VMware, Inc.", "VMware Virtual Platform", "None"],
+    hyperv: ["Microsoft", "Virtual Machine", "7.0"],
+    amazonec2: ["Amazon EC2", "c5n.large", "Not Specified"],
+    veertu: ["Veertu", "Veertu", "Not Specified"],
+    parallels: ["Parallels Software International Inc.", "Parallels Virtual Platform", "None"],
+    vbox: ["Oracle Corporation", "VirtualBox", "1.2"],
+    openstack: ["Red Hat Inc.", "OpenStack Nova", "2014.1.2-1.el6"],
+    kvm: ["Red Hat", "KVM", "RHEL 7.0.0 PC (i440FX + PIIX, 1996"],
+    bhyve: ["", "BHYVE", "1.0"],
+  }.each_pair do |hypervisor, values|
+    describe "when passed #{hypervisor} dmi data" do
+      it "returns '#{hypervisor}'" do
+        expect(mixin.guest_from_dmi_data(values[0], values[1], values[2])).to eq("#{hypervisor}")
+      end
+    end
+  end
+
+  describe "When running on RHEV Hypervisor" do
+    it "returns 'kvm'" do
+      expect(mixin.guest_from_dmi_data("Red Hat", "RHEV Hypervisor", "6.7-20150911.0.el6ev")).to eq("kvm")
+    end
+  end
+
+  describe "When the manufactuer is 'QEMU'" do
+    it "return kvm" do
+      expect(mixin.guest_from_dmi_data("QEMU", "", "")).to eq("kvm")
+    end
+  end
+
+  describe "returns nil if manufactuer is 'Microsoft', but product is not 'Virtual Machine'" do
+    it "returns nil" do
+      expect(mixin.guest_from_dmi_data("Microsot", "Zune", "2018")).to be_nil
+    end
+  end
+
+  describe "When running on an unkown system" do
+    it "returns nil" do
+      expect(mixin.guest_from_dmi_data("TimCorp", "SuperServer", "2018")).to be_nil
+    end
+  end
+end

--- a/spec/unit/plugins/solaris2/dmi_spec.rb
+++ b/spec/unit/plugins/solaris2/dmi_spec.rb
@@ -112,17 +112,16 @@ SOLARIS_DMI_OUT = <<~EOS.freeze
 EOS
 
 describe Ohai::System, "Solaris2.X DMI plugin" do
-  let(:plugin) { get_plugin("solaris/dmi") }
-
   before(:each) do
-    allow(plugin).to receive(:collect_os).and_return("solaris2")
+    @plugin = get_plugin("solaris2/dmi")
+    allow(@plugin).to receive(:collect_os).and_return("solaris2")
     @stdout = SOLARIS_DMI_OUT
-    allow(plugin).to receive(:shell_out).with("smbios").and_return(mock_shell_out(0, @stdout, ""))
+    allow(@plugin).to receive(:shell_out).with("smbios").and_return(mock_shell_out(0, @stdout, ""))
   end
 
   it "should run smbios" do
-    expect(plugin).to receive(:shell_out).with("smbios").and_return(mock_shell_out(0, @stdout, ""))
-    plugin.run
+    expect(@plugin).to receive(:shell_out).with("smbios").and_return(mock_shell_out(0, @stdout, ""))
+    @plugin.run
   end
 
   {
@@ -141,14 +140,14 @@ describe Ohai::System, "Solaris2.X DMI plugin" do
   }.each do |id, data|
     data.each do |attribute, value|
       it "should have [:dmi][:#{id}][:#{attribute}] set" do
-        plugin.run
-        expect(plugin[:dmi][id][attribute]).to eql(value)
+        @plugin.run
+        expect(@plugin[:dmi][id][attribute]).to eql(value)
       end
     end
   end
 
   it "should ignore unwanted types" do
-    plugin.run
-    expect(plugin[:dmi]).not_to have_key(:on_board_devices)
+    @plugin.run
+    expect(@plugin[:dmi]).not_to have_key(:on_board_devices)
   end
 end

--- a/spec/unit/plugins/solaris2/dmi_spec.rb
+++ b/spec/unit/plugins/solaris2/dmi_spec.rb
@@ -112,16 +112,17 @@ SOLARIS_DMI_OUT = <<~EOS.freeze
 EOS
 
 describe Ohai::System, "Solaris2.X DMI plugin" do
+  let(:plugin) { get_plugin("solaris/dmi") }
+
   before(:each) do
-    @plugin = get_plugin("solaris2/dmi")
-    allow(@plugin).to receive(:collect_os).and_return("solaris2")
+    allow(plugin).to receive(:collect_os).and_return("solaris2")
     @stdout = SOLARIS_DMI_OUT
-    allow(@plugin).to receive(:shell_out).with("smbios").and_return(mock_shell_out(0, @stdout, ""))
+    allow(plugin).to receive(:shell_out).with("smbios").and_return(mock_shell_out(0, @stdout, ""))
   end
 
   it "should run smbios" do
-    expect(@plugin).to receive(:shell_out).with("smbios").and_return(mock_shell_out(0, @stdout, ""))
-    @plugin.run
+    expect(plugin).to receive(:shell_out).with("smbios").and_return(mock_shell_out(0, @stdout, ""))
+    plugin.run
   end
 
   {
@@ -140,14 +141,14 @@ describe Ohai::System, "Solaris2.X DMI plugin" do
   }.each do |id, data|
     data.each do |attribute, value|
       it "should have [:dmi][:#{id}][:#{attribute}] set" do
-        @plugin.run
-        expect(@plugin[:dmi][id][attribute]).to eql(value)
+        plugin.run
+        expect(plugin[:dmi][id][attribute]).to eql(value)
       end
     end
   end
 
   it "should ignore unwanted types" do
-    @plugin.run
-    expect(@plugin[:dmi]).not_to have_key(:on_board_devices)
+    plugin.run
+    expect(plugin[:dmi]).not_to have_key(:on_board_devices)
   end
 end

--- a/spec/unit/plugins/solaris2/virtualization_spec.rb
+++ b/spec/unit/plugins/solaris2/virtualization_spec.rb
@@ -19,6 +19,8 @@
 require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Solaris virtualization platform" do
+  let(:plugin) { get_plugin("solaris2/virtualization") }
+
   before(:each) do
     @psrinfo_pv = <<~PSRINFO_PV
       The physical processor has 1 virtual processor (0)
@@ -26,15 +28,14 @@ describe Ohai::System, "Solaris virtualization platform" do
               Intel Pentium(r) Pro
 PSRINFO_PV
 
-    @plugin = get_plugin("solaris2/virtualization")
-    allow(@plugin).to receive(:collect_os).and_return(:solaris2)
+    allow(plugin).to receive(:collect_os).and_return(:solaris2)
 
     # default to all requested Files not existing
     allow(File).to receive(:exist?).with("/usr/sbin/psrinfo").and_return(false)
     allow(File).to receive(:exist?).with("/usr/sbin/smbios").and_return(false)
     allow(File).to receive(:exist?).with("/usr/sbin/zoneadm").and_return(false)
-    allow(@plugin).to receive(:shell_out).with("/usr/sbin/smbios").and_return(mock_shell_out(0, "", ""))
-    allow(@plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, "", ""))
+    allow(plugin).to receive(:shell_out).with("/usr/sbin/smbios").and_return(mock_shell_out(0, "", ""))
+    allow(plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, "", ""))
   end
 
   describe "when we are checking for kvm" do
@@ -43,22 +44,22 @@ PSRINFO_PV
     end
 
     it "should run psrinfo -pv" do
-      expect(@plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv")
-      @plugin.run
+      expect(plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv")
+      plugin.run
     end
 
     it "Should set kvm guest if psrinfo -pv contains QEMU Virtual CPU" do
-      allow(@plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, "QEMU Virtual CPU", ""))
-      @plugin.run
-      expect(@plugin[:virtualization][:system]).to eq("kvm")
-      expect(@plugin[:virtualization][:role]).to eq("guest")
-      expect(@plugin[:virtualization][:systems][:kvm]).to eq("guest")
+      allow(plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, "QEMU Virtual CPU", ""))
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("kvm")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+      expect(plugin[:virtualization][:systems][:kvm]).to eq("guest")
     end
 
     it "should not set virtualization if kvm isn't there" do
-      expect(@plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, @psrinfo_pv, ""))
-      @plugin.run
-      expect(@plugin[:virtualization][:systems]).to eq({})
+      expect(plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, @psrinfo_pv, ""))
+      plugin.run
+      expect(plugin[:virtualization][:systems]).to eq({})
     end
   end
 
@@ -68,8 +69,8 @@ PSRINFO_PV
     end
 
     it "should run smbios" do
-      expect(@plugin).to receive(:shell_out).with("/usr/sbin/smbios")
-      @plugin.run
+      expect(plugin).to receive(:shell_out).with("/usr/sbin/smbios")
+      plugin.run
     end
 
     it "should set vmware guest if smbios detects VMware Virtual Platform" do
@@ -85,22 +86,49 @@ PSRINFO_PV
           UUID: a86cc405-e1b9-447b-ad05-6f8db39d876a
           Wake-Up Event: 0x6 (power switch)
 VMWARE
-      allow(@plugin).to receive(:shell_out).with("/usr/sbin/smbios").and_return(mock_shell_out(0, vmware_smbios, ""))
-      @plugin.run
-      expect(@plugin[:virtualization][:system]).to eq("vmware")
-      expect(@plugin[:virtualization][:role]).to eq("guest")
-      expect(@plugin[:virtualization][:systems][:vmware]).to eq("guest")
+      allow(plugin).to receive(:shell_out).with("/usr/sbin/smbios").and_return(mock_shell_out(0, vmware_smbios, ""))
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("vmware")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+      expect(plugin[:virtualization][:systems][:vmware]).to eq("guest")
     end
 
     it "should run smbios and not set virtualization if nothing is detected" do
-      expect(@plugin).to receive(:shell_out).with("/usr/sbin/smbios")
-      @plugin.run
-      expect(@plugin[:virtualization][:systems]).to eq({})
+      expect(plugin).to receive(:shell_out).with("/usr/sbin/smbios")
+      plugin.run
+      expect(plugin[:virtualization][:systems]).to eq({})
+    end
+  end
+
+  describe "when we are parsing DMI data" do
+
+    it "sets virtualization attributes if the appropriate DMI data is present" do
+      plugin[:dmi] = { system: {
+                                  manufacturer: "Amazon EC2",
+                                  product: "c5n.large",
+                                  version: nil,
+                               },
+                     }
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("amazonec2")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+      expect(plugin[:virtualization][:systems][:amazonec2]).to eq("guest")
+    end
+
+    it "sets empty virtualization attributes if nothing is detected" do
+      plugin[:dmi] = { system: {
+                                  manufacturer: "Supermicro",
+                                  product: "X10SLH-N6-ST031",
+                                  version: "0123456789",
+                               },
+                     }
+      plugin.run
+      expect(plugin[:virtualization]).to eq({ "systems" => {} })
     end
   end
 
   it "should not set virtualization if no tests match" do
-    @plugin.run
-    expect(@plugin[:virtualization][:systems]).to eq({})
+    plugin.run
+    expect(plugin[:virtualization][:systems]).to eq({})
   end
 end

--- a/spec/unit/plugins/solaris2/virtualization_spec.rb
+++ b/spec/unit/plugins/solaris2/virtualization_spec.rb
@@ -63,43 +63,6 @@ PSRINFO_PV
     end
   end
 
-  describe "when we are parsing smbios" do
-    before(:each) do
-      expect(File).to receive(:exist?).with("/usr/sbin/smbios").and_return(true)
-    end
-
-    it "should run smbios" do
-      expect(plugin).to receive(:shell_out).with("/usr/sbin/smbios")
-      plugin.run
-    end
-
-    it "should set vmware guest if smbios detects VMware Virtual Platform" do
-      vmware_smbios = <<~VMWARE
-        ID    SIZE TYPE
-        1     72   SMB_TYPE_SYSTEM (system information)
-
-          Manufacturer: VMware, Inc.
-          Product: VMware Virtual Platform
-          Version: None
-          Serial Number: VMware-50 3f f7 14 42 d1 f1 da-3b 46 27 d0 29 b4 74 1d
-
-          UUID: a86cc405-e1b9-447b-ad05-6f8db39d876a
-          Wake-Up Event: 0x6 (power switch)
-VMWARE
-      allow(plugin).to receive(:shell_out).with("/usr/sbin/smbios").and_return(mock_shell_out(0, vmware_smbios, ""))
-      plugin.run
-      expect(plugin[:virtualization][:system]).to eq("vmware")
-      expect(plugin[:virtualization][:role]).to eq("guest")
-      expect(plugin[:virtualization][:systems][:vmware]).to eq("guest")
-    end
-
-    it "should run smbios and not set virtualization if nothing is detected" do
-      expect(plugin).to receive(:shell_out).with("/usr/sbin/smbios")
-      plugin.run
-      expect(plugin[:virtualization][:systems]).to eq({})
-    end
-  end
-
   describe "when we are parsing DMI data" do
 
     it "sets virtualization attributes if the appropriate DMI data is present" do

--- a/spec/unit/plugins/windows/cpu_spec.rb
+++ b/spec/unit/plugins/windows/cpu_spec.rb
@@ -65,7 +65,6 @@ describe Ohai::System, "Windows cpu plugin" do
     @plugin = get_plugin("cpu")
     allow(@plugin).to receive(:collect_os).and_return(:windows)
 
-    @double_wmi = double(WmiLite::Wmi)
     @double_wmi_instance = instance_double(WmiLite::Wmi)
 
     @processors = [{ "description" => "Intel64 Family 6 Model 70 Stepping 1",

--- a/spec/unit/plugins/windows/virtualization_spec.rb
+++ b/spec/unit/plugins/windows/virtualization_spec.rb
@@ -22,21 +22,23 @@ require_relative "../../../spec_helper.rb"
 
 describe Ohai::System, "Windows virtualization platform" do
   let(:plugin) { get_plugin("windows/virtualization") }
+  let(:wmi) { double("WmiLite::Wmi") }
 
   before(:each) do
+    allow(WmiLite::Wmi).to receive(:new).and_return(wmi)
     allow(plugin).to receive(:collect_os).and_return(:windows)
   end
 
   describe "it sets virtualization guest status from Win32_ComputerSystemProduct data" do
     it "system is vmware" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_ComputerSystemProduct").and_return( { "caption" => "Computer System Product",
-                                                                                                                      "description" => "Computer System Product",
-                                                                                                                      "identifyingnumber" => "ec2d6aad-f59b-a10d-5784-ca9b7ba4f727",
-                                                                                                                      "name" => "HVM domU",
-                                                                                                                      "skunumber" => nil,
-                                                                                                                      "uuid" => "EC2D6AAD-F59B-A10D-5784-CA9B7BA4F727",
-                                                                                                                      "vendor" => "Xen",
-                                                                                                                      "version" => "4.2.amazon" } )
+      allow(wmi).to receive(:first_of).with("Win32_ComputerSystemProduct").and_return( { "caption" => "Computer System Product",
+                                                                                         "description" => "Computer System Product",
+                                                                                         "identifyingnumber" => "ec2d6aad-f59b-a10d-5784-ca9b7ba4f727",
+                                                                                         "name" => "HVM domU",
+                                                                                         "skunumber" => nil,
+                                                                                         "uuid" => "EC2D6AAD-F59B-A10D-5784-CA9B7BA4F727",
+                                                                                         "vendor" => "Xen",
+                                                                                         "version" => "4.2.amazon" } )
       plugin.run
       expect(plugin[:virtualization][:system]).to eq("xen")
       expect(plugin[:virtualization][:role]).to eq("guest")
@@ -46,14 +48,14 @@ describe Ohai::System, "Windows virtualization platform" do
 
   context "when running on a hardware system" do
     it "does not set virtualization attributes" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_ComputerSystemProduct").and_return({ "caption" => "Computer System Product",
-                                                                                                                     "description" => "Computer System Product",
-                                                                                                                     "identifyingnumber" => "0123456789",
-                                                                                                                     "name" => "X10SLH-N6-ST031",
-                                                                                                                     "skunumber" => nil,
-                                                                                                                     "uuid" => "00000000-0000-0000-0000-0CC47A8F7618",
-                                                                                                                     "vendor" => "Supermicro",
-                                                                                                                     "version" => "0123456789" })
+      allow(wmi).to receive(:first_of).with("Win32_ComputerSystemProduct").and_return({ "caption" => "Computer System Product",
+                                                                                        "description" => "Computer System Product",
+                                                                                        "identifyingnumber" => "0123456789",
+                                                                                        "name" => "X10SLH-N6-ST031",
+                                                                                        "skunumber" => nil,
+                                                                                        "uuid" => "00000000-0000-0000-0000-0CC47A8F7618",
+                                                                                        "vendor" => "Supermicro",
+                                                                                        "version" => "0123456789" })
       plugin.run
       expect(plugin[:virtualization]).to eq("systems" => {})
     end

--- a/spec/unit/plugins/windows/virtualization_spec.rb
+++ b/spec/unit/plugins/windows/virtualization_spec.rb
@@ -27,196 +27,16 @@ describe Ohai::System, "Windows virtualization platform" do
     allow(plugin).to receive(:collect_os).and_return(:windows)
   end
 
-  context "when running on vmware" do
+  describe "it sets virtualization guest status from Win32_ComputerSystemProduct data" do
     it "system is vmware" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "bioscharacteristics" => [4, 7, 8, 9, 10, 11, 12, 14, 15, 16, 19, 26, 27, 28, 29, 30, 32, 39, 40, 41, 42, 50, 57, 58],
-                                                                                                     "biosversion" => ["INTEL  - 6040000", "PhoenixBIOS 4.0 Release 6.0     "],
-                                                                                                     "buildnumber" => nil,
-                                                                                                     "caption" => "PhoenixBIOS 4.0 Release 6.0     ",
-                                                                                                     "codeset" => nil, "currentlanguage" => nil,
-                                                                                                     "description" => "PhoenixBIOS 4.0 Release 6.0     ",
-                                                                                                     "identificationcode" => nil,
-                                                                                                     "installablelanguages" => nil,
-                                                                                                     "installdate" => nil,
-                                                                                                     "languageedition" => nil,
-                                                                                                     "listoflanguages" => nil,
-                                                                                                     "manufacturer" => "Phoenix Technologies LTD",
-                                                                                                     "name" => "PhoenixBIOS 4.0 Release 6.0     ",
-                                                                                                     "othertargetos" => nil,
-                                                                                                     "primarybios" => true,
-                                                                                                     "releasedate" => "20130731000000.000000+000",
-                                                                                                     "serialnumber" => "VMware-56 4d 65 24 ac cf ec 72-fa 29 b2 7d 8f df b2 7a",
-                                                                                                     "smbiosbiosversion" => "6.00",
-                                                                                                     "smbiosmajorversion" => 2,
-                                                                                                     "smbiosminorversion" => 4,
-                                                                                                     "smbiospresent" => true,
-                                                                                                     "softwareelementid" => "PhoenixBIOS 4.0 Release 6.0     ",
-                                                                                                     "softwareelementstate" => 3,
-                                                                                                     "status" => "OK",
-                                                                                                     "targetoperatingsystem" => 0,
-                                                                                                     "version" => "INTEL  - 6040000"
-         }])
-      plugin.run
-      expect(plugin[:virtualization][:system]).to eq("vmware")
-      expect(plugin[:virtualization][:role]).to eq("guest")
-      expect(plugin[:virtualization][:systems][:vmware]).to eq("guest")
-    end
-  end
-
-  context "when running on parallels desktop" do
-    it "system is parallels" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "bioscharacteristics" => [4, 7, 9, 10, 15, 24, 25, 27, 28, 29, 30, 32, 42, 44, 48, 49, 51, 64, 65, 67],
-                                                                                                     "biosversion" => ["PRLS   - 1"],
-                                                                                                     "buildnumber" => nil,
-                                                                                                     "caption" => "Default System BIOS",
-                                                                                                     "codeset" => nil,
-                                                                                                     "currentlanguage" => nil,
-                                                                                                     "description" => "Default System BIOS",
-                                                                                                     "identificationcode" => nil,
-                                                                                                     "installablelanguages" => nil,
-                                                                                                     "installdate" => nil,
-                                                                                                     "languageedition" => nil,
-                                                                                                     "listoflanguages" => nil,
-                                                                                                     "manufacturer" => "Parallels Software International Inc.",
-                                                                                                     "name" => "Default System BIOS",
-                                                                                                     "othertargetos" => nil,
-                                                                                                     "primarybios" => true,
-                                                                                                     "releasedate" => "20151005000000.000000+000",
-                                                                                                     "serialnumber" =>      "Parallels-82 75 A0 A0 9B B4 47 7C 87 A9 D9 E1 2B 90 4B 1F",
-                                                                                                     "smbiosbiosversion" => "11.0.2 (31348)",
-                                                                                                     "smbiosmajorversion" => 2,
-                                                                                                     "smbiosminorversion" => 7,
-                                                                                                     "smbiospresent" => true,
-                                                                                                     "softwareelementid" => "Default System BIOS",
-                                                                                                     "softwareelementstate" => 3,
-                                                                                                     "status" => "OK",
-                                                                                                     "targetoperatingsystem" => 0,
-                                                                                                     "version" => "PRLS   - 1",
-         }])
-      plugin.run
-      expect(plugin[:virtualization][:system]).to eq("parallels")
-      expect(plugin[:virtualization][:role]).to eq("guest")
-      expect(plugin[:virtualization][:systems][:parallels]).to eq("guest")
-    end
-  end
-
-  context "when running on kvm" do
-    it "system is kvm" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "bioscharacteristics" => [3, 42, 48, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79],
-                                                                                                     "biosversion" => ["BOCHS  - 1"],
-                                                                                                     "buildnumber" => nil,
-                                                                                                     "caption" => "Default System BIOS",
-                                                                                                     "codeset" => nil,
-                                                                                                     "currentlanguage" => nil,
-                                                                                                     "description" => "Default System BIOS",
-                                                                                                     "identificationcode" => nil,
-                                                                                                     "installablelanguages" => nil,
-                                                                                                     "installdate" => nil,
-                                                                                                     "languageedition" => nil,
-                                                                                                     "listoflanguages" => nil,
-                                                                                                     "manufacturer" => "Bochs",
-                                                                                                     "name" => "Default System BIOS",
-                                                                                                     "othertargetos" => nil,
-                                                                                                     "primarybios" => true,
-                                                                                                     "releasedate" => "20110101******.******+***",
-                                                                                                     "serialnumber" => nil,
-                                                                                                     "smbiosbiosversion" => "Bochs",
-                                                                                                     "smbiosmajorversion" => 2,
-                                                                                                     "smbiosminorversion" => 4,
-                                                                                                     "smbiospresent" => true,
-                                                                                                     "softwareelementid" => "Default System BIOS",
-                                                                                                     "softwareelementstate" => 3,
-                                                                                                     "status" => "OK",
-                                                                                                     "targetoperatingsystem" => 0, "version" => "BOCHS  -1"
-          }])
-      plugin.run
-      expect(plugin[:virtualization][:system]).to eq("kvm")
-      expect(plugin[:virtualization][:role]).to eq("guest")
-      expect(plugin[:virtualization][:systems][:kvm]).to eq("guest")
-    end
-  end
-
-  context "when running on virtualbox" do
-    it "system is vbox" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "bioscharacteristics" => [4, 7, 15, 16, 27, 30, 32],
-                                                                                                     "biosversion" => ["VBOX   - 1"],
-                                                                                                     "buildnumber" => nil,
-                                                                                                     "caption" => "Default System BIOS",
-                                                                                                     "codeset" => nil,
-                                                                                                     "currentlanguage" => nil,
-                                                                                                     "description" => "Default System BIOS",
-                                                                                                     "identificationcode" => nil,
-                                                                                                     "installablelanguages" => nil,
-                                                                                                     "installdate" => nil,
-                                                                                                     "languageedition" => nil,
-                                                                                                     "listoflanguages" => nil,
-                                                                                                     "manufacturer" => "innotek GmbH",
-                                                                                                     "name" => "Default System BIOS",
-                                                                                                     "othertargetos" => nil,
-                                                                                                     "primarybios" => true,
-                                                                                                     "releasedate" => "20061201000000.000000+000",
-                                                                                                     "serialnumber" => "0",
-                                                                                                     "smbiosbiosversion" => "VirtualBox",
-                                                                                                     "smbiosmajorversion" => 2,
-                                                                                                     "smbiosminorversion" => 5,
-                                                                                                     "smbiospresent" => true,
-                                                                                                     "softwareelementid" => "Default System BIOS",
-                                                                                                     "softwareelementstate" => 3,
-                                                                                                     "status" => "OK",
-                                                                                                     "targetoperatingsystem" => 0,
-                                                                                                     "version" => "VBOX   - 1",
-        }])
-      plugin.run
-      expect(plugin[:virtualization][:system]).to eq("vbox")
-      expect(plugin[:virtualization][:role]).to eq("guest")
-      expect(plugin[:virtualization][:systems][:vbox]).to eq("guest")
-    end
-  end
-
-  context "when running on hyper-v" do
-    it "system is hyper-v" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "bioscharacteristics" => [4, 7, 9, 11, 12, 14, 15, 16, 17, 19, 22, 23, 24, 25, 26, 27, 28, 29, 30, 34, 36, 37, 40],
-                                                                                                     "biosversion" => ["VRTUAL - 4001628, BIOS Date: 04/28/16 13:00:17  Ver: 09.00.06, BIOS Date: 04/28/16 13:00:17 Ver: 09.00.06"],
-                                                                                                     "buildnumber" => nil,
-                                                                                                     "codeset" => nil,
-                                                                                                     "currentlanguage" => "enUS",
-                                                                                                     "description" => "BIOS Date: 04/28/16 13:00:17  Ver: 09.00.06",
-                                                                                                     "identificationcode" => nil,
-                                                                                                     "installablelanguages" => 1,
-                                                                                                     "installdate" => nil,
-                                                                                                     "languageedition" => nil,
-                                                                                                     "listoflanguages" => ["enUS"],
-                                                                                                     "manufacturer" => "American Megatrends Inc.",
-                                                                                                     "name" => "BIOS Date: 04/28/16 13:00:17  Ver: 09.00.06",
-                                                                                                     "othertargetos" => nil,
-                                                                                                     "primarybios" => true,
-                                                                                                     "releasedate" => "20160428000000.000000+000",
-                                                                                                     "serialnumber" => "1158-1757-7941-3855-2170-4122-00",
-                                                                                                     "smbiosbiosversion" => "090006",
-                                                                                                     "smbiosmajorversion" => 2,
-                                                                                                     "smbiosminorversion" => 3,
-                                                                                                     "smbiospresent" => true,
-                                                                                                     "softwareelementid" => "BIOS Date: 04/28/16 13:00:17  Ver: 09.00.06",
-                                                                                                     "softwareelementstate" => 3,
-                                                                                                     "status" => "OK",
-                                                                                                     "targetoperatingsystem" => 0,
-                                                                                                     "version" => "VRTUAL - 4001628",
-      }])
-      plugin.run
-      expect(plugin[:virtualization][:system]).to eq("hyper-v")
-      expect(plugin[:virtualization][:role]).to eq("guest")
-      expect(plugin[:virtualization][:systems][:hyperv]).to eq("guest")
-    end
-  end
-
-  context "when running on xen" do
-    it "system is xen" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "smbiosbiosversion" => ["4.2.amazon"],
-                                                                                                     "manufacturer" => "Xen",
-                                                                                                     "name" => "Revision: 1.221",
-                                                                                                     "serialnumber" => "ec2b487f-d9ed-7d17-c7c0-1d4599d6c1da",
-                                                                                                     "version" => "Xen - 0",
-      }])
+      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_ComputerSystemProduct").and_return( { "caption" => "Computer System Product",
+                                                                                                                      "description" => "Computer System Product",
+                                                                                                                      "identifyingnumber" => "ec2d6aad-f59b-a10d-5784-ca9b7ba4f727",
+                                                                                                                      "name" => "HVM domU",
+                                                                                                                      "skunumber" => nil,
+                                                                                                                      "uuid" => "EC2D6AAD-F59B-A10D-5784-CA9B7BA4F727",
+                                                                                                                      "vendor" => "Xen",
+                                                                                                                      "version" => "4.2.amazon" } )
       plugin.run
       expect(plugin[:virtualization][:system]).to eq("xen")
       expect(plugin[:virtualization][:role]).to eq("guest")
@@ -224,56 +44,16 @@ describe Ohai::System, "Windows virtualization platform" do
     end
   end
 
-  context "when running on veertu" do
-    it "system is veertu" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "smbiosbiosversion" => ["Veertu"],
-                                                                                                     "manufacturer" => "Veertu",
-                                                                                                     "name" => "Default System BIOS",
-                                                                                                     "serialnumber" => "",
-                                                                                                     "version" => "Veertu - 1",
-
-      }])
-      plugin.run
-      expect(plugin[:virtualization][:system]).to eq("veertu")
-      expect(plugin[:virtualization][:role]).to eq("guest")
-      expect(plugin[:virtualization][:systems][:veertu]).to eq("guest")
-    end
-  end
-
   context "when running on a hardware system" do
     it "does not set virtualization attributes" do
-      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_BIOS").and_return([{ "bioscharacteristics" => [7, 11, 12, 15, 16, 17, 19, 23, 24, 25, 26, 27, 28, 29, 32, 33, 40, 42, 43],
-                                                                                                     "biosversion" => ["DELL   - 1072009", "A10", "American Megatrends - 4028D"],
-                                                                                                     "buildnumber" => nil,
-                                                                                                     "caption" => "A10",
-                                                                                                     "codeset" => nil,
-                                                                                                     "currentlanguage" => nil,
-                                                                                                     "description" => "A10",
-                                                                                                     "embeddedcontrollermajorversion" => 255,
-                                                                                                     "embeddedcontrollerminorversion" => 255,
-                                                                                                     "identificationcode" => nil,
-                                                                                                     "installablelanguages" => nil,
-                                                                                                     "installdate" => nil,
-                                                                                                     "languageedition" => nil,
-                                                                                                     "listoflanguages" => nil,
-                                                                                                     "manufacturer" => "Dell Inc.",
-                                                                                                     "name" => "A10",
-                                                                                                     "othertargetos" => nil,
-                                                                                                     "primarybios" => true,
-                                                                                                     "releasedate" => "20130513000000.000000+000",
-                                                                                                     "serialnumber" => "87GBNY1",
-                                                                                                     "smbiosbiosversion" => "A10",
-                                                                                                     "smbiosmajorversion" => 2,
-                                                                                                     "smbiosminorversion" => 7,
-                                                                                                     "smbiospresent" => true,
-                                                                                                     "softwareelementid" => "A10",
-                                                                                                     "softwareelementstate" => 3,
-                                                                                                     "status" => "OK",
-                                                                                                     "systembiosmajorversion" => 4,
-                                                                                                     "systembiosminorversion" => 6,
-                                                                                                     "targetoperatingsystem" => 0,
-                                                                                                     "version" => "DELL   - 1072009",
-        }])
+      allow_any_instance_of(WmiLite::Wmi).to receive(:instances_of).with("Win32_ComputerSystemProduct").and_return({ "caption" => "Computer System Product",
+                                                                                                                     "description" => "Computer System Product",
+                                                                                                                     "identifyingnumber" => "0123456789",
+                                                                                                                     "name" => "X10SLH-N6-ST031",
+                                                                                                                     "skunumber" => nil,
+                                                                                                                     "uuid" => "00000000-0000-0000-0000-0CC47A8F7618",
+                                                                                                                     "vendor" => "Supermicro",
+                                                                                                                     "version" => "0123456789" })
       plugin.run
       expect(plugin[:virtualization]).to eq("systems" => {})
     end


### PR DESCRIPTION
We've always detected virtualization on *nix using dmidecode data. A few
years ago I unified this with the dmi_decode helper. It parsed out the
text of the dmidecode command. This greatly improved detection on BSD
and Solaris, but there was more that could be done. With this change
we're now passing in the manufacturer, product, and version data from
the dmi data. On the *nix side we'll use the dmi plugins data which has
already been split out nicely and doesn't need to be fetched or parsed
again. On the windows side we can actually get this data via WMI pretty
easily. The field names are different, but under the hood it's just DMI
data. This way if we accept a PR from a windows, solaris, bsd, or linux
user we get improves on all the other platforms.

Signed-off-by: Tim Smith <tsmith@chef.io>