### PR TITLE
Add support for antergos linux and fix opensuseleap platform_family

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -153,7 +153,7 @@ Ohai.plugin(:Platform) do
       "rhel"
     when /amazon/
       "amazon"
-    when /suse/, /sles/, /opensuse/
+    when /suse/, /sles/, /opensuse/, /opensuseleap/
       "suse"
     when /fedora/, /pidora/, /arista_eos/
       # In the broadest sense:  RPM-based, fedora-derived distributions which are not strictly re-compiled RHEL (if it uses RPMs, and smells more like redhat and less like
@@ -165,7 +165,7 @@ Ohai.plugin(:Platform) do
       "gentoo"
     when /slackware/
       "slackware"
-    when /arch/, /manjaro/
+    when /arch/, /manjaro/, /antergos/
       "arch"
     when /exherbo/
       "exherbo"

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -158,32 +158,32 @@ describe Ohai::System, "Linux plugin platform" do
       end
     end
 
-    %w{suse sles opensuse}.each do |p|
-      it "returns suse for #{p} platform" do
+    %w{suse sles opensuse opensuseleap}.each do |p|
+      it "returns suse for #{p} platform_family" do
         expect(plugin.platform_family_from_platform(p)).to eq("suse")
       end
     end
 
     %w{fedora pidora arista_eos}.each do |p|
-      it "returns fedora for #{p} platform" do
+      it "returns fedora for #{p} platform_family" do
         expect(plugin.platform_family_from_platform(p)).to eq("fedora")
       end
     end
 
     %w{nexus ios_xr}.each do |p|
-      it "returns wrlinux for #{p} platform" do
+      it "returns wrlinux for #{p} platform_family" do
         expect(plugin.platform_family_from_platform(p)).to eq("wrlinux")
       end
     end
 
-    %w{arch manjaro}.each do |p|
-      it "returns arch for #{p} platform" do
+    %w{arch manjaro antergos}.each do |p|
+      it "returns arch for #{p} platform_family" do
         expect(plugin.platform_family_from_platform(p)).to eq("arch")
       end
     end
 
     %w{amazon slackware gentoo exherbo alpine clearlinux}.each do |same_name|
-      it "returns #{same_name} for #{same_name} platform" do
+      it "returns #{same_name} for #{same_name} platform_family" do
         expect(plugin.platform_family_from_platform(same_name)).to eq(same_name)
       end
     end


### PR DESCRIPTION
Add antergos linux, which is based on Arch https://github.com/chef/os_release/blob/master/antergos

In the refactor opensuseleap platform_family logic was lost and there was a missing test. I've added back the logic and the test.=

Signed-off-by: Tim Smith <tsmith@chef.io>