### PR TITLE
Support more than 10 interfaces

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -295,7 +295,7 @@ Ohai.plugin(:Network) do
     if line =~ IPROUTE_INT_REGEX
       cint = $2
       iface[cint] = Mash.new
-      if cint =~ /^(\w+)(\d+.*)/
+      if cint =~ /^(\w+?)(\d+.*)/
         iface[cint][:type] = $1
         iface[cint][:number] = $2
       end
@@ -598,7 +598,7 @@ Ohai.plugin(:Network) do
         if line =~ /^([0-9a-zA-Z@\.\:\-_]+)\s+/
           cint = $1
           iface[cint] = Mash.new
-          if cint =~ /^(\w+)(\d+.*)/
+          if cint =~ /^(\w+?)(\d+.*)/
             iface[cint][:type] = $1
             iface[cint][:number] = $2
           end


### PR DESCRIPTION
## Description
If you have more than 10 interfaces, `eth10` ended up at `:type => eth1` and `:number => 0`. This fixes it on our test host.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
