### PR TITLE
Use correct DMI attribute name for product name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - "pkg/**/*"
 
 # these have shellout examples that need to have the tabs that come with the shellout
-Layout/Tab:
+Layout/IndentationStyle:
   Exclude:
     - "lib/ohai/plugins/mono.rb"
     - "lib/ohai/plugins/darwin/hardware.rb"

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -118,8 +118,8 @@ Ohai.plugin(:Virtualization) do
 
     # parse dmi to discover various virtualization guests
     # we do this *after* the kvm detection so that OpenStack isn't detected as KVM
-    logger.trace("Looking up DMI data manufacturer: '#{get_attribute(:dmi, :system, :manufacturer)}' product: '#{get_attribute(:dmi, :system, :product)}' version: '#{get_attribute(:dmi, :system, :version)}'")
-    guest = guest_from_dmi_data(get_attribute(:dmi, :system, :manufacturer), get_attribute(:dmi, :system, :product), get_attribute(:dmi, :system, :version))
+    logger.trace("Looking up DMI data manufacturer: '#{get_attribute(:dmi, :system, :manufacturer)}' product_name: '#{get_attribute(:dmi, :system, :product_name)}' version: '#{get_attribute(:dmi, :system, :version)}'")
+    guest = guest_from_dmi_data(get_attribute(:dmi, :system, :manufacturer), get_attribute(:dmi, :system, :product_name), get_attribute(:dmi, :system, :version))
     if guest
       logger.trace("Plugin Virtualization: DMI data indicates #{guest} guest")
       virtualization[:system] = guest

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -190,7 +190,7 @@ describe Ohai::System, "Linux virtualization platform" do
     it "sets virtualization attributes if the appropriate DMI data is present" do
       plugin[:dmi] = { system: {
                                   manufacturer: "Amazon EC2",
-                                  product: "c5n.large",
+                                  product_name: "c5n.large",
                                   version: nil,
                                },
                      }
@@ -203,7 +203,7 @@ describe Ohai::System, "Linux virtualization platform" do
     it "sets empty virtualization attributes if nothing is detected" do
       plugin[:dmi] = { system: {
                                   manufacturer: "Supermicro",
-                                  product: "X10SLH-N6-ST031",
+                                  product_name: "X10SLH-N6-ST031",
                                   version: "0123456789",
                                },
                      }


### PR DESCRIPTION
I discovered that ohai was incorrectly detecting our OpenStack guests showing
the following output:
```json
{
  "systems": {

  }
}
```
With this change, it correctly shows the following output:
```json
{
  "systems": {
    "openstack": "guest"
  },
  "system": "openstack",
  "role": "guest"
}
```
The problem was the fact that ``dmi/system/product`` was the incorrect attribute and
should be ``dmi/system/product_name`` instead.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
