### PR TITLE
Simplify the Openstack plugin by not polling DMI data

### DIFF
--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Matt Ray (<matt@chef.io>)
 # Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: Copyright (c) 2012-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2012-2019 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,24 +23,8 @@ Ohai.plugin(:Openstack) do
   include Ohai::Mixin::HttpHelper
 
   provides "openstack"
-  depends "dmi"
   depends "etc"
   depends "virtualization"
-
-  # do we have the openstack dmi data
-  def openstack_dmi?
-    # detect a manufacturer of OpenStack Foundation
-    if get_attribute(:dmi, :system, :all_records, 0, :Manufacturer) =~ /OpenStack/
-      logger.trace("Plugin Openstack: has_openstack_dmi? == true")
-      true
-    elsif get_attribute(:dmi, :system, :product_name) == "OpenStack Compute"
-      logger.trace("Plugin Openstack: has_openstack_dmi? == true")
-      true
-    else
-      logger.trace("Plugin Openstack: has_openstack_dmi? == false")
-      false
-    end
-  end
 
   # use virtualization data
   def openstack_virtualization?
@@ -70,7 +54,7 @@ Ohai.plugin(:Openstack) do
 
   collect_data do
     # fetch data if we look like openstack
-    if openstack_hint? || openstack_dmi? || openstack_virtualization?
+    if openstack_hint? || openstack_virtualization?
       openstack Mash.new
       openstack[:provider] = openstack_provider
 

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -25,51 +25,32 @@ describe Ohai::System, "plugin openstack" do
 
   before(:each) do
     allow(plugin).to receive(:hint?).with("openstack").and_return(false)
-    plugin[:dmi] = nil
+    plugin[:virtualization] = { system: {} }
   end
 
-  context "when there is no relevant hint or dmi data" do
+  context "when there is no relevant hint or virtualization data" do
     it "does not set any openstack data" do
       plugin.run
       expect(plugin[:openstack]).to be_nil
     end
   end
 
-  context "when DMI data is Openstack" do
+  context "when virtualization data is Openstack" do
     context "and the metadata service is not available" do
       before do
         allow(plugin).to receive(:can_socket_connect?)
           .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
           .and_return(false)
-        plugin[:dmi] = dmi_data
+        plugin[:virtualization] = { system: { guest: "openstack" } }
         plugin.run
       end
 
-      context "with normal openstack metadata" do
-        let(:dmi_data) do
-          { system: { all_records: [ { Manufacturer: "OpenStack Foundation" } ] } }
-        end
-
-        it "sets openstack attribute" do
-          expect(plugin[:openstack][:provider]).to eq("openstack")
-        end
-
-        it "doesn't set metadata attributes" do
-          expect(plugin[:openstack][:instance_id]).to be_nil
-        end
+      it "sets openstack attribute" do
+        expect(plugin[:openstack][:provider]).to eq("openstack")
       end
-      context "with Red Hat openstack metadata" do
-        let(:dmi_data) do
-          { system: { manufacturer: "Red Hat", product_name: "OpenStack Compute" } }
-        end
 
-        it "sets openstack attribute" do
-          expect(plugin[:openstack][:provider]).to eq("openstack")
-        end
-
-        it "doesn't set metadata attributes" do
-          expect(plugin[:openstack][:instance_id]).to be_nil
-        end
+      it "doesn't set metadata attributes" do
+        expect(plugin[:openstack][:instance_id]).to be_nil
       end
     end
   end
@@ -80,7 +61,7 @@ describe Ohai::System, "plugin openstack" do
       allow(plugin).to receive(:can_socket_connect?)
         .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
         .and_return(false)
-      plugin[:dmi] = { system: { all_records: [ { Manufacturer: "OpenStack Foundation" } ] } }
+      plugin[:virtualization] = { system: { guest: "openstack" } }
       plugin.run
       expect(plugin[:openstack][:provider]).to eq("dreamhost")
     end


### PR DESCRIPTION
Since we rely on the Virtualization plugin now there's no reason to also poll the DMI plugin data. That's a waste of time since we'll have already matched if virtualization came back Openstack. I didn't move the manufacturer = Openstack detection since that seems wrong on all modern Openstack installs which identify product field: https://cloudinit.readthedocs.io/en/latest/topics/datasources/openstack.html

Signed-off-by: Tim Smith <tsmith@chef.io>