### PR TITLE
Translating platform "archarm" to "arch"

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -32,6 +32,7 @@ Ohai.plugin(:Platform) do
       "opensuse-leap" => "opensuseleap",
       "xenenterprise" => "xenserver",
       "cumulus-linux" => "cumulus",
+      "archarm" => "arch",
     }.freeze
 
   # @deprecated

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -101,6 +101,11 @@ describe Ohai::System, "Linux plugin platform" do
       expect(plugin.platform_id_remap("sles_sap")).to eq("suse")
     end
 
+    # https://github.com/chef/os_release/blob/master/archarm
+    it "returns arch for archarm" do
+      expect(plugin.platform_id_remap("archarm")).to eq("arch")
+    end
+
     # https://github.com/chef/os_release/blob/master/sles_15_0
     it "returns suse for sles os-release id" do
       expect(plugin.platform_id_remap("sles")).to eq("suse")


### PR DESCRIPTION
## Description
The ARM installer for arch sets this OS identifier, however Chef doesn't
recognize it (e.g. doesn't find a package provider).
Since Chef handles providers by "platform" (and not by platform family),
we should probably make ArchARM seem like Arch

## Related Issue
Fixes #1387

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
