### PR TITLE
Simplify and fix Openstack detection on Linux

### DIFF
--- a/lib/ohai/mixin/dmi_decode.rb
+++ b/lib/ohai/mixin/dmi_decode.rb
@@ -19,6 +19,8 @@
 module ::Ohai::Mixin::DmiDecode
   def guest_from_dmi_data(manufacturer, product, version)
     case manufacturer
+    when /OpenStack/
+      return "openstack"
     when /Xen/
       return "xen"
     when /VMware/
@@ -38,13 +40,14 @@ module ::Ohai::Mixin::DmiDecode
     case product
     when /VirtualBox/
       return "vbox"
-    when /OpenStack/
+    when /OpenStack/ # yes this is here twice. Product catches Redhat's version
       return "openstack"
     when /(KVM|RHEV)/
       return "kvm"
     when /BHYVE/
       return "bhyve"
     end
+
     nil # doesn't look like a virt
   end
 end

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -28,7 +28,7 @@ Ohai.plugin(:Openstack) do
 
   # use virtualization data
   def openstack_virtualization?
-    if get_attribute(:virtualization, :system, :guest) == "openstack"
+    if get_attribute(:virtualization, :systems, :openstack)
       logger.trace("Plugin Openstack: has_openstack_virtualization? == true")
       true
     end

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -47,6 +47,9 @@ Ohai.plugin(:Openstack) do
 
   # dreamhost systems have the dhc-user on them
   def openstack_provider
+    # dream host doesn't support windows so bail early if we're on windows
+    return "openstack" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+
     if Etc.getpwnam("dhc-user")
       "dreamhost"
     end

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -19,11 +19,11 @@
 Ohai.plugin(:Openstack) do
   require_relative "../mixin/ec2_metadata"
   require_relative "../mixin/http_helper"
+  require "etc" unless defined?(Etc)
   include Ohai::Mixin::Ec2Metadata
   include Ohai::Mixin::HttpHelper
 
   provides "openstack"
-  depends "etc"
   depends "virtualization"
 
   # use virtualization data
@@ -47,8 +47,10 @@ Ohai.plugin(:Openstack) do
 
   # dreamhost systems have the dhc-user on them
   def openstack_provider
-    return "dreamhost" if get_attribute("etc", "passwd", "dhc-user")
-
+    if Etc.getpwnam("dhc-user")
+      "dreamhost"
+    end
+  rescue ArgumentError # getpwnam raises ArgumentError if the user is not found
     "openstack"
   end
 

--- a/lib/ohai/plugins/passwd.rb
+++ b/lib/ohai/plugins/passwd.rb
@@ -4,6 +4,10 @@ Ohai.plugin(:Passwd) do
   provides "etc", "current_user"
   optional true
 
+  # @param [String] str
+  #
+  # @return [String]
+  #
   def fix_encoding(str)
     str.force_encoding(Encoding.default_external) if str.respond_to?(:force_encoding)
     str

--- a/spec/unit/mixin/dmi_decode.rb
+++ b/spec/unit/mixin/dmi_decode.rb
@@ -23,6 +23,7 @@ describe Ohai::Mixin::DmiDecode, "guest_from_dmi_data" do
   let(:mixin) { Object.new.extend(Ohai::Mixin::DmiDecode) }
 
   # for the full DMI data used in these tests see https://github.com/chef/dmidecode_collection
+  # the fields here are manufacturer, product, and version as passed to #guest_from_dmi_data
   {
     xen: ["Xen", "HVM domU", "4.2.amazon"],
     vmware: ["VMware, Inc.", "VMware Virtual Platform", "None"],
@@ -31,7 +32,7 @@ describe Ohai::Mixin::DmiDecode, "guest_from_dmi_data" do
     veertu: ["Veertu", "Veertu", "Not Specified"],
     parallels: ["Parallels Software International Inc.", "Parallels Virtual Platform", "None"],
     vbox: ["Oracle Corporation", "VirtualBox", "1.2"],
-    openstack: ["Red Hat Inc.", "OpenStack Nova", "2014.1.2-1.el6"],
+    openstack: ["OpenStack Foundation", "", "15.1.5"],
     kvm: ["Red Hat", "KVM", "RHEL 7.0.0 PC (i440FX + PIIX, 1996"],
     bhyve: ["", "BHYVE", "1.0"],
   }.each_pair do |hypervisor, values|
@@ -39,6 +40,12 @@ describe Ohai::Mixin::DmiDecode, "guest_from_dmi_data" do
       it "returns '#{hypervisor}'" do
         expect(mixin.guest_from_dmi_data(values[0], values[1], values[2])).to eq("#{hypervisor}")
       end
+    end
+  end
+
+  describe "when passed Redhat's Openstack varient dmi data" do
+    it "returns 'openstack'" do
+      expect(mixin.guest_from_dmi_data("Red Hat Inc.", "OpenStack Nova", "2014.1.2-1.el6")).to eq("openstack")
     end
   end
 

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -24,6 +24,7 @@ describe Ohai::System, "plugin openstack" do
   let(:default_timeout) { 2 }
 
   before do
+    PasswdEntry = Struct.new(:name, :uid, :gid, :dir, :shell, :gecos)
     allow(plugin).to receive(:hint?).with("openstack").and_return(false)
     plugin[:virtualization] = { system: {} }
   end
@@ -42,10 +43,11 @@ describe Ohai::System, "plugin openstack" do
           .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
           .and_return(false)
         plugin[:virtualization] = { system: { guest: "openstack" } }
+        expect(Etc).to receive(:getpwnam).and_raise(ArgumentError)
         plugin.run
       end
 
-      it "sets openstack attribute" do
+      it "sets provider attribute to openstack" do
         expect(plugin[:openstack][:provider]).to eq("openstack")
       end
 
@@ -62,6 +64,7 @@ describe Ohai::System, "plugin openstack" do
         .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
         .and_return(false)
       plugin[:virtualization] = { system: { guest: "openstack" } }
+      expect(Etc).to receive(:getpwnam).and_return(PasswdEntry.new("dhc-user", 800, 800, "/var/www", "/bin/false", "The dreamhost user"))
       plugin.run
       expect(plugin[:openstack][:provider]).to eq("dreamhost")
     end

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -26,7 +26,7 @@ describe Ohai::System, "plugin openstack" do
   before do
     PasswdEntry = Struct.new(:name, :uid, :gid, :dir, :shell, :gecos)
     allow(plugin).to receive(:hint?).with("openstack").and_return(false)
-    plugin[:virtualization] = { system: {} }
+    plugin[:virtualization] = { systems: {} }
   end
 
   context "when there is no relevant hint or virtualization data" do
@@ -42,7 +42,7 @@ describe Ohai::System, "plugin openstack" do
         allow(plugin).to receive(:can_socket_connect?)
           .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
           .and_return(false)
-        plugin[:virtualization] = { system: { guest: "openstack" } }
+        plugin[:virtualization] = { systems: { openstack: "guest" } }
         expect(Etc).to receive(:getpwnam).and_raise(ArgumentError)
         plugin.run
       end
@@ -63,7 +63,7 @@ describe Ohai::System, "plugin openstack" do
       allow(plugin).to receive(:can_socket_connect?)
         .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
         .and_return(false)
-      plugin[:virtualization] = { system: { guest: "openstack" } }
+      plugin[:virtualization] = { systems: { openstack: "guest" } }
       expect(Etc).to receive(:getpwnam).and_return(PasswdEntry.new("dhc-user", 800, 800, "/var/www", "/bin/false", "The dreamhost user"))
       plugin.run
       expect(plugin[:openstack][:provider]).to eq("dreamhost")
@@ -295,7 +295,7 @@ describe Ohai::System, "plugin openstack" do
         allow(plugin).to receive(:can_socket_connect?)
           .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
           .and_return(false)
-        plugin[:virtualization] = { system: { guest: "openstack" } }
+        plugin[:virtualization] = { systems: { openstack: "guest" } }
         plugin.run
       end
 

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -36,7 +36,7 @@ describe Ohai::System, "plugin openstack" do
     end
   end
 
-  context "when virtualization data is Openstack" do
+  context "when virtualization data is Openstack", :unix_only do
     context "and the metadata service is not available" do
       before do
         allow(plugin).to receive(:can_socket_connect?)
@@ -57,7 +57,7 @@ describe Ohai::System, "plugin openstack" do
     end
   end
 
-  context "when running on dreamhost" do
+  context "when running on dreamhost", :unix_only do
     it "sets openstack provider attribute to dreamhost" do
       plugin["etc"] = { "passwd" => { "dhc-user" => {} } }
       allow(plugin).to receive(:can_socket_connect?)

--- a/spec/unit/plugins/passwd_spec.rb
+++ b/spec/unit/plugins/passwd_spec.rb
@@ -1,5 +1,6 @@
 #
 # License:: Apache License, Version 2.0
+# Copyright:: 2019 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +18,7 @@
 require "spec_helper"
 
 describe Ohai::System, "plugin etc", :unix_only do
-  before do
-    @plugin = get_plugin("passwd")
-  end
+  let(:plugin) { get_plugin("passwd") }
 
   PasswdEntry = Struct.new(:name, :uid, :gid, :dir, :shell, :gecos)
   GroupEntry = Struct.new(:name, :gid, :mem)
@@ -27,30 +26,30 @@ describe Ohai::System, "plugin etc", :unix_only do
   it "includes a list of all users" do
     expect(Etc).to receive(:passwd).and_yield(PasswdEntry.new("root", 1, 1, "/root", "/bin/zsh", "BOFH"))
       .and_yield(PasswdEntry.new("www", 800, 800, "/var/www", "/bin/false", "Serving the web since 1970"))
-    @plugin.run
-    expect(@plugin[:etc][:passwd]["root"]).to eq(Mash.new(shell: "/bin/zsh", gecos: "BOFH", gid: 1, uid: 1, dir: "/root"))
-    expect(@plugin[:etc][:passwd]["www"]).to eq(Mash.new(shell: "/bin/false", gecos: "Serving the web since 1970", gid: 800, uid: 800, dir: "/var/www"))
+    plugin.run
+    expect(plugin[:etc][:passwd]["root"]).to eq(Mash.new(shell: "/bin/zsh", gecos: "BOFH", gid: 1, uid: 1, dir: "/root"))
+    expect(plugin[:etc][:passwd]["www"]).to eq(Mash.new(shell: "/bin/false", gecos: "Serving the web since 1970", gid: 800, uid: 800, dir: "/var/www"))
   end
 
   it "ignores duplicate users" do
     expect(Etc).to receive(:passwd).and_yield(PasswdEntry.new("root", 1, 1, "/root", "/bin/zsh", "BOFH"))
       .and_yield(PasswdEntry.new("root", 1, 1, "/", "/bin/false", "I do not belong"))
-    @plugin.run
-    expect(@plugin[:etc][:passwd]["root"]).to eq(Mash.new(shell: "/bin/zsh", gecos: "BOFH", gid: 1, uid: 1, dir: "/root"))
+    plugin.run
+    expect(plugin[:etc][:passwd]["root"]).to eq(Mash.new(shell: "/bin/zsh", gecos: "BOFH", gid: 1, uid: 1, dir: "/root"))
   end
 
   it "sets the current user" do
     expect(Process).to receive(:euid).and_return("31337")
     expect(Etc).to receive(:getpwuid).and_return(PasswdEntry.new("chef", 31337, 31337, "/home/chef", "/bin/ksh", "Julia Child"))
-    @plugin.run
-    expect(@plugin[:current_user]).to eq("chef")
+    plugin.run
+    expect(plugin[:current_user]).to eq("chef")
   end
 
   it "sets the available groups" do
     expect(Etc).to receive(:group).and_yield(GroupEntry.new("admin", 100, %w{root chef})).and_yield(GroupEntry.new("www", 800, %w{www deploy}))
-    @plugin.run
-    expect(@plugin[:etc][:group]["admin"]).to eq(Mash.new(gid: 100, members: %w{root chef}))
-    expect(@plugin[:etc][:group]["www"]).to eq(Mash.new(gid: 800, members: %w{www deploy}))
+    plugin.run
+    expect(plugin[:etc][:group]["admin"]).to eq(Mash.new(gid: 100, members: %w{root chef}))
+    expect(plugin[:etc][:group]["www"]).to eq(Mash.new(gid: 800, members: %w{www deploy}))
   end
 
   if "".respond_to?(:force_encoding)
@@ -58,8 +57,8 @@ describe Ohai::System, "plugin etc", :unix_only do
       fields = ["root", 1, 1, "/root", "/bin/zsh", "BOFH"]
       fields.each { |f| f.force_encoding(Encoding::ASCII_8BIT) if f.respond_to?(:force_encoding) }
       allow(Etc).to receive(:passwd).and_yield(PasswdEntry.new(*fields))
-      @plugin.run
-      root = @plugin[:etc][:passwd]["root"]
+      plugin.run
+      root = plugin[:etc][:passwd]["root"]
       expect(root["gecos"].encoding).to eq(Encoding.default_external)
     end
   end


### PR DESCRIPTION
Don't require the Etc plugin for detection of Dreamhost which was causing this plugin to run on all hosts and make Ohai take several minutes on large AD domains.

Fix detection of openstack on non-Redhat based Openstack setups.

Signed-off-by: Tim Smith <tsmith@chef.io>