### PR TITLE
Use virtualization plugin to detect if we're on openstack on Windows.

### DIFF
--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -25,6 +25,7 @@ Ohai.plugin(:Openstack) do
   provides "openstack"
   depends "dmi"
   depends "etc"
+  depends "virtualization"
 
   # do we have the openstack dmi data
   def openstack_dmi?
@@ -38,6 +39,14 @@ Ohai.plugin(:Openstack) do
     else
       logger.trace("Plugin Openstack: has_openstack_dmi? == false")
       false
+    end
+  end
+
+  # use virtualization data
+  def openstack_virtualization?
+    if get_attribute(:virtualization, :system, :guest) == "openstack"
+      logger.trace("Plugin Openstack: has_openstack_virtualization? == true")
+      true
     end
   end
 
@@ -61,7 +70,7 @@ Ohai.plugin(:Openstack) do
 
   collect_data do
     # fetch data if we look like openstack
-    if openstack_hint? || openstack_dmi?
+    if openstack_hint? || openstack_dmi? || openstack_virtualization?
       openstack Mash.new
       openstack[:provider] = openstack_provider
 

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -302,4 +302,24 @@ describe Ohai::System, "plugin openstack" do
       end
     end
   end
+
+  context "when openstack virtualization is present" do
+    context "and the metadata service is not available" do
+      before do
+        allow(plugin).to receive(:can_socket_connect?)
+          .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
+          .and_return(false)
+        plugin[:virtualization] = { system: { guest: "openstack" } }
+        plugin.run
+      end
+
+      it "sets openstack provider attribute since virtualization is present" do
+        expect(plugin[:openstack][:provider]).to eq("openstack")
+      end
+
+      it "doesn't set metadata attributes" do
+        expect(plugin[:openstack][:instance_id]).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Signed-off-by: Joshua Justice <jjustice6@bloomberg.net>

<!--- Provide a short summary of your changes in the Title above -->

## Description

If you are using Windows on openstack, the openstack plugin fails to detect that it is using openstack unless you use hints due to the lack of `dmi` on Windows.
It is possible to work around this using `'wmi-lite'` via data contained in `wmi.first_of('Win32_ComputerSystem')`, specifically, the 'manufacturer' and 'model' fields, or data already collected by Ohai elsewhere.

## Related Issue

https://github.com/chef/ohai/issues/1390

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
