### PR TITLE
Add :no_df_remote configuration flag to filesystem plugin

### DIFF
--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -159,8 +159,8 @@ Ohai.plugin(:Filesystem) do
       # free information. This is rarely useful. Turn on this option to
       # disable remote filesystem enumeration in df. Note that device +
       # mountpoint will still be obtained from mount and /proc/mounts.
-      params = if Ohai.config[:plugin][:filesystem][:no_remote]
-        ' --local'
+      params = if Ohai.config[:plugin][:filesystem][:no_df_remote]
+        ' -l'
       else
         ''
       end
@@ -168,7 +168,7 @@ Ohai.plugin(:Filesystem) do
       fs.merge!(parse_common_df(so.stdout))
 
       # Grab filesystem inode data from df
-      so = shell_out("df -iP#{local}")
+      so = shell_out("df -iP#{params}")
       so.stdout.each_line do |line|
         case line
         when /^Filesystem\s+Inodes/

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -154,11 +154,21 @@ Ohai.plugin(:Filesystem) do
 
     # Grab filesystem data from df
     run_with_check("df") do
-      so = shell_out("df -P")
+      # df runs statfs across all filesystems including remote ones. When run
+      # at scale, Ohai adds extra load, simply to obtain block / inode usage
+      # free information. This is rarely useful. Turn on this option to
+      # disable remote filesystem enumeration in df. Note that device +
+      # mountpoint will still be obtained from mount and /proc/mounts.
+      params = if Ohai.config[:plugin][:filesystem][:no_remote]
+        ' --local'
+      else
+        ''
+      end
+      so = shell_out("df -P#{params}")
       fs.merge!(parse_common_df(so.stdout))
 
       # Grab filesystem inode data from df
-      so = shell_out("df -iP")
+      so = shell_out("df -iP#{local}")
       so.stdout.each_line do |line|
         case line
         when /^Filesystem\s+Inodes/

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -159,11 +159,7 @@ Ohai.plugin(:Filesystem) do
       # free information. This is rarely useful. Turn on this option to
       # disable remote filesystem enumeration in df. Note that device +
       # mountpoint will still be obtained from mount and /proc/mounts.
-      params = if Ohai.config[:plugin][:filesystem][:no_df_remote]
-        ' -l'
-      else
-        ''
-      end
+      params = if Ohai.config[:plugin][:filesystem][:no_df_remote] ? 'l' : ''
       so = shell_out("df -P#{params}")
       fs.merge!(parse_common_df(so.stdout))
 


### PR DESCRIPTION
## Description
`df` runs statfs across all filesystems including remote ones. When run at scale, Ohai adds extra load simply to obtain block / inode usage free information. This is rarely useful. Turn on this option to disable remote filesystem enumeration in `df`. Note that device + mountpoint will still be obtained from `mount` and `/proc/mounts`

## Related Issue
Issue #1357 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
