### PR TITLE
[shard_seed] fix default_sources for linux, darwin and windows

### DIFF
--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -30,7 +30,7 @@ Ohai.plugin(:ShardSeed) do
 
   def default_sources
     case collect_os
-    when :linux, :darwin, :windows
+    when "linux", "darwin", "windows"
       [:machinename, :serial, :uuid]
     else
       [:machinename]

--- a/spec/unit/plugins/shard_spec.rb
+++ b/spec/unit/plugins/shard_spec.rb
@@ -27,7 +27,7 @@ describe Ohai::System, "shard plugin" do
   let(:machine_id) { "0a1f869f457a4c8080ab19faf80af9cc" }
   let(:machinename) { "somehost004" }
   let(:fips) { false }
-  let(:os) { :linux }
+  let(:os) { "linux" }
 
   subject do
     plugin.run
@@ -66,7 +66,7 @@ describe Ohai::System, "shard plugin" do
   end
 
   context "with Darwin OS" do
-    let(:os) { :darwin }
+    let(:os) { "darwin" }
     before do
       plugin["hardware"] = { "serial_number" => serial, "platform_UUID" => uuid }
     end
@@ -77,7 +77,7 @@ describe Ohai::System, "shard plugin" do
   end
 
   context "with Windows OS" do
-    let(:os) { :windows }
+    let(:os) { "windows" }
     before do
       wmi = double("WmiLite::Wmi")
       allow(WmiLite::Wmi).to receive(:new).and_return(wmi)
@@ -99,7 +99,7 @@ describe Ohai::System, "shard plugin" do
   end
 
   context "with a weird OS" do
-    let(:os) { :aix }
+    let(:os) { "aix" }
 
     it "should provide a shard with a default-safe set of sources" do
       # Note: this is different than the other defaults.


### PR DESCRIPTION
## Description
`collect_os` now returns a string (see `mixin/os.rb`), but the shard plugin still assumed it returns a symbol, so no matter the OS, unless overridden in `client.rb` this plugin will only use the machine name as the shard source.

Signed-off-by: Michel Salim <michel@fb.com>

## Related Issue
https://github.com/chef/ohai/issues/1378

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chef/ohai/1379)
<!-- Reviewable:end -->
