### PR TITLE
Solaris network plugin fix for issue https://github.com/chef/ohai/iss…

### DIFF
--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -104,7 +104,8 @@ Ohai.plugin(:Network) do
 
     so.stdout.lines do |line|
       # regex: http://rubular.com/r/Iag7JLVTVe
-      if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+) index (\d+)/
+      if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+) index (\d+)/ ||
+          line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+)/
         cint = $1
         iface[cint] = Mash.new unless iface[cint]
         iface[cint][:mtu] = $2

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -104,7 +104,7 @@ Ohai.plugin(:Network) do
 
     so.stdout.lines do |line|
       # regex: https://rubular.com/r/ZiIHbsnfiWPW1p
-      if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+)(?: index (\d+))?/ 
+      if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+)(?: index (\d+))?/
         cint = $1
         iface[cint] = Mash.new unless iface[cint]
         iface[cint][:mtu] = $2

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -105,6 +105,7 @@ Ohai.plugin(:Network) do
     so.stdout.lines do |line|
       # regex: http://rubular.com/r/Iag7JLVTVe
       if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+) index (\d+)/ ||
+          # regex: https://rubular.com/r/0vSO7KocyLBHTd
           line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+)/
         cint = $1
         iface[cint] = Mash.new unless iface[cint]

--- a/lib/ohai/plugins/solaris2/network.rb
+++ b/lib/ohai/plugins/solaris2/network.rb
@@ -103,10 +103,8 @@ Ohai.plugin(:Network) do
     cint = nil
 
     so.stdout.lines do |line|
-      # regex: http://rubular.com/r/Iag7JLVTVe
-      if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+) index (\d+)/ ||
-          # regex: https://rubular.com/r/0vSO7KocyLBHTd
-          line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+)/
+      # regex: https://rubular.com/r/ZiIHbsnfiWPW1p
+      if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+)(?: index (\d+))?/ 
         cint = $1
         iface[cint] = Mash.new unless iface[cint]
         iface[cint][:mtu] = $2

--- a/spec/unit/plugins/solaris2/network_spec.rb
+++ b/spec/unit/plugins/solaris2/network_spec.rb
@@ -161,7 +161,7 @@ describe Ohai::System, "Solaris2.X network plugin" do
       expect(@plugin["network"]["interfaces"]["net0"]["flags"]).to include("L3PROTECT")
     end
 
-    it "detects the an interface with no index number" do
+    it "detects an interface with no index number" do
       expect(@plugin["network"]["interfaces"]["ipmp0"]["index"]).to eq(nil)
       expect(@plugin["network"]["interfaces"]["ipmp0"]["mtu"]).to eq("1500")
     end

--- a/spec/unit/plugins/solaris2/network_spec.rb
+++ b/spec/unit/plugins/solaris2/network_spec.rb
@@ -44,6 +44,9 @@ describe Ohai::System, "Solaris2.X network plugin" do
     ARP_RN
 
     @solaris_ifconfig = <<~ENDIFCONFIG
+      ipmp0: flags=108000000843<UP,BROADCAST,RUNNING,MULTICAST,IPMP,PHYSRUNNING> mtu 1500
+              inet 10.10.130.103 netmask fffffe00 broadcast 10.10.131.255
+              groupname ipmp0
       lo0:3: flags=2001000849<UP,LOOPBACK,RUNNING,MULTICAST,IPv4,VIRTUAL> mtu 8232 index 1
               inet 127.0.0.1 netmask ff000000
       e1000g0:3: flags=201000843<UP,BROADCAST,RUNNING,MULTICAST,IPv4,CoS> mtu 1500 index 3
@@ -143,7 +146,7 @@ describe Ohai::System, "Solaris2.X network plugin" do
     end
 
     it "detects the interfaces" do
-      expect(@plugin["network"]["interfaces"].keys.sort).to eq(["e1000g0:3", "e1000g2:1", "eri0", "ip.tun0", "ip.tun0:1", "ip6.tun0", "lo0", "lo0:3", "net0", "net1:1", "qfe1", "vni0"])
+      expect(@plugin["network"]["interfaces"].keys.sort).to eq(["e1000g0:3", "e1000g2:1", "eri0", "ip.tun0", "ip.tun0:1", "ip6.tun0", "ipmp0", "lo0", "lo0:3", "net0", "net1:1", "qfe1", "vni0"])
     end
 
     it "detects the ip addresses of the interfaces" do
@@ -157,6 +160,12 @@ describe Ohai::System, "Solaris2.X network plugin" do
     it "detects the L3PROTECT network flag" do
       expect(@plugin["network"]["interfaces"]["net0"]["flags"]).to include("L3PROTECT")
     end
+
+    it "detects the an interface with no index number" do
+      expect(@plugin["network"]["interfaces"]["ipmp0"]["index"]).to eq(nil)
+      expect(@plugin["network"]["interfaces"]["ipmp0"]["mtu"]).to eq("1500")
+    end
+
   end
 
   describe "gathering solaris 11 zone IP layer address info" do


### PR DESCRIPTION
…ues/1366

Signed-off-by: devoptimist <sbrown@chef.io>

added an additional regex to capture solaris interfaces that do not have an index number. 
Added unit test
## Description

solves the issue described here:
https://github.com/chef/ohai/issues/1366

in short it helps ohai to return data for Solaris interfaces that under some configurations have their index number suppressed
## Related Issue
https://github.com/chef/ohai/issues/1366

## Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
