### PR TITLE
Loosen the mixlib pins to allow for new major releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
   - rm -f .bundle/config
 
 rvm:
-  - 2.5.3
-  - 2.6
+  - 2.5.5
+  - 2.6.2
   - ruby-head
 
 matrix:

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "mixlib-cli", ">= 1.7.0" # 1.7+ needed to support passing multiple options
-  s.add_dependency "mixlib-config", "~> 2.0"
-  s.add_dependency "mixlib-log", "~> 2.0", ">= 2.0.1"
-  s.add_dependency "mixlib-shellout", "~> 2.0"
+  s.add_dependency "mixlib-config", ">= 2.0", "< 4.0"
+  s.add_dependency "mixlib-log", ">= 2.0.1", "< 4.0"
+  s.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   s.add_dependency "plist", "~> 3.1"
   s.add_dependency "ipaddress"
   s.add_dependency "wmi-lite", "~> 1.0"


### PR DESCRIPTION
These new releases just drop support for Ruby 2.1 and 2.2.

Signed-off-by: Tim Smith <tsmith@chef.io>