### PR TITLE
Define CONVERSION_STATUS only if it wasn't defined earlier

### DIFF
--- a/lib/ohai/plugins/windows/filesystem.rb
+++ b/lib/ohai/plugins/windows/filesystem.rb
@@ -23,8 +23,8 @@ Ohai.plugin(:Filesystem) do
   #
   # @see https://docs.microsoft.com/en-us/windows/desktop/SecProv/getconversionstatus-win32-encryptablevolume#parameters
   #
-  CONVERSION_STATUS = %w{FullyDecrypted FullyEncrypted EncryptionInProgress
-                         DecryptionInProgress EncryptionPaused DecryptionPaused}.freeze
+  CONVERSION_STATUS ||= %w{FullyDecrypted FullyEncrypted EncryptionInProgress
+                           DecryptionInProgress EncryptionPaused DecryptionPaused}.freeze
 
   # Returns a Mash loaded with logical details
   #


### PR DESCRIPTION
Note: This PR targets 14-stable branch, as it is looking at fixing a problem in Chef-14

Closes: https://github.com/chef/ohai/issues/1276

When ohai is reloaded, Ruby warns about `CONVERSION_STATUS` constant being already defined. This PR fixes those warnings.

## Types of changes
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
