### PR TITLE
Add antergos and manjaro linux to the Arch platform_family

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -149,7 +149,7 @@ Ohai.plugin(:Platform) do
       "gentoo"
     when /slackware/
       "slackware"
-    when /arch/
+    when /arch/, /manjaro/, /antergos/
       "arch"
     when /exherbo/
       "exherbo"


### PR DESCRIPTION
Add antergos linux, which is based on Arch https://github.com/chef/os_release/blob/master/antergos

Signed-off-by: Tim Smith <tsmith@chef.io>