### PR TITLE
Add a new ipc plugin for Linux

### DIFF
--- a/lib/ohai/plugins/linux/ipc.rb
+++ b/lib/ohai/plugins/linux/ipc.rb
@@ -17,32 +17,32 @@
 #
 
 Ohai.plugin(:IPC) do
-  provides 'ipc'
+  provides "ipc"
 
   collect_data(:linux) do
-    ipcs_path = which('ipcs')
+    ipcs_path = which("ipcs")
     if ipcs_path
       # NOTE: currently only supports shared memory
       cmd = "#{ipcs_path} -m"
       ipcs = shell_out(cmd)
 
       ipc Mash.new unless ipc
-      ipc['shm'] = Mash.new unless ipc['shm']
+      ipc["shm"] = Mash.new unless ipc["shm"]
 
       ipcs.stdout.split("\n").each do |line|
-        next unless line.start_with?('0x')
+        next unless line.start_with?("0x")
 
         parts = line.split
         segment = {
-          'key' => parts[0],
-          'owner' => parts[2],
-          'perms' => parts[3],
-          'bytes' => parts[4].to_i,
-          'nattch' => parts[5].to_i,
-          'status' => parts[6] ? parts[6] : '',
+          "key" => parts[0],
+          "owner" => parts[2],
+          "perms" => parts[3],
+          "bytes" => parts[4].to_i,
+          "nattch" => parts[5].to_i,
+          "status" => parts[6] ? parts[6] : "",
         }
 
-        ipc['shm'][parts[1].to_i] = segment
+        ipc["shm"][parts[1].to_i] = segment
       end
     end
   end

--- a/lib/ohai/plugins/linux/ipc.rb
+++ b/lib/ohai/plugins/linux/ipc.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Jay Vana <jsvana@fb.com>
-# Copyright:: Copyright (c) 2016 Facebook, Inc.
+# Author:: Davide Cavalca <dcavalca@fb.com>
+# Copyright:: Copyright (c) 2016-2020 Facebook, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +19,7 @@
 
 Ohai.plugin(:IPC) do
   provides "ipc"
+  optional true
 
   collect_data(:linux) do
     ipcs_path = which("ipcs")

--- a/lib/ohai/plugins/linux/ipc.rb
+++ b/lib/ohai/plugins/linux/ipc.rb
@@ -1,0 +1,49 @@
+#
+# Author:: Jay Vana <jsvana@fb.com>
+# Copyright:: Copyright (c) 2016 Facebook, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:IPC) do
+  provides 'ipc'
+
+  collect_data(:linux) do
+    ipcs_path = which('ipcs')
+    if ipcs_path
+      # NOTE: currently only supports shared memory
+      cmd = "#{ipcs_path} -m"
+      ipcs = shell_out(cmd)
+
+      ipc Mash.new unless ipc
+      ipc['shm'] = Mash.new unless ipc['shm']
+
+      ipcs.stdout.split("\n").each do |line|
+        next unless line.start_with?('0x')
+
+        parts = line.split
+        segment = {
+          'key' => parts[0],
+          'owner' => parts[2],
+          'perms' => parts[3],
+          'bytes' => parts[4].to_i,
+          'nattch' => parts[5].to_i,
+          'status' => parts[6] ? parts[6] : '',
+        }
+
+        ipc['shm'][parts[1].to_i] = segment
+      end
+    end
+  end
+end

--- a/spec/unit/plugins/linux/ipc_spec.rb
+++ b/spec/unit/plugins/linux/ipc_spec.rb
@@ -1,0 +1,85 @@
+#
+# Author:: Davide Cavalca <dcavalca@fb.com>
+# Copyright:: Copyright (c) 2020 Facebook
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Ohai::System, "Linux ipc plugin" do
+  let(:plugin) { get_plugin("linux/ipc") }
+
+  before do
+    allow(plugin).to receive(:collect_os).and_return(:linux)
+  end
+
+  it "populates ipc if ipcs is available" do
+    ipcs_out = <<-IPCS_OUT
+
+------ Shared Memory Segments --------
+key        shmid      owner      perms      bytes      nattch     status      
+0x00000000 131072     dcavalca   600        524288     2          dest         
+0x00000000 38993921   dcavalca   600        393216     2          dest         
+0x00000000 39092226   dcavalca   600        524288     2          dest         
+0x00000000 9437188    dcavalca   600        524288     2          dest         
+
+    IPCS_OUT
+
+    allow(plugin).to receive(:which).with("ipcs").and_return("/bin/ipcs")
+    allow(plugin).to receive(:shell_out).with("/bin/ipcs -m").and_return(mock_shell_out(0, ipcs_out, ""))
+    plugin.run
+    expect(plugin[:ipc].to_hash).to eq({
+      "shm" => {
+        131072 => {
+          "bytes" => 524288,
+          "key" => "0x00000000",
+          "nattch" => 2,
+          "owner" => "dcavalca",
+          "perms" => "600",
+          "status" => "dest",
+        },
+        38993921 => {
+          "bytes" => 393216,
+          "key" => "0x00000000",
+          "nattch" => 2,
+          "owner" => "dcavalca",
+          "perms" => "600",
+          "status" => "dest",
+        },
+        39092226 => {
+          "bytes" => 524288,
+          "key" => "0x00000000",
+          "nattch" => 2,
+          "owner" => "dcavalca",
+          "perms" => "600",
+          "status" => "dest",
+        },
+        9437188 => {
+          "bytes" => 524288,
+          "key" => "0x00000000",
+          "nattch" => 2,
+          "owner" => "dcavalca",
+          "perms" => "600",
+          "status" => "dest",
+        },
+      },
+    })
+  end
+
+  it "does not populate ipc if ipcs is not available" do
+    allow(plugin).to receive(:which).with("ipcs").and_return(false)
+    expect(plugin[:ipc]).to eq(nil)
+  end
+end

--- a/spec/unit/plugins/linux/ipc_spec.rb
+++ b/spec/unit/plugins/linux/ipc_spec.rb
@@ -29,11 +29,11 @@ describe Ohai::System, "Linux ipc plugin" do
     ipcs_out = <<-IPCS_OUT
 
 ------ Shared Memory Segments --------
-key        shmid      owner      perms      bytes      nattch     status      
-0x00000000 131072     dcavalca   600        524288     2          dest         
-0x00000000 38993921   dcavalca   600        393216     2          dest         
-0x00000000 39092226   dcavalca   600        524288     2          dest         
-0x00000000 9437188    dcavalca   600        524288     2          dest         
+key        shmid      owner      perms      bytes      nattch     status
+0x00000000 131072     dcavalca   600        524288     2          dest
+0x00000000 38993921   dcavalca   600        393216     2          dest
+0x00000000 39092226   dcavalca   600        524288     2          dest
+0x00000000 9437188    dcavalca   600        524288     2          dest
 
     IPCS_OUT
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Add a basic plugin to expose SysV IPC shmem information. This could be easily extended to cover other SysV IPC types as well. This plugin was originally written by @jsvana in 2016.

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
