### PR TITLE
Drop unneeded require in ec2 plugin

### DIFF
--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -27,11 +27,9 @@
 
 Ohai.plugin(:EC2) do
   require_relative "../mixin/ec2_metadata"
-  require_relative "../mixin/http_helper"
   require "base64"
 
   include Ohai::Mixin::Ec2Metadata
-  include Ohai::Mixin::HttpHelper
 
   provides "ec2"
 


### PR DESCRIPTION
Signed-off-by: Davide Cavalca <dcavalca@fb.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
The ec2 plugin requires `http_helper`, but it doesn't seem to actually use it anywhere, so we might as well drop it. This caused issues for us while backporting this plugin to an older Chef version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
