### PR TITLE
fix [#1406]: ensure optional_plugins to be array of symbols

### DIFF
--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -39,7 +39,7 @@ module Ohai
       # causes all optional plugins to be run.
       default :run_all_plugins, false
       # optional plugins are the set of plugins that are marked optional but you wish to run.
-      default :optional_plugins, []
+      default(:optional_plugins, []).writes_value { |arr| arr.map(&:to_sym) }
       default :shellout_timeout, 30
     end
   end


### PR DESCRIPTION
updated the ohai configuration declaration to ensure that values written to ohai[:optional_plugins] are always an array of symbols. 

## Related Issue
fixes #1406

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
