### PR TITLE
Fix failures under Ruby 2.7

### DIFF
--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -24,6 +24,13 @@ module Ohai
         "inet" => "default",
         "inet6" => "default_inet6",
       }.freeze
+
+      def hex_to_dec_netmask(netmask)
+        # example 'ffff0000' -> '255.255.0.0'
+        dec = netmask[0..1].to_i(16).to_s(10)
+        [2, 4, 6].each { |n| dec = dec + "." + netmask[n..n + 1].to_i(16).to_s(10) }
+        dec
+      end
     end
   end
 end

--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -19,7 +19,7 @@
 
 module Ohai
   module Mixin
-    module NetworkConstants
+    module NetworkHelper
       FAMILIES = {
         "inet" => "default",
         "inet6" => "default_inet6",

--- a/lib/ohai/plugins/aix/network.rb
+++ b/lib/ohai/plugins/aix/network.rb
@@ -25,9 +25,9 @@ Ohai.plugin(:Network) do
 
   # Helpers
   def hex_to_dec_netmask(netmask)
-    # example '0xffff0000' -> '255.255.0.0'
-    dec = netmask[2..3].to_i(16).to_s(10)
-    [4, 6, 8].each { |n| dec = dec + "." + netmask[n..n + 1].to_i(16).to_s(10) }
+    # example 'ffff0000' -> '255.255.0.0'
+    dec = netmask[0..1].to_i(16).to_s(10)
+    [2, 4, 6].each { |n| dec = dec + "." + netmask[n..n + 1].to_i(16).to_s(10) }
     dec
   end
 
@@ -80,7 +80,7 @@ Ohai.plugin(:Network) do
           if lin =~ %r{inet (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(/(\d{1,2}))?}
             tmp_addr, tmp_prefix = $1, $3
             if tmp_prefix.nil?
-              netmask = hex_to_dec_netmask($1) if lin =~ /netmask\s(\S+)\s/
+              netmask = hex_to_dec_netmask($1) if lin =~ /netmask\s0x(\S+)\s/
               unless netmask
                 tmp_prefix ||= "32"
                 netmask = IPAddr.new("255.255.255.255").mask(tmp_prefix.to_i).to_s

--- a/lib/ohai/plugins/aix/network.rb
+++ b/lib/ohai/plugins/aix/network.rb
@@ -20,16 +20,11 @@
 
 Ohai.plugin(:Network) do
   require "ipaddr"
+  require_relative "../../mixin/network_helper"
 
   provides "network", "counters/network", "macaddress"
 
-  # Helpers
-  def hex_to_dec_netmask(netmask)
-    # example 'ffff0000' -> '255.255.0.0'
-    dec = netmask[0..1].to_i(16).to_s(10)
-    [2, 4, 6].each { |n| dec = dec + "." + netmask[n..n + 1].to_i(16).to_s(10) }
-    dec
-  end
+  include Ohai::Mixin::NetworkHelper
 
   collect_data(:aix) do
     # Loads following information.

--- a/lib/ohai/plugins/darwin/network.rb
+++ b/lib/ohai/plugins/darwin/network.rb
@@ -17,8 +17,12 @@
 #
 
 Ohai.plugin(:Network) do
+  require_relative "../../mixin/network_helper"
+
   provides "network", "network/interfaces"
   provides "counters/network", "counters/network/interfaces"
+
+  include Ohai::Mixin::NetworkHelper
 
   def parse_media(media_string)
     media = {}
@@ -87,8 +91,6 @@ Ohai.plugin(:Network) do
   end
 
   collect_data(:darwin) do
-    require "scanf"
-
     network Mash.new unless network
     network[:interfaces] ||= Mash.new
     counters Mash.new unless counters
@@ -138,11 +140,11 @@ Ohai.plugin(:Network) do
       end
       if line =~ /\s+inet (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) netmask 0x(([0-9a-f]){1,8})\s*$/
         iface[cint][:addresses] ||= Mash.new
-        iface[cint][:addresses][$1] = { "family" => "inet", "netmask" => $2.scanf("%2x" * 4) * "." }
+        iface[cint][:addresses][$1] = { "family" => "inet", "netmask" => hex_to_dec_netmask($2) }
       end
       if line =~ /\s+inet (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) netmask 0x(([0-9a-f]){1,8}) broadcast (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/
         iface[cint][:addresses] ||= Mash.new
-        iface[cint][:addresses][$1] = { "family" => "inet", "netmask" => $2.scanf("%2x" * 4) * ".", "broadcast" => $4 }
+        iface[cint][:addresses][$1] = { "family" => "inet", "netmask" => hex_to_dec_netmask($2) , "broadcast" => $4 }
       end
       if line =~ /\s+inet6 ([a-f0-9\:]+)(\s*|(\%[a-z0-9]+)\s*) prefixlen (\d+)\s*/
         iface[cint][:addresses] ||= Mash.new

--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -18,8 +18,8 @@
 
 Ohai.plugin(:NetworkAddresses) do
   require "ipaddress"
-  require_relative "../mixin/network_constants"
-  include Ohai::Mixin::NetworkConstants
+  require_relative "../mixin/network_helper"
+  include Ohai::Mixin::NetworkHelper
 
   provides "ipaddress", "ip6address", "macaddress"
 
@@ -69,8 +69,8 @@ Ohai.plugin(:NetworkAddresses) do
     return [ nil, nil ] if ips.empty?
 
     # shortcuts to access default #{family} interface and gateway
-    int_attr = Ohai::Mixin::NetworkConstants::FAMILIES[family] + "_interface"
-    gw_attr = Ohai::Mixin::NetworkConstants::FAMILIES[family] + "_gateway"
+    int_attr = Ohai::Mixin::NetworkHelper::FAMILIES[family] + "_interface"
+    gw_attr = Ohai::Mixin::NetworkHelper::FAMILIES[family] + "_gateway"
 
     if network[int_attr]
       # working with the address(es) of the default network interface
@@ -142,7 +142,7 @@ Ohai.plugin(:NetworkAddresses) do
     counters[:network] ||= Mash.new
 
     # inet family is processed before inet6 to give ipv4 precedence
-    Ohai::Mixin::NetworkConstants::FAMILIES.keys.sort.each do |family|
+    Ohai::Mixin::NetworkHelper::FAMILIES.keys.sort.each do |family|
       r = {}
       # find the ip/interface with the default route for this family
       (r["ip"], r["iface"]) = find_ip(family)

--- a/spec/unit/mixin/network_helper_spec.rb
+++ b/spec/unit/mixin/network_helper_spec.rb
@@ -1,0 +1,30 @@
+#
+# Author:: Kris Shannon <k.shannon@amaze.com.au>
+# Copyright:: Copyright (c) 2019 Amaze Communication.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "ohai/mixin/network_helper"
+
+describe Ohai::Mixin::NetworkHelper, "Network Helper Mixin" do
+  let(:mixin) { Object.new.extend(Ohai::Mixin::NetworkHelper) }
+
+  describe "hex_to_dec_netmask method" do
+    it "converts a netmask from hexadecimal form to decimal form" do
+      expect(mixin.hex_to_dec_netmask("ffff0000")).to eq("255.255.0.0")
+    end
+  end
+end

--- a/spec/unit/plugins/aix/network_spec.rb
+++ b/spec/unit/plugins/aix/network_spec.rb
@@ -307,7 +307,7 @@ describe Ohai::System, "AIX network plugin" do
     end
 
     it "converts a netmask from hexadecimal form to decimal form" do
-      expect(@plugin.hex_to_dec_netmask("0xffff0000")).to eq("255.255.0.0")
+      expect(@plugin.hex_to_dec_netmask("ffff0000")).to eq("255.255.0.0")
     end
   end
 end

--- a/spec/unit/plugins/aix/network_spec.rb
+++ b/spec/unit/plugins/aix/network_spec.rb
@@ -300,14 +300,4 @@ describe Ohai::System, "AIX network plugin" do
       expect(@plugin["network"]["arp"][0][:remote_mac]).to eq("6e:87:70:0:40:3")
     end
   end
-
-  describe "hex_to_dec_netmask method" do
-    before do
-      @plugin.run
-    end
-
-    it "converts a netmask from hexadecimal form to decimal form" do
-      expect(@plugin.hex_to_dec_netmask("ffff0000")).to eq("255.255.0.0")
-    end
-  end
 end


### PR DESCRIPTION
Ruby 2.7 removes the scanf library which is used in the network plugins for darwin and solaris to parse the hex netmask into a dotted decimal

Replaced the scanf library with simple regex and to_i(16) calls

## Related Issue
Pull #1410 added ruby 2.7 to the testing matrix which is now causing failures

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
