### PR TITLE
Replace filesystem with filesystem2 on aix/solaris/bsd

### DIFF
--- a/spec/unit/plugins/aix/filesystem_spec.rb
+++ b/spec/unit/plugins/aix/filesystem_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Prabhu Das (<prabhu.das@clogeny.com>)
 # Author:: Isa Farnik (<isa@chef.io>)
-# Copyright:: Copyright (c) 2013-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -100,27 +100,27 @@ describe Ohai::System, "AIX filesystem plugin" do
     describe "df -Pk" do
 
       it "returns the filesystem block size" do
-        expect(@plugin[:filesystem]["/dev/hd4"]["kb_size"]).to eq("2097152")
+        expect(@plugin[:filesystem]["by_pair"]["/dev/hd4,/"]["kb_size"]).to eq("2097152")
         expect(@plugin[:filesystem2]["by_pair"]["/dev/hd4,/"]["kb_size"]).to eq("2097152")
       end
 
       it "returns the filesystem used space in kb" do
-        expect(@plugin[:filesystem]["/dev/hd4"]["kb_used"]).to eq("219796")
+        expect(@plugin[:filesystem]["by_pair"]["/dev/hd4,/"]["kb_used"]).to eq("219796")
         expect(@plugin[:filesystem2]["by_pair"]["/dev/hd4,/"]["kb_used"]).to eq("219796")
       end
 
       it "returns the filesystem available space in kb" do
-        expect(@plugin[:filesystem]["/dev/hd4"]["kb_available"]).to eq("1877356")
+        expect(@plugin[:filesystem]["by_pair"]["/dev/hd4,/"]["kb_available"]).to eq("1877356")
         expect(@plugin[:filesystem2]["by_pair"]["/dev/hd4,/"]["kb_available"]).to eq("1877356")
       end
 
       it "returns the filesystem capacity in percentage" do
-        expect(@plugin[:filesystem]["/dev/hd4"]["percent_used"]).to eq("11%")
+        expect(@plugin[:filesystem]["by_pair"]["/dev/hd4,/"]["percent_used"]).to eq("11%")
         expect(@plugin[:filesystem2]["by_pair"]["/dev/hd4,/"]["percent_used"]).to eq("11%")
       end
 
       it "returns the filesystem mounted location" do
-        expect(@plugin[:filesystem]["/dev/hd4"]["mount"]).to eq("/")
+        expect(@plugin[:filesystem]["by_pair"]["/dev/hd4,/"]["mount"]).to eq("/")
         expect(@plugin[:filesystem2]["by_pair"]["/dev/hd4,/"]["mount"]).to eq("/")
       end
     end
@@ -128,17 +128,17 @@ describe Ohai::System, "AIX filesystem plugin" do
     describe "mount" do
 
       it "returns the filesystem mount location" do
-        expect(@plugin[:filesystem]["/dev/hd4"]["mount"]).to eq("/")
+        expect(@plugin[:filesystem]["by_pair"]["/dev/hd4,/"]["mount"]).to eq("/")
         expect(@plugin[:filesystem2]["by_pair"]["/dev/hd4,/"]["mount"]).to eq("/")
       end
 
       it "returns the filesystem type" do
-        expect(@plugin[:filesystem]["/dev/hd4"]["fs_type"]).to eq("jfs2")
+        expect(@plugin[:filesystem]["by_pair"]["/dev/hd4,/"]["fs_type"]).to eq("jfs2")
         expect(@plugin[:filesystem2]["by_pair"]["/dev/hd4,/"]["fs_type"]).to eq("jfs2")
       end
 
       it "returns the filesystem mount options" do
-        expect(@plugin[:filesystem]["/dev/hd4"]["mount_options"]).to eq(["rw", "log=/dev/hd8"])
+        expect(@plugin[:filesystem]["by_pair"]["/dev/hd4,/"]["mount_options"]).to eq(["rw", "log=/dev/hd8"])
         expect(@plugin[:filesystem2]["by_pair"]["/dev/hd4,/"]["mount_options"]).to eq(["rw", "log=/dev/hd8"])
       end
 
@@ -146,17 +146,17 @@ describe Ohai::System, "AIX filesystem plugin" do
       context "having node values" do
 
         it "returns the filesystem mount location" do
-          expect(@plugin[:filesystem]["192.168.1.11:/stage/middleware1"]["mount"]).to eq("/stage/middleware2")
+          expect(@plugin[:filesystem]["by_pair"]["192.168.1.11:/stage/middleware1,/stage/middleware2"]["mount"]).to eq("/stage/middleware2")
           expect(@plugin[:filesystem2]["by_pair"]["192.168.1.11:/stage/middleware1,/stage/middleware2"]["mount"]).to eq("/stage/middleware2")
         end
 
         it "returns the filesystem type" do
-          expect(@plugin[:filesystem]["192.168.1.11:/stage/middleware1"]["fs_type"]).to eq("nfs3")
+          expect(@plugin[:filesystem]["by_pair"]["192.168.1.11:/stage/middleware1,/stage/middleware2"]["fs_type"]).to eq("nfs3")
           expect(@plugin[:filesystem2]["by_pair"]["192.168.1.11:/stage/middleware1,/stage/middleware2"]["fs_type"]).to eq("nfs3")
         end
 
         it "returns the filesystem mount options" do
-          expect(@plugin[:filesystem]["192.168.1.11:/stage/middleware1"]["mount_options"]).to eq(["ro", "bg", "hard", "intr", "sec=sys"])
+          expect(@plugin[:filesystem]["by_pair"]["192.168.1.11:/stage/middleware1,/stage/middleware2"]["mount_options"]).to eq(["ro", "bg", "hard", "intr", "sec=sys"])
           expect(@plugin[:filesystem2]["by_pair"]["192.168.1.11:/stage/middleware1,/stage/middleware2"]["mount_options"]).to eq(["ro", "bg", "hard", "intr", "sec=sys"])
         end
       end
@@ -173,27 +173,27 @@ describe Ohai::System, "AIX filesystem plugin" do
     describe "df -Pk" do
 
       it "returns the filesystem block size" do
-        expect(@plugin[:filesystem]["Global:/"]["kb_size"]).to eq("10485760")
+        expect(@plugin[:filesystem]["by_pair"]["Global:/,/"]["kb_size"]).to eq("10485760")
         expect(@plugin[:filesystem2]["by_pair"]["Global:/,/"]["kb_size"]).to eq("10485760")
       end
 
       it "returns the filesystem used space in kb" do
-        expect(@plugin[:filesystem]["Global:/"]["kb_used"]).to eq("130872")
+        expect(@plugin[:filesystem]["by_pair"]["Global:/,/"]["kb_used"]).to eq("130872")
         expect(@plugin[:filesystem2]["by_pair"]["Global:/,/"]["kb_used"]).to eq("130872")
       end
 
       it "returns the filesystem available space in kb" do
-        expect(@plugin[:filesystem]["Global:/"]["kb_available"]).to eq("10354888")
+        expect(@plugin[:filesystem]["by_pair"]["Global:/,/"]["kb_available"]).to eq("10354888")
         expect(@plugin[:filesystem2]["by_pair"]["Global:/,/"]["kb_available"]).to eq("10354888")
       end
 
       it "returns the filesystem capacity in percentage" do
-        expect(@plugin[:filesystem]["Global:/"]["percent_used"]).to eq("2%")
+        expect(@plugin[:filesystem]["by_pair"]["Global:/,/"]["percent_used"]).to eq("2%")
         expect(@plugin[:filesystem2]["by_pair"]["Global:/,/"]["percent_used"]).to eq("2%")
       end
 
       it "returns the filesystem mounted location" do
-        expect(@plugin[:filesystem]["Global:/"]["mount"]).to eq("/")
+        expect(@plugin[:filesystem]["by_pair"]["Global:/,/"]["mount"]).to eq("/")
         expect(@plugin[:filesystem2]["by_pair"]["Global:/,/"]["mount"]).to eq("/")
       end
     end
@@ -201,17 +201,17 @@ describe Ohai::System, "AIX filesystem plugin" do
     describe "mount" do
 
       it "returns the filesystem mount location" do
-        expect(@plugin[:filesystem]["Global:/"]["mount"]).to eq("/")
+        expect(@plugin[:filesystem]["by_pair"]["Global:/,/"]["mount"]).to eq("/")
         expect(@plugin[:filesystem2]["by_pair"]["Global:/,/"]["mount"]).to eq("/")
       end
 
       it "returns the filesystem type" do
-        expect(@plugin[:filesystem]["Global:/"]["fs_type"]).to eq("jfs2")
+        expect(@plugin[:filesystem]["by_pair"]["Global:/,/"]["fs_type"]).to eq("jfs2")
         expect(@plugin[:filesystem2]["by_pair"]["Global:/,/"]["fs_type"]).to eq("jfs2")
       end
 
       it "returns the filesystem mount options" do
-        expect(@plugin[:filesystem]["Global:/"]["mount_options"]).to eq(["rw", "log=NULL"])
+        expect(@plugin[:filesystem]["by_pair"]["Global:/,/"]["mount_options"]).to eq(["rw", "log=NULL"])
         expect(@plugin[:filesystem2]["by_pair"]["Global:/,/"]["mount_options"]).to eq(["rw", "log=NULL"])
       end
 
@@ -219,17 +219,17 @@ describe Ohai::System, "AIX filesystem plugin" do
       context "having node values" do
 
         it "returns the filesystem mount location" do
-          expect(@plugin[:filesystem]["192.168.1.11:/stage/middleware3"]["mount"]).to eq("/stage/middleware4")
+          expect(@plugin[:filesystem]["by_pair"]["192.168.1.11:/stage/middleware3,/stage/middleware4"]["mount"]).to eq("/stage/middleware4")
           expect(@plugin[:filesystem2]["by_pair"]["192.168.1.11:/stage/middleware3,/stage/middleware4"]["mount"]).to eq("/stage/middleware4")
         end
 
         it "returns the filesystem type" do
-          expect(@plugin[:filesystem]["192.168.1.11:/stage/middleware3"]["fs_type"]).to eq("nfs3")
+          expect(@plugin[:filesystem]["by_pair"]["192.168.1.11:/stage/middleware3,/stage/middleware4"]["fs_type"]).to eq("nfs3")
           expect(@plugin[:filesystem2]["by_pair"]["192.168.1.11:/stage/middleware3,/stage/middleware4"]["fs_type"]).to eq("nfs3")
         end
 
         it "returns the filesystem mount options" do
-          expect(@plugin[:filesystem]["192.168.1.11:/stage/middleware3"]["mount_options"]).to eq(["ro", "bg", "hard", "intr", "sec=sys"])
+          expect(@plugin[:filesystem]["by_pair"]["192.168.1.11:/stage/middleware3,/stage/middleware4"]["mount_options"]).to eq(["ro", "bg", "hard", "intr", "sec=sys"])
           expect(@plugin[:filesystem2]["by_pair"]["192.168.1.11:/stage/middleware3,/stage/middleware4"]["mount_options"]).to eq(["ro", "bg", "hard", "intr", "sec=sys"])
         end
       end

--- a/spec/unit/plugins/bsd/filesystem_spec.rb
+++ b/spec/unit/plugins/bsd/filesystem_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Matthew Kent (<mkent@magoazul.com>)
 # Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: Copyright (c) 2011-2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2011-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,49 +55,49 @@ describe Ohai::System, "BSD filesystem plugin" do
 
     it "sets kb_size to value from df" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:kb_size]).to eq("9637788")
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:kb_size]).to eq("9637788")
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:kb_size]).to eq("9637788")
     end
 
     it "sets kb_used to value from df" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:kb_used]).to eq("3313504")
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:kb_used]).to eq("3313504")
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:kb_used]).to eq("3313504")
     end
 
     it "sets kb_available to value from df" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:kb_available]).to eq("5553264")
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:kb_available]).to eq("5553264")
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:kb_available]).to eq("5553264")
     end
 
     it "sets percent_used to value from df" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:percent_used]).to eq("37%")
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:percent_used]).to eq("37%")
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:percent_used]).to eq("37%")
     end
 
     it "sets mount to value from df" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:mount]).to eq("/")
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:mount]).to eq("/")
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:mount]).to eq("/")
     end
 
     it "sets total_inodes to value from df -iP" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:total_inodes]).to eq("1043326")
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:total_inodes]).to eq("1043326")
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:total_inodes]).to eq("1043326")
     end
 
     it "sets inodes_used to value from df -iP" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:inodes_used]).to eq("252576")
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:inodes_used]).to eq("252576")
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:inodes_used]).to eq("252576")
     end
 
     it "sets inodes_available to value from df -iP" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:inodes_available]).to eq("790750")
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:inodes_available]).to eq("790750")
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:inodes_available]).to eq("790750")
     end
   end
@@ -118,19 +118,19 @@ describe Ohai::System, "BSD filesystem plugin" do
 
     it "sets mount to value from mount" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:mount]).to eq("/")
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:mount]).to eq("/")
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:mount]).to eq("/")
     end
 
     it "sets fs_type to value from mount" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:fs_type]).to eq("ufs")
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:fs_type]).to eq("ufs")
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:fs_type]).to eq("ufs")
     end
 
     it "sets mount_options to an array of values from mount" do
       plugin.run
-      expect(plugin[:filesystem]["/dev/ada0p2"][:mount_options]).to eq(["local", "journaled soft-updates"])
+      expect(plugin[:filesystem]["by_pair"]["/dev/ada0p2,/"][:mount_options]).to eq(["local", "journaled soft-updates"])
       expect(plugin[:filesystem2]["by_pair"]["/dev/ada0p2,/"][:mount_options]).to eq(["local", "journaled soft-updates"])
     end
   end


### PR DESCRIPTION
We added filesystem2 plugin data mid way through the Chef 14 release
cycle. This converts the filesystem plugin to write data in the
filesystem2 format. In Chef 17 we'll remove those filesystem2 namespaces
and just write the data out in the filesystem2 format.

Signed-off-by: Tim Smith <tsmith@chef.io>