### PR TITLE
Display elapsed real time instead of total cpu time

### DIFF
--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -38,7 +38,7 @@ module Ohai
     # If force is set to true, then this plugin and its dependencies
     # will be run even if they have been run before.
     def run_plugin(plugin)
-      elapsed = Benchmark.measure do
+      elapsed = Benchmark.realtime do
         unless plugin.is_a?(Ohai::DSL::Plugin)
           raise Ohai::Exceptions::InvalidPlugin, "Invalid plugin #{plugin} (must be an Ohai::DSL::Plugin or subclass)"
         end
@@ -57,7 +57,7 @@ module Ohai
           logger.trace("Plugin #{plugin.name} threw exception #{e.inspect} #{e.backtrace.join("\n")}")
         end
       end
-      logger.trace("Plugin #{plugin.name} took #{elapsed.total} seconds to run.")
+      logger.trace("Plugin #{plugin.name} took #{elapsed} seconds to run.")
     end
 
     def run_v7_plugin(plugin)


### PR DESCRIPTION
## Description

The ohai plugin benchmarks show total cputime instead of the real running time (wall time).  

You can see in the output from chef-client below that the Cloud plugin shows it took 20 seconds but based on the log timestamps it actually took 24minutes.

```
[2019-07-31T14:53:15-05:00] TRACE: Plugin Ohai took 0.0002349999999999297 seconds to run.
[2019-07-31T15:17:39-05:00] TRACE: Plugin Cloud took 19.176537999999997 seconds to run.
[2019-07-31T15:17:39-05:00] TRACE: Plugin Command took 8.900000000000574e-05 seconds to run.
```

## Related Issue

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
