### PR TITLE
Loosen the mixlib version dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ before_install:
   - rm -f .bundle/config
 rvm:
   - 2.4.5
-  - 2.5.3
+  - 2.5.5
+  - 2.6.2
   - ruby-head
 
 matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
-  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
+  gem "chefstyle", "=0.11.2"
   gem "rake", ">= 10.1.0"
   gem "rspec-core", "~> 3.0"
   gem "rspec-expectations", "~> 3.0"

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.add_dependency "systemu", "~> 2.6.4"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "mixlib-cli", ">= 1.7.0" # 1.7+ needed to support passing multiple options
-  s.add_dependency "mixlib-config", "~> 2.0"
-  s.add_dependency "mixlib-log", "~> 2.0", ">= 2.0.1"
-  s.add_dependency "mixlib-shellout", "~> 2.0"
+  s.add_dependency "mixlib-config", ">= 2.0", "< 4.0"
+  s.add_dependency "mixlib-log", ">= 2.0.1", "< 4.0"
+  s.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   s.add_dependency "plist", "~> 3.1"
   s.add_dependency "ipaddress"
   s.add_dependency "wmi-lite", "~> 1.0"


### PR DESCRIPTION
Allow us to bring in the new major releases which just drop Ruby 2.1/2.2
support.

Signed-off-by: Tim Smith <tsmith@chef.io>