### PR TITLE
Fix platform_version detection on Fedora rawhide

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -40,20 +40,14 @@ Ohai.plugin(:Platform) do
     contents[/^Red Hat/i] ? "redhat" : contents[/(\w+)/i, 1].downcase
   end
 
-  # Amazon Linux AMI release 2013.09
-  # Amazon Linux 2
-  # Amazon Linux 2 (Karoo)
-  # Fedora release 28 (Twenty Eight)
-  # CentOS release 5.8 (Final)
-  # CentOS release 6.7 (Final)
-  # Red Hat Enterprise Linux Server release 7.5 (Maipo)
+  # See https://rubular.com/r/78c1yXYa7zDhdV for example matches
   #
   # @param contents [String] the contents of /etc/redhat-release
   #
   # @returns [String] the version string
   #
   def get_redhatish_version(contents)
-    contents[/Rawhide/i] ? contents[/((\d+) \(Rawhide\))/i, 1].downcase : contents[/(release)? ([\d\.]+)/, 2]
+    contents[/(release)? ([\d\.]+)/, 2]
   end
 
   #

--- a/lib/ohai/provides_map.rb
+++ b/lib/ohai/provides_map.rb
@@ -31,7 +31,6 @@ module Ohai
       @map = Mash.new
     end
 
-
     # @param [Ohai::DSL::Plugin] plugin
     # @param [Array] provided_attributes
     #

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -133,7 +133,6 @@ module Ohai
       freeze_strings!
     end
 
-
     # @param [String] plugin_path
     #
     # @return [void]


### PR DESCRIPTION
package resource fails on rawhide. The updated regex - https://rubular.com/r/3JaKsAeOMLbszj , to only return the version string.

## Description
package resource fails on fedora rawhide with the below message. 
```
ArgumentError
-------------
Malformed version number string 31 (rawhide)

Cookbook Trace:
---------------
  /var/chef/cache/XXX/recipes/main.rb:37:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/XXX/main.rb:

 36:  if node.linux?
 37>>   package 'dmidecode' do
 38:      action :nothing
 39:    end.run_action(:install)
 40:  end

System Info:
------------
chef_version=14.10.9
platform=fedora
platform_version=31 (rawhide)   <-- this bit is trouble
```

the section which fails
```
$ vi .chef/lib/chef/node_map.rb
269     def filters_match?(node, filters)
270       matches_black_white_list?(node, filters, :os) &&
271         matches_black_white_list?(node, filters, :platform_family) &&
272         matches_black_white_list?(node, filters, :platform) &&
273         matches_version_list?(node, filters, :platform_version) && <-- This breaks
274         matches_target_mode?(filters)
275     end
```

The stacktrace
```
chef (14.10.9)> recipe_mode
chef:recipe (14.10.9)> package 'dmidecode' do
chef:recipe > action :nothing
chef:recipe ?> end.run_action(:install)
Traceback (most recent call last):
       16: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/resource_resolver.rb:33:in `resolve'
       15: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/resource_resolver.rb:80:in `resolve'
       14: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/resource_resolver.rb:147:in `prioritized_handlers'
       13: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/resource_resolver.rb:142:in `enabled_handlers'
       12: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/resource_resolver.rb:138:in `potential_handlers'
       11: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/node_map.rb:161:in `list'
       10: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/node_map.rb:161:in `select'
        9: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/node_map.rb:162:in `block in list'
        8: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/node_map.rb:286:in `node_matches?'
        7: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/node_map.rb:276:in `filters_match?'
        6: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/node_map.rb:267:in `matches_version_list?'
        5: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/node_map.rb:267:in `any?'
        4: from /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.10.9/lib/chef/node_map.rb:268:in `block in matches_version_list?'
        3: from /opt/chef/embedded/lib/ruby/2.5.0/rubygems/version.rb:199:in `new'
        2: from /opt/chef/embedded/lib/ruby/2.5.0/rubygems/version.rb:199:in `new'
        1: from /opt/chef/embedded/lib/ruby/2.5.0/rubygems/version.rb:208:in `initialize'
ArgumentError (Malformed version number string 31 (rawhide))

```

## Related Issue
 Similar one - #1218 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
