### PR TITLE
Fix test failure from missing require.

### DIFF
--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -23,6 +23,8 @@
 # limitations under the License.
 #
 
+require "set"
+
 Ohai.plugin(:Filesystem) do
   provides "filesystem"
 


### PR DESCRIPTION
## Description
Running the tests in a Windows 2019 vm I saw several failures like this:

```
  1) Ohai::System Windows Filesystem Plugin the plugin when there are no volume names returns space information
     Failure/Error: encryption_keys_used = Set.new

     NameError:
       uninitialized constant Set
       Did you mean?  Net
     # ./lib/ohai/plugins/filesystem.rb:266:in `merge_info'
     # ./lib/ohai/plugins/filesystem.rb:722:in `block (2 levels) in <main>'
     # //vboxsvr/vagrant/lib/ohai/dsl/plugin/versionvii.rb:126:in `instance_eval'
     # //vboxsvr/vagrant/lib/ohai/dsl/plugin/versionvii.rb:126:in `run_plugin'
     # //vboxsvr/vagrant/lib/ohai/dsl/plugin.rb:107:in `run'
     # ./spec/unit/plugins/windows/filesystem_spec.rb:82:in `block (4 levels) in <top (required)>'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
