### PR TITLE
Adding drive type to windows filesystem plugin.

### DIFF
--- a/lib/ohai/plugins/windows/filesystem.rb
+++ b/lib/ohai/plugins/windows/filesystem.rb
@@ -94,6 +94,7 @@ Ohai.plugin(:Filesystem) do
       property[:mount] = disk["name"]
       property[:fs_type] = disk["filesystem"].to_s.downcase
       property[:volume_name] = disk["volumename"].to_s.downcase
+      property[:drive_type] = disk["drivetype"].to_i
       properties[drive] = property
     end
     properties

--- a/lib/ohai/plugins/windows/filesystem.rb
+++ b/lib/ohai/plugins/windows/filesystem.rb
@@ -19,6 +19,9 @@
 Ohai.plugin(:Filesystem) do
   provides "filesystem"
 
+  # Drive types
+  DRIVE_TYPE ||= %W{unknown no_root_dir removable local network cd ram}.freeze
+
   # Volume encryption or decryption status
   #
   # @see https://docs.microsoft.com/en-us/windows/desktop/SecProv/getconversionstatus-win32-encryptablevolume#parameters
@@ -95,6 +98,8 @@ Ohai.plugin(:Filesystem) do
       property[:fs_type] = disk["filesystem"].to_s.downcase
       property[:volume_name] = disk["volumename"].to_s.downcase
       property[:drive_type] = disk["drivetype"].to_i
+      property[:drive_type_string] = DRIVE_TYPE[disk["drivetype"].to_i]
+      property[:drive_type_human] = disk["description"].to_s
       properties[drive] = property
     end
     properties

--- a/lib/ohai/plugins/windows/filesystem.rb
+++ b/lib/ohai/plugins/windows/filesystem.rb
@@ -20,7 +20,7 @@ Ohai.plugin(:Filesystem) do
   provides "filesystem"
 
   # Drive types
-  DRIVE_TYPE ||= %W{unknown no_root_dir removable local network cd ram}.freeze
+  DRIVE_TYPE ||= %w{unknown no_root_dir removable local network cd ram}.freeze
 
   # Volume encryption or decryption status
   #

--- a/spec/unit/plugins/windows/filesystem_spec.rb
+++ b/spec/unit/plugins/windows/filesystem_spec.rb
@@ -72,7 +72,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
 
   describe "#logical_properties" do
     let(:disks) { logical_disks_instances }
-    let(:logical_props) { %i{kb_size kb_available kb_used percent_used mount fs_type volume_name drive_type} }
+    let(:logical_props) { %i{kb_size kb_available kb_used percent_used mount fs_type volume_name drive_type drive_type_string drive_type_human} }
 
     it "Returns a mash" do
       expect(plugin.logical_properties(disks)).to be_a(Mash)

--- a/spec/unit/plugins/windows/filesystem_spec.rb
+++ b/spec/unit/plugins/windows/filesystem_spec.rb
@@ -72,7 +72,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
 
   describe "#logical_properties" do
     let(:disks) { logical_disks_instances }
-    let(:logical_props) { %i{kb_size kb_available kb_used percent_used mount fs_type volume_namei drive_type} }
+    let(:logical_props) { %i{kb_size kb_available kb_used percent_used mount fs_type volume_name drive_type} }
 
     it "Returns a mash" do
       expect(plugin.logical_properties(disks)).to be_a(Mash)

--- a/spec/unit/plugins/windows/filesystem_spec.rb
+++ b/spec/unit/plugins/windows/filesystem_spec.rb
@@ -72,7 +72,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
 
   describe "#logical_properties" do
     let(:disks) { logical_disks_instances }
-    let(:logical_props) { %i{kb_size kb_available kb_used percent_used mount fs_type volume_name} }
+    let(:logical_props) { %i{kb_size kb_available kb_used percent_used mount fs_type volume_namei drive_type} }
 
     it "Returns a mash" do
       expect(plugin.logical_properties(disks)).to be_a(Mash)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Currently drive type isn't included in the windows filesystem plugin. This PR adds this.


## Description
Currently drive type isn't included in the windows filesystem plugin. This PR adds this.

Sample output:

{
  "A:": {
    "kb_size": 0,
    "kb_available": 0,
    "kb_used": 0,
    "percent_used": 0,
    "mount": "A:",
    "fs_type": "",
    "volume_name": "",
    "drive_type": 2
  },

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
