### PR TITLE
Add mangeia platform with madriva platform_family

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -157,6 +157,8 @@ Ohai.plugin(:Platform) do
       "alpine"
     when /clearlinux/
       "clearlinux"
+    when /mangeia/
+      "mandriva"
     end
   end
 


### PR DESCRIPTION
mangeia is a popular OS in France. It's a fork of Mandriva which went out of business. There's a few other forks of mandriva so that should probably be the platform_family. It even identifies that as being similar in the os-release file.

Signed-off-by: Tim Smith <tsmith@chef.io>
