### PR TITLE
Back out SLES -> SUSE remapping and instead fix the platform_family

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -154,7 +154,7 @@ Ohai.plugin(:Platform) do
       "rhel"
     when /amazon/
       "amazon"
-    when /suse/, /sles/, /opensuse/, /opensuseleap/
+    when /suse/, /sles/, /opensuse/, /opensuseleap/, /sled/
       "suse"
     when /fedora/, /pidora/, /arista_eos/
       # In the broadest sense:  RPM-based, fedora-derived distributions which are not strictly re-compiled RHEL (if it uses RPMs, and smells more like redhat and less like

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -28,7 +28,6 @@ Ohai.plugin(:Platform) do
       "rhel" => "redhat",
       "amzn" => "amazon",
       "ol" => "oracle",
-      "sled" => "suse",
       "sles" => "suse",
       "sles_sap" => "suse",
       "opensuse-leap" => "opensuseleap",

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -96,11 +96,6 @@ describe Ohai::System, "Linux plugin platform" do
       expect(plugin.platform_id_remap("ol")).to eq("oracle")
     end
 
-    # https://github.com/chef/os_release/blob/master/sled_15
-    it "returns suse for sled os-release id" do
-      expect(plugin.platform_id_remap("sled")).to eq("suse")
-    end
-
     # https://github.com/chef/os_release/blob/master/sles_sap_12_3
     it "returns suse for sles_sap os-release id" do
       expect(plugin.platform_id_remap("sles_sap")).to eq("suse")

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -170,7 +170,7 @@ describe Ohai::System, "Linux plugin platform" do
       end
     end
 
-    %w{suse sles opensuse opensuseleap}.each do |p|
+    %w{suse sles opensuse opensuseleap sled}.each do |p|
       it "returns suse for #{p} platform_family" do
         expect(plugin.platform_family_from_platform(p)).to eq("suse")
       end


### PR DESCRIPTION
After thinking about this remapping SLED to SUSE was wrong. People would want a way to identify SLED and distinguish it from the server variety. This backs out the previous change and instead adds SLED to the suse platform_family.