### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -747,7 +747,7 @@ Ohai.plugin(:Filesystem) do
 
   collect_data(:windows) do
     require "wmi-lite/wmi"
-    require "ohai/mash"
+    require_relative "../mash"
 
     fs = merge_info(logical_info, encryptable_info)
 


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>