### PR TITLE
Fix openSUSE leap and SLES detection in Chef 14

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -266,7 +266,8 @@ Ohai.plugin(:Platform) do
     elsif File.exist?("/etc/alpine-release")
       platform "alpine"
       platform_version File.read("/etc/alpine-release").strip
-    elsif File.exist?("/usr/lib/os-release")
+    # If /etc/os-release file exists, we take that as source of truth
+    elsif File.exist?("/usr/lib/os-release") && !File.exist?("/etc/os-release")
       contents = File.read("/usr/lib/os-release")
       if /Clear Linux/ =~ contents
         platform "clearlinux"
@@ -300,6 +301,8 @@ Ohai.plugin(:Platform) do
         platform "suse" # SLES is wrong. We call it SUSE
       when "opensuse-leap"
         platform "opensuseleap"
+      when "clear-linux-os"
+        platform "clearlinux"
       else
         platform os_release_info["ID"]
       end


### PR DESCRIPTION
Detection of openSUSE leap and SLES distributions fail with Chef 14 because these distributions satisfy the `if File.exist?('/usr/lib/os-release')` check. However, in that check, we only consider Clear Linux and not anything else, thus causing detection to fail for any other OS.

In my experiments, all the Clear Linux distributions provided  `/etc/os-release` file also. So, moving Clear Linux detection to be based on that file, and using `/usr/lib/os-release` only if `/etc/os-release` is not found (to handle any weird edge cases out there) seems like a safe option to handle Clear Linux, openSUSE Leap and SLES.

## Related Issue

https://github.com/chef/ohai/issues/1343

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
