### PR TITLE
Make shard plugin more resilient and throw better errors

### DIFF
--- a/lib/ohai/plugins/shard.rb
+++ b/lib/ohai/plugins/shard.rb
@@ -22,10 +22,12 @@ Ohai.plugin(:ShardSeed) do
 
   def get_dmi_property(dmi, thing)
     %w{system base_board chassis}.each do |section|
-      unless dmi[section][thing].strip.empty?
+      if dmi[section] && dmi[section][thing] && !dmi[section][thing].strip.empty?
         return dmi[section][thing]
       end
     end
+    Ohai::Log.error("shard_seed: Failed to get dmi property #{thing}: is dmidecode installed?")
+    raise "Failed to generate shard_seed"
   end
 
   def default_sources
@@ -77,11 +79,16 @@ Ohai.plugin(:ShardSeed) do
                 yield(src)
               end
     end
+    if data.empty?
+      Ohai::Log.error("shard_seed: Unable to generate seed! Either ensure 'dmidecode' is installed, or use 'Ohai.config[:plugin][:shard_seed][:sources]' to set different sources.")
+      raise "Failed to generate shard_seed"
+    end
     shard_seed digest_algorithm.hexdigest(data)[0...7].to_i(16)
   end
 
   collect_data do
     create_seed do |src|
+      Ohai::Log.error("shard_seed: No such source #{src}")
       raise "No such shard_seed source: #{src}"
     end
   end
@@ -99,6 +106,7 @@ Ohai.plugin(:ShardSeed) do
       when :uuid
         wmi.first_of("Win32_ComputerSystemProduct")["UUID"]
       else
+        Ohai::Log.error("shard_seed: No such source #{src}")
         raise "No such shard_seed source: #{src}"
       end
     end
@@ -112,6 +120,7 @@ Ohai.plugin(:ShardSeed) do
       when :uuid
         hardware["platform_UUID"]
       else
+        Ohai::Log.error("shard_seed: No such source #{src}")
         raise "No such shard_seed source: #{src}"
       end
     end
@@ -125,6 +134,7 @@ Ohai.plugin(:ShardSeed) do
       when :uuid
         get_dmi_property(dmi, :uuid)
       else
+        Ohai::Log.error("shard_seed: No such source #{src}")
         raise "No such shard_seed source: #{src}"
       end
     end

--- a/spec/unit/plugins/shard_spec.rb
+++ b/spec/unit/plugins/shard_spec.rb
@@ -54,8 +54,9 @@ describe Ohai::System, "shard plugin" do
     expect(subject).to eq(203669792)
   end
 
-  it "fails on an unrecognized source" do
+  it "logs and fails on an unrecognized source" do
     Ohai.config[:plugin][:shard_seed][:sources] = [:GreatGooglyMoogly]
+    expect(Ohai::Log).to receive(:error).with(/No such source/)
     expect { subject }.to raise_error(RuntimeError)
   end
 
@@ -64,6 +65,20 @@ describe Ohai::System, "shard plugin" do
     expect(Digest::MD5).not_to receive(:new)
     expect(subject).to eq(117055036)
   end
+
+  it "logs and fails when dmidecode data is not available" do
+    plugin["dmi"] = {}
+    expect(Ohai::Log).to receive(:error).with(/Failed to get dmi/)
+    expect { subject }.to raise_error(RuntimeError)
+  end
+
+  it "logs and fails when no data sources were available" do
+    Ohai.config[:plugin][:shard_seed][:sources] = [:fqdn]
+    plugin["fqdn"] = ""
+    expect(Ohai::Log).to receive(:error).with(/Unable to generate seed/)
+    expect { subject }.to raise_error(RuntimeError)
+  end
+
 
   context "with Darwin OS" do
     let(:os) { "darwin" }


### PR DESCRIPTION
* Catch a variety of problems and Ohai::Log.error about them. Since this
  is an optional plugin, if we're hitting these, someone specifically
  requested this plugin, so an error is warranted.
* We raise anyway, so that you don't spew further errors

Fixes #1385

Signed-off-by: Phil Dibowitz <phil@ipom.com>