### PR TITLE
Fixes ec2 adding json? attribute

### DIFF
--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -202,6 +202,20 @@ module Ohai
         key.gsub(/\-|\//, "_")
       end
 
+      # @param [String] data that might be JSON
+      #
+      # @return [Boolean] is the data JSON or not?
+      def json?(data)
+        data = StringIO.new(data)
+        parser = FFI_Yajl::Parser.new
+        begin
+          parser.parse(data)
+          true
+        rescue FFI_Yajl::ParseError
+          false
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Description

Because of the method_missing approach to setting data the use of json?
here without the function serves only to assign the response.body to a
new attribute named `json?`

Signed-off-by: Franklin Webber <franklin.webber@gmail.com>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
