### PR TITLE
Use virtualization attributes to run or skip the virtualbox plugin

### DIFF
--- a/lib/ohai/plugins/vbox_host.rb
+++ b/lib/ohai/plugins/vbox_host.rb
@@ -21,11 +21,7 @@ Ohai.plugin(:VboxHost) do
   # determine if this host is configured with virtualbox or not
   # the determination is ultimately controlled by the "virtualization" plugin
   def vbox_host?
-    host = false
-    if !virtualization.nil? && (virtualization["system"] == "vbox" || virtualization["systems"]["vbox"] == "host")
-      host = true if which("VBoxManage")
-    end
-    host
+    virtualization.dig("systems", "vbox") == "host"
   end
 
   # query virtualbox for each configured vm, as well as

--- a/lib/ohai/plugins/virtualbox.rb
+++ b/lib/ohai/plugins/virtualbox.rb
@@ -21,7 +21,7 @@ Ohai.plugin(:Virtualbox) do
   provides "virtualbox"
 
   collect_data(:default) do
-    if virtualization["systems"].key?("vbox") && virtualization["systems"]["vbox"] == "guest"
+    if virtualization.dig("systems", "vbox") == "guest"
       begin
         so = shell_out("VBoxControl guestproperty enumerate")
 


### PR DESCRIPTION
Instead of attempting to shellout on every system we can just check the attributes we already have. This is slightly faster and improves logging since you won't see a failure.

Signed-off-by: Tim Smith <tsmith@chef.io>