### PR TITLE
Require ohai/version where we use it

### DIFF
--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2017, Chef Software Inc.
+# Copyright:: Copyright (c) 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require "ohai/version"
 require "ohai/loader"
 require "ohai/log"
 require "ohai/mash"


### PR DESCRIPTION
This was missed until automate required just ohai system

Signed-off-by: Tim Smith <tsmith@chef.io>