### PR TITLE
Ohai::Util::FileHelper does not need to be loaded in this systemd_paths plugin

### DIFF
--- a/lib/ohai/plugins/linux/systemd_paths.rb
+++ b/lib/ohai/plugins/linux/systemd_paths.rb
@@ -19,9 +19,6 @@
 Ohai.plugin(:SystemdPaths) do
   provides "systemd_paths"
 
-  require "ohai/util/file_helper"
-  include Ohai::Util::FileHelper
-
   collect_data(:linux) do
     systemd_path_path = which("systemd-path")
     if systemd_path_path


### PR DESCRIPTION
## Description

This module is already in the mix.

Signed-off-by: Franklin Webber <franklin.webber@gmail.com>

## Related Issue

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
