### PR TITLE
Fully remove support for HP-UX

### DIFF
--- a/lib/ohai/mixin/os.rb
+++ b/lib/ohai/mixin/os.rb
@@ -32,8 +32,6 @@ module Ohai
           "aix"
         when /darwin(.+)$/
           "darwin"
-        when /hpux(.+)$/
-          "hpux"
         when /linux/
           "linux"
         when /freebsd(.+)$/

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -149,19 +149,6 @@ Ohai.plugin(:C) do
     end
   end
 
-  def collect_hpux_cc
-    # hpux cc
-    collect("what /opt/ansic/bin/cc") do |so|
-      description = so.stdout.split($/).select { |line| line =~ /HP C Compiler/ }.first
-      if description
-        output = description.split
-        @c[:hpcc] = Mash.new
-        @c[:hpcc][:version] = output[1] if output.size >= 1
-        @c[:hpcc][:description] = description.strip
-      end
-    end
-  end
-
   collect_data(:aix) do
     @c = Mash.new
     collect_xlc
@@ -179,13 +166,6 @@ Ohai.plugin(:C) do
     @c = Mash.new
     check_for_cl
     check_for_devenv
-    languages[:c] = @c unless @c.empty?
-  end
-
-  collect_data(:hpux) do
-    @c = Mash.new
-    collect_gcc
-    collect_hpux_cc
     languages[:c] = @c unless @c.empty?
   end
 

--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -74,7 +74,7 @@ Ohai.plugin(:Hostname) do
     end
   end
 
-  collect_data(:hpux, :default) do
+  collect_data(:default) do
     machinename from_cmd("hostname")
     fqdn resolve_fqdn
     collect_hostname

--- a/lib/ohai/plugins/ps.rb
+++ b/lib/ohai/plugins/ps.rb
@@ -23,7 +23,7 @@ Ohai.plugin(:PS) do
   provides "command/ps"
   depends "command"
 
-  collect_data(:aix, :darwin, :hpux, :linux, :solaris2) do
+  collect_data(:aix, :darwin, :linux, :solaris2) do
     command[:ps] = "ps -ef"
   end
 

--- a/spec/unit/plugins/c_spec.rb
+++ b/spec/unit/plugins/c_spec.rb
@@ -70,14 +70,6 @@ C_SUN = <<~EOF.freeze
   cc: Sun C 5.8 Patch 121016-06 2007/08/01
 EOF
 
-C_HPUX = <<~EOF.freeze
-  /opt/ansic/bin/cc:
-          $Revision: 92453-07 linker linker crt0.o B.11.47 051104 $
-          LINT B.11.11.16 CXREF B.11.11.16
-          HP92453-01 B.11.11.16 HP C Compiler
-           $ PATCH/11.00:PHCO_27774  Oct  3 2002 09:45:59 $
-EOF
-
 describe Ohai::System, "plugin c" do
 
   let(:plugin) { get_plugin("c") }
@@ -131,43 +123,6 @@ describe Ohai::System, "plugin c" do
     end
 
   end
-
-  context "on HPUX" do
-    before(:each) do
-      allow(plugin).to receive(:collect_os).and_return(:hpux)
-      allow(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_return(mock_shell_out(0, C_HPUX, ""))
-    end
-
-    # hpux cc
-    it "gets the cc version from running what cc" do
-      expect(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_return(mock_shell_out(0, C_HPUX, ""))
-      plugin.run
-    end
-
-    it "sets languages[:c][:hpcc][:version]" do
-      plugin.run
-      expect(plugin.languages[:c][:hpcc][:version]).to eql("B.11.11.16")
-    end
-
-    it "sets languages[:c][:hpcc][:description]" do
-      plugin.run
-      expect(plugin.languages[:c][:hpcc][:description]).to eql("HP92453-01 B.11.11.16 HP C Compiler")
-    end
-
-    it "does not set the languages[:c][:hpcc] tree up if cc command exits nonzero" do
-      allow(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_return(mock_shell_out(1, "", ""))
-      plugin.run
-      expect(plugin[:languages][:c]).not_to have_key(:hpcc)
-    end
-
-    it "does not set the languages[:c][:hpcc] tree up if cc command fails" do
-      allow(plugin).to receive(:shell_out).with("what /opt/ansic/bin/cc").and_raise(Ohai::Exceptions::Exec)
-      plugin.run
-      expect(plugin[:languages][:c]).not_to have_key(:hpcc)
-      expect(plugin[:languages][:c]).not_to be_empty # expect other attributes
-    end
-  end
-
   context "on Darwin" do
     before(:each) do
       allow(plugin).to receive(:shell_out).with("/usr/bin/xcode-select -p").and_return(mock_shell_out(0, "", ""))
@@ -378,13 +333,6 @@ describe Ohai::System, "plugin c" do
       fedora_error_message = "cc: error trying to exec 'i686-redhat-linux-gcc--flags': execvp: No such file or directory"
 
       allow(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(0, "", fedora_error_message))
-      plugin.run
-      expect(plugin[:languages][:c]).not_to have_key(:sunpro)
-    end
-
-    it "does not set the languages[:c][:sunpro] tree if the corresponding cc command fails on hpux" do
-      hpux_error_message = "cc: warning 901: unknown option: `-flags': use +help for online documentation.\ncc: HP C/aC++ B3910B A.06.25 [Nov 30 2009]"
-      allow(plugin).to receive(:shell_out).with("cc -V -flags").and_return(mock_shell_out(0, "", hpux_error_message))
       plugin.run
       expect(plugin[:languages][:c]).not_to have_key(:sunpro)
     end

--- a/spec/unit/plugins/root_group_spec.rb
+++ b/spec/unit/plugins/root_group_spec.rb
@@ -55,16 +55,6 @@ describe Ohai::System, "root_group" do
       end
     end
 
-    describe "platform hpux with sys group" do
-      before(:each) do
-        allow(@pwnam).to receive(:gid).and_return(3)
-        allow(@grgid).to receive(:name).and_return("sys")
-      end
-      it "should have a root_group of sys" do
-        @plugin.run
-        expect(@plugin[:root_group]).to eq("sys")
-      end
-    end
     describe "platform aix with system group" do
       before(:each) do
         allow(@grgid).to receive(:name).and_return("system")


### PR DESCRIPTION
There hasn't been a working Ruby release for HP-UX for many years. We shouldn't continue to execute this logic and ship it around to all our customers when it's not possible that any of them are running HP-UX.

Signed-off-by: Tim Smith <tsmith@chef.io>