### PR TITLE
Feature - Change regex for detecting interface's state

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -276,7 +276,7 @@ Ohai.plugin(:Network) do
         end
       end
 
-      if line =~ /state (\w+)/
+      if line =~ /\sstate (\w+)/
         iface[tmp_int]["state"] = $1.downcase
       end
     end

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -276,6 +276,7 @@ Ohai.plugin(:Network) do
         end
       end
 
+      # https://rubular.com/r/JRp6lNANmpcLV5
       if line =~ /\sstate (\w+)/
         iface[tmp_int]["state"] = $1.downcase
       end


### PR DESCRIPTION
##  Description

Plugin fails in parsing the output of this:
```
$ ip -d -s link
```
and thinks that an interface with `stp_state` option is down.

## Related Issue
TBD

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
