### PR TITLE
Make the new sysctl plugin optional

### DIFF
--- a/lib/ohai/plugins/linux/sysctl.rb
+++ b/lib/ohai/plugins/linux/sysctl.rb
@@ -18,6 +18,7 @@
 
 Ohai.plugin(:Sysctl) do
   provides "sysctl"
+  optional true
 
   collect_data(:linux) do
     sysctl_path = which("sysctl")


### PR DESCRIPTION
This way we avoid further bloating node data

Signed-off-by: Tim Smith <tsmith@chef.io>