### PR TITLE
[shard_seed] fix default_digest_algorithm on darwin

### DIFF
--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -38,7 +38,7 @@ Ohai.plugin(:ShardSeed) do
   end
 
   def default_digest_algorithm
-    if fips["kernel"]["enabled"]
+    if fips && fips["kernel"]["enabled"]
       # Even though it is being used safely, FIPS-mode will still blow up on
       # any use of MD5 so default to SHA2 instead.
       "sha256"

--- a/spec/unit/plugins/shard_spec.rb
+++ b/spec/unit/plugins/shard_spec.rb
@@ -68,6 +68,7 @@ describe Ohai::System, "shard plugin" do
   context "with Darwin OS" do
     let(:os) { :darwin }
     before do
+      plugin.data.delete("fips") # FIPS is undefined on Macs, make sure this still work
       plugin["hardware"] = { "serial_number" => serial, "platform_UUID" => uuid }
     end
 


### PR DESCRIPTION
## Description
`fips` is nil on Macs, and `default_digest_algorithm` did not check for this, causing the shard plugin to throw an exception.

Make it safer by assuming `fips` is not enabled by default.

Signed-off-by: Michel Salim <michel@fb.com>

## Related Issue
https://github.com/chef/ohai/issues/1380

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chef/ohai/1381)
<!-- Reviewable:end -->
