### PR TITLE
Make SLED be part of the suse platform_family

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -137,7 +137,7 @@ Ohai.plugin(:Platform) do
       "rhel"
     when /amazon/
       "amazon"
-    when /suse/, /sles/, /opensuse/
+    when /suse/, /sles/, /opensuse/, /opensuseleap/, /sled/
       "suse"
     when /fedora/, /pidora/, /arista_eos/
       # In the broadest sense:  RPM-based, fedora-derived distributions which are not strictly re-compiled RHEL (if it uses RPMs, and smells more like redhat and less like


### PR DESCRIPTION
SUSE Linux Enterprise Desktop is SLES with a UI. It's SUSE platform_family.

Signed-off-by: Tim Smith <tsmith@chef.io>