### PR TITLE
Use is_a? to check the class in the DMI plugin

### DIFF
--- a/lib/ohai/common/dmi.rb
+++ b/lib/ohai/common/dmi.rb
@@ -117,12 +117,12 @@ module Ohai
       def convenience_keys(dmi)
         dmi.each do |type, records|
           in_common = Mash.new
-          next unless records.class.to_s == "Mash"
+          next unless records.is_a?(Mash)
           next unless records.key?("all_records")
 
           records[:all_records].each do |record|
             record.each do |field, value|
-              next if value.class.to_s == "Mash"
+              next if value.is_a?(Mash)
               next if field.to_s == "application_identifier"
               next if field.to_s == "size"
               next if field.to_s == "record_id"

--- a/lib/ohai/plugins/solaris2/dmi.rb
+++ b/lib/ohai/plugins/solaris2/dmi.rb
@@ -24,7 +24,7 @@ Ohai.plugin(:DMI) do
 
     # if we already have a "dmi" with keys (presumably from dmidecode), don't try smbios
     # note that a single key just means dmidecode exited with its version
-    if (dmi.class.to_s == "Mash") && (dmi.keys.length > 1)
+    if dmi.is_a?(Mash) && dmi.keys.length > 1
       logger.trace("Plugin DMI: skipping smbios output, since DMI information has already been provided")
       return
     end
@@ -177,7 +177,7 @@ Ohai.plugin(:DMI) do
           next
         end
         # overwrite "raw" value with a new Mash
-        dmi[dmi_record[:type]][:all_records][dmi_record[:position]][field] = Mash.new unless dmi[dmi_record[:type]][:all_records][dmi_record[:position]][field].class.to_s == "Mash"
+        dmi[dmi_record[:type]][:all_records][dmi_record[:position]][field] = Mash.new unless dmi[dmi_record[:type]][:all_records][dmi_record[:position]][field].is_a?(Mash)
         dmi[dmi_record[:type]][:all_records][dmi_record[:position]][field][extended_data[1]] = extended_data[2]
 
       else


### PR DESCRIPTION
We broke this when we added chef-utils to chef-client. Thanks for digging into this @zmscwx and @Sliim

Signed-off-by: Tim Smith <tsmith@chef.io>