### PR TITLE
Fix missing volume name and re-implement adding drivetype to filesystem plugin

### DIFF
--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -162,6 +162,9 @@ Ohai.plugin(:Filesystem) do
   end
 
   ### Windows specific methods BEGINS
+  # Drive types
+  DRIVE_TYPE ||= %w{unknown no_root_dir removable local network cd ram}.freeze
+
   # Volume encryption or decryption status
   #
   # @see https://docs.microsoft.com/en-us/windows/desktop/SecProv/getconversionstatus-win32-encryptablevolume#parameters
@@ -244,6 +247,9 @@ Ohai.plugin(:Filesystem) do
       property[:percent_used] = (property[:kb_size] == 0 ? 0 : (property[:kb_used] * 100 / property[:kb_size]))
       property[:mount] = mount
       property[:fs_type] = disk["filesystem"].to_s.downcase
+      property[:drive_type] = disk["drivetype"].to_i
+      property[:drive_type_string] = DRIVE_TYPE[disk["drivetype"].to_i]
+      property[:drive_type_human] = disk["description"].to_s
       property[:volume_name] = device
       property[:device] = device
 

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -236,7 +236,7 @@ Ohai.plugin(:Filesystem) do
       property = Mash.new
       # In windows the closet thing we have to a device is the volume_name
       # and the "mountpoint" is the drive letter...
-      device = disk["volume_name"].to_s.downcase
+      device = disk["volumename"].to_s.downcase
       mount = disk["deviceid"]
       property[:kb_size] = disk["size"] ? disk["size"].to_i / 1000 : 0
       property[:kb_available] = disk["freespace"].to_i / 1000

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -237,7 +237,7 @@ Ohai.plugin(:Filesystem) do
     properties = Mash.new
     disks.each do |disk|
       property = Mash.new
-      # In windows the closet thing we have to a device is the volume_name
+      # In windows the closest thing we have to a device is the volume name
       # and the "mountpoint" is the drive letter...
       device = disk["volumename"].to_s.downcase
       mount = disk["deviceid"]
@@ -250,7 +250,7 @@ Ohai.plugin(:Filesystem) do
       property[:drive_type] = disk["drivetype"].to_i
       property[:drive_type_string] = DRIVE_TYPE[disk["drivetype"].to_i]
       property[:drive_type_human] = disk["description"].to_s
-      property[:volume_name] = device
+      property[:volume_name] = disk["volumename"].to_s
       property[:device] = device
 
       key = "#{device},#{mount}"

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -173,7 +173,7 @@ Ohai.plugin(:Filesystem) do
 
   # Returns a Mash loaded with logical details
   #
-  # Uses Win32_LogicalDisk and logical_properties to return encryption details of volumes.
+  # Uses Win32_LogicalDisk and logical_properties to return general details of volumes.
   #
   # Returns an empty Mash in case of any WMI exception.
   #
@@ -184,7 +184,7 @@ Ohai.plugin(:Filesystem) do
   def logical_info
     wmi = WmiLite::Wmi.new("Root\\CIMV2")
 
-    # Note: we should really be parsing Win32_Volume and Win32_Mapped drive.
+    # TODO: We should really be parsing Win32_Volume and Win32_MountPoint.
     disks = wmi.instances_of("Win32_LogicalDisk")
     logical_properties(disks)
   rescue WmiLite::WmiException

--- a/spec/unit/plugins/windows/filesystem_spec.rb
+++ b/spec/unit/plugins/windows/filesystem_spec.rb
@@ -33,7 +33,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
         "filesystem" => "NTFS",
         "freespace" => "100000",
         "name" => "C:",
-        "volumename " => "",
+        # omit "volumename"; it will be added in (some) tests below
       },
       {
         "caption" => "D:",
@@ -42,7 +42,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
         "filesystem" => "FAT32",
         "freespace" => "100000",
         "name" => "D:",
-        # Lets not pass "volumename" for this drive
+        # omit "volumename"; it will be added in (some) tests below
       },
     ]
   end
@@ -116,7 +116,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
     context "when there are volume names" do
       before do
         ldi = logical_disks_instances
-        ldi.each_with_index { |d, i| d["volume_name"] = "Volume #{i}" }
+        ldi.each_with_index { |d, i| d["volumename"] = "Volume #{i}" }
         allow(plugin).to receive(:logical_info).and_return(plugin.logical_properties(ldi))
         allow(plugin).to receive(:encryptable_info).and_return(plugin.encryption_properties(encryptable_volume_instances))
         plugin.run

--- a/spec/unit/plugins/windows/filesystem_spec.rb
+++ b/spec/unit/plugins/windows/filesystem_spec.rb
@@ -31,6 +31,8 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
         "deviceid" => "C:",
         "size" => "10000000",
         "filesystem" => "NTFS",
+        "drivetype" => 3,
+        "description" => "Local Fixed Disk",
         "freespace" => "100000",
         "name" => "C:",
         # omit "volumename"; it will be added in (some) tests below
@@ -40,6 +42,8 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
         "deviceid" => "D:",
         "size" => "10000000",
         "filesystem" => "FAT32",
+        "drivetype" => 2,
+        "description" => "Removable Disk",
         "freespace" => "100000",
         "name" => "D:",
         # omit "volumename"; it will be added in (some) tests below
@@ -95,6 +99,9 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
       it "returns disk information" do
         {
           "fs_type" => "ntfs",
+          "drive_type" => 3,
+          "drive_type_string" => "local",
+          "drive_type_human" => "Local Fixed Disk",
           "volume_name" => "",
           "encryption_status" => "FullyDecrypted",
         }.each do |k, v|
@@ -104,6 +111,9 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
 
         {
           "fs_type" => "fat32",
+          "drive_type" => 2,
+          "drive_type_string" => "removable",
+          "drive_type_human" => "Removable Disk",
           "volume_name" => "",
           "encryption_status" => "EncryptionInProgress",
         }.each do |k, v|
@@ -139,6 +149,9 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
       it "returns disk information" do
         {
           "fs_type" => "ntfs",
+          "drive_type" => 3,
+          "drive_type_string" => "local",
+          "drive_type_human" => "Local Fixed Disk",
           "volume_name" => "volume 0",
           "encryption_status" => "FullyDecrypted",
         }.each do |k, v|
@@ -148,6 +161,9 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
 
         {
           "fs_type" => "fat32",
+          "drive_type" => 2,
+          "drive_type_string" => "removable",
+          "drive_type_human" => "Removable Disk",
           "volume_name" => "volume 1",
           "encryption_status" => "EncryptionInProgress",
         }.each do |k, v|
@@ -160,7 +176,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
 
   describe "#logical_properties" do
     let(:disks) { logical_disks_instances }
-    let(:logical_props) { %i{kb_size kb_available kb_used percent_used mount fs_type volume_name device} }
+    let(:logical_props) { %i{kb_size kb_available kb_used percent_used mount fs_type drive_type drive_type_string drive_type_human volume_name device} }
 
     it "Returns a mash" do
       expect(plugin.logical_properties(disks)).to be_a(Mash)

--- a/spec/unit/plugins/windows/filesystem_spec.rb
+++ b/spec/unit/plugins/windows/filesystem_spec.rb
@@ -152,7 +152,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "drive_type" => 3,
           "drive_type_string" => "local",
           "drive_type_human" => "Local Fixed Disk",
-          "volume_name" => "volume 0",
+          "volume_name" => "Volume 0",
           "encryption_status" => "FullyDecrypted",
         }.each do |k, v|
           expect(plugin[:filesystem]["C:"][k]).to eq(v)
@@ -164,7 +164,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "drive_type" => 2,
           "drive_type_string" => "removable",
           "drive_type_human" => "Removable Disk",
-          "volume_name" => "volume 1",
+          "volume_name" => "Volume 1",
           "encryption_status" => "EncryptionInProgress",
         }.each do |k, v|
           expect(plugin[:filesystem]["D:"][k]).to eq(v)


### PR DESCRIPTION
Fix volume name and add drive type to filesystem plugin (windows-specific).

## Description
1. Fix the volume name, which previously was always empty due to a misnamed field in Win32_LogicalDisk.

2. Re-implement PR #1403 to add drive type.  That PR had conflicts due to PR #1267.  This PR fixes that and includes a few more specs.

## Related Issue
Fixes #1418.  Replaces #1403.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

## Filesystem Comparison:

Before:

```
  "filesystem": {
    "C:": {
      "kb_size": 104849207,
      "kb_available": 15268880,
      "kb_used": 89580327,
      "percent_used": 85,
      "fs_type": "ntfs",
      "volume_name": ""
    }
  },
```

After:

```
  "filesystem": {
    "C:": {
      "kb_size": 104849207,
      "kb_available": 16072687,
      "kb_used": 88776520,
      "percent_used": 84,
      "fs_type": "ntfs",
      "drive_type": 3,
      "drive_type_string": "local",
      "drive_type_human": "Local Fixed Disk",
      "volume_name": "Windows8_OS"
    }
```

## Filesystem2 Comparison:

Before:

```
  "filesystem2": {
    "by_device": {
      "": {
        "kb_size": 104849207,
        "kb_available": 15268880,
        "kb_used": 89580327,
        "percent_used": 85,
        "fs_type": "ntfs",
        "volume_name": "",
        "mounts": [
          "C:"
        ]
      }
    },
    "by_mountpoint": {
      "C:": {
        "kb_size": 104849207,
        "kb_available": 15268880,
        "kb_used": 89580327,
        "percent_used": 85,
        "fs_type": "ntfs",
        "volume_name": "",
        "devices": [
          ""
        ]
      }
    },
    "by_pair": {
      ",C:": {
        "kb_size": 104849207,
        "kb_available": 15268880,
        "kb_used": 89580327,
        "percent_used": 85,
        "mount": "C:",
        "fs_type": "ntfs",
        "volume_name": "",
        "device": ""
      }
    }
  },
```

After:

```
  "filesystem2": {
    "by_device": {
      "windows8_os": {
        "kb_size": 104849207,
        "kb_available": 16072687,
        "kb_used": 88776520,
        "percent_used": 84,
        "fs_type": "ntfs",
        "drive_type": 3,
        "drive_type_string": "local",
        "drive_type_human": "Local Fixed Disk",
        "volume_name": "Windows8_OS",
        "mounts": [
          "C:"
        ]
      }
    },
    "by_mountpoint": {
      "C:": {
        "kb_size": 104849207,
        "kb_available": 16072687,
        "kb_used": 88776520,
        "percent_used": 84,
        "fs_type": "ntfs",
        "drive_type": 3,
        "drive_type_string": "local",
        "drive_type_human": "Local Fixed Disk",
        "volume_name": "Windows8_OS",
        "devices": [
          "windows8_os"
        ]
      }
    },
    "by_pair": {
      "windows8_os,C:": {
        "kb_size": 104849207,
        "kb_available": 16072687,
        "kb_used": 88776520,
        "percent_used": 84,
        "mount": "C:",
        "fs_type": "ntfs",
        "drive_type": 3,
        "drive_type_string": "local",
        "drive_type_human": "Local Fixed Disk",
        "volume_name": "Windows8_OS",
        "device": "windows8_os"
      }
    }
  },
```