### PR TITLE
use bool instead of raise/rescue to detect linux user is exists

### DIFF
--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -51,7 +51,7 @@ Ohai.plugin(:Openstack) do
     # dream host doesn't support windows so bail early if we're on windows
     return "openstack" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
 
-    if Etc::Passwd.map{|a| a.name}.include?("dhc-user")
+    if Etc::Passwd.map(&:name).include?("dhc-user")
       "dreamhost"
     else
       "openstack"

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -51,11 +51,11 @@ Ohai.plugin(:Openstack) do
     # dream host doesn't support windows so bail early if we're on windows
     return "openstack" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
 
-    if Etc.getpwnam("dhc-user")
+    if Etc::Passwd.map{|a| a.name}.include?("dhc-user")
       "dreamhost"
+    else
+      "openstack"
     end
-  rescue ArgumentError # getpwnam raises ArgumentError if the user is not found
-    "openstack"
   end
 
   collect_data do

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -51,7 +51,7 @@ Ohai.plugin(:Openstack) do
     # dream host doesn't support windows so bail early if we're on windows
     return "openstack" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
 
-    if Etc::Passwd.map(&:name).include?("dhc-user")
+    if Etc::Passwd.entries.map(&:name).include?("dhc-user")
       "dreamhost"
     else
       "openstack"

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -63,7 +63,6 @@ describe Ohai::System, "plugin openstack" do
         .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
         .and_return(false)
       plugin[:virtualization] = { systems: { openstack: "guest" } }
-      # expect(Etc).to receive(:getpwnam).and_return(PasswdEntry.new("dhc-user", 800, 800, "/var/www", "/bin/false", "The dreamhost user"))
       expect(Etc::Passwd).to receive(:entries).and_return([PasswdEntry.new("dhc-user", 800, 800, "/var/www", "/bin/false", "The dreamhost user")])
       plugin.run
       expect(plugin[:openstack][:provider]).to eq("dreamhost")

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -43,7 +43,6 @@ describe Ohai::System, "plugin openstack" do
           .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
           .and_return(false)
         plugin[:virtualization] = { systems: { openstack: "guest" } }
-        expect(Etc).to receive(:getpwnam).and_raise(ArgumentError)
         plugin.run
       end
 
@@ -64,7 +63,8 @@ describe Ohai::System, "plugin openstack" do
         .with(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80, default_timeout)
         .and_return(false)
       plugin[:virtualization] = { systems: { openstack: "guest" } }
-      expect(Etc).to receive(:getpwnam).and_return(PasswdEntry.new("dhc-user", 800, 800, "/var/www", "/bin/false", "The dreamhost user"))
+      # expect(Etc).to receive(:getpwnam).and_return(PasswdEntry.new("dhc-user", 800, 800, "/var/www", "/bin/false", "The dreamhost user"))
+      expect(Etc::Passwd).to receive(:entries).and_return([PasswdEntry.new("dhc-user", 800, 800, "/var/www", "/bin/false", "The dreamhost user")])
       plugin.run
       expect(plugin[:openstack][:provider]).to eq("dreamhost")
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

For problem #1433 , I don't know the cause, but it is a segmentation fault. This change worked.

Once this change is allowed, I'd like to make a backport PR for 15 branches as well.

## Related Issue

- #1433 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
