### PR TITLE
Minor testing updates

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -50,4 +50,4 @@ else
 fi
 
 echo "+++ bundle exec task"
-bundle exec $1
+bundle exec $@

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,3 @@ Layout/Tab:
   Exclude:
     - "lib/ohai/plugins/mono.rb"
     - "lib/ohai/plugins/darwin/hardware.rb"
-
-# this can cause failures that we need to look at one by one
-Performance/RegexpMatch:
-  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,6 @@ group :development do
   gem "ipaddr_extensions"
 end
 
-group :ci do
-  gem "rspec_junit_formatter"
-end
-
 group :docs do
   gem "yard"
   gem "redcarpet"


### PR DESCRIPTION
Update the buildkite script to pass vars correctly
Remove the CI group in the gemfile, which isn't being used anywhere
Remove the legacy Performance/RegexpMatch cop from .rubocop.yml since the Performance cops are in rubocop (or Chefstyle) anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>