### PR TITLE
Parse new /proc/meminfo fields

### DIFF
--- a/lib/ohai/plugins/linux/memory.rb
+++ b/lib/ohai/plugins/linux/memory.rb
@@ -97,7 +97,7 @@ Ohai.plugin(:Memory) do
         memory[:hugepage_size] = "#{$1}#{$2}"
       when /^Hugetlb:\s+(\d+) (.+)$/
         memory[:hugetlb] = "#{$1}#{$2}"
-      when /^DirectMap([0-9][a-zA-Z]):\s+(\d+) (.+)$/
+      when /^DirectMap([0-9]+[a-zA-Z]):\s+(\d+) (.+)$/
         memory[:directmap][$1.to_sym] = "#{$2}#{$3}"
       end
     end

--- a/lib/ohai/plugins/linux/memory.rb
+++ b/lib/ohai/plugins/linux/memory.rb
@@ -23,6 +23,7 @@ Ohai.plugin(:Memory) do
     memory Mash.new
     memory[:swap] = Mash.new
     memory[:hugepages] = Mash.new
+    memory[:directmap] = Mash.new
 
     File.open("/proc/meminfo").each do |line|
       case line
@@ -94,6 +95,10 @@ Ohai.plugin(:Memory) do
         memory[:hugepages][:surplus] = $1.to_s
       when /^Hugepagesize:\s+(\d+) (.+)$/
         memory[:hugepage_size] = "#{$1}#{$2}"
+      when /^Hugetlb:\s+(\d+) (.+)$/
+        memory[:hugetlb] = "#{$1}#{$2}"
+      when /^DirectMap([0-9][a-zA-Z]):\s+(\d+) (.+)$/
+        memory[:directmap][$1.to_sym] = "#{$2}#{$3}"
       end
     end
   end

--- a/spec/unit/plugins/linux/memory_spec.rb
+++ b/spec/unit/plugins/linux/memory_spec.rb
@@ -56,6 +56,11 @@ describe Ohai::System, "Linux memory plugin" do
       .and_yield("HugePages_Rsvd:  11226")
       .and_yield("HugePages_Surp:      0")
       .and_yield("Hugepagesize:     2048 kB")
+      .and_yield("Hugetlb:               0 kB")
+      .and_yield("DirectMap4k:     3720736 kB")
+      .and_yield("DirectMap2M:    12795904 kB")
+      .and_yield("DirectMap1G:           0 kB")
+
     allow(File).to receive(:open).with("/proc/meminfo").and_return(@double_file)
   end
 
@@ -227,5 +232,25 @@ describe Ohai::System, "Linux memory plugin" do
   it "should get hugepage size" do
     @plugin.run
     expect(@plugin[:memory][:hugepage_size]).to eql("2048kB")
+  end
+
+  it "should get hugetlb memory" do
+    @plugin.run
+    expect(@plugin[:memory][:hugetlb]).to eql("0kB")
+  end
+
+  it "should get directmap 4k memory" do
+    @plugin.run
+    expect(@plugin[:memory][:directmap][:'4k']).to eql("3720736kB")
+  end
+
+  it "should get directmap 2M memory" do
+    @plugin.run
+    expect(@plugin[:memory][:directmap][:'2M']).to eql("12795904kB")
+  end
+
+  it "should get directmap 1G memory" do
+    @plugin.run
+    expect(@plugin[:memory][:directmap][:'1G']).to eql("0kB")
   end
 end


### PR DESCRIPTION
Signed-off-by: Davide Cavalca <dcavalca@fb.com>

### Description

Add parsing logic for some relatively new fields in `/proc/meminfo`

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
