### PR TITLE
Use correct DMI attribute name for product name to fix Openstack detection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,7 @@ AllCops:
     - "pkg/**/*"
 
 # these have shellout examples that need to have the tabs that come with the shellout
-Layout/Tab:
+Layout/IndentationStyle:
   Exclude:
     - "lib/ohai/plugins/mono.rb"
     - "lib/ohai/plugins/darwin/hardware.rb"
-
-# this can cause failures that we need to look at one by one
-Performance/RegexpMatch:
-  Enabled: false

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -118,8 +118,8 @@ Ohai.plugin(:Virtualization) do
 
     # parse dmi to discover various virtualization guests
     # we do this *after* the kvm detection so that OpenStack isn't detected as KVM
-    logger.trace("Looking up DMI data manufacturer: '#{get_attribute(:dmi, :system, :manufacturer)}' product: '#{get_attribute(:dmi, :system, :product)}' version: '#{get_attribute(:dmi, :system, :version)}'")
-    guest = guest_from_dmi_data(get_attribute(:dmi, :system, :manufacturer), get_attribute(:dmi, :system, :product), get_attribute(:dmi, :system, :version))
+    logger.trace("Looking up DMI data manufacturer: '#{get_attribute(:dmi, :system, :manufacturer)}' product_name: '#{get_attribute(:dmi, :system, :product_name)}' version: '#{get_attribute(:dmi, :system, :version)}'")
+    guest = guest_from_dmi_data(get_attribute(:dmi, :system, :manufacturer), get_attribute(:dmi, :system, :product_name), get_attribute(:dmi, :system, :version))
     if guest
       logger.trace("Plugin Virtualization: DMI data indicates #{guest} guest")
       virtualization[:system] = guest

--- a/spec/unit/plugins/linux/virtualization_spec.rb
+++ b/spec/unit/plugins/linux/virtualization_spec.rb
@@ -190,7 +190,7 @@ describe Ohai::System, "Linux virtualization platform" do
     it "sets virtualization attributes if the appropriate DMI data is present" do
       plugin[:dmi] = { system: {
                                   manufacturer: "Amazon EC2",
-                                  product: "c5n.large",
+                                  product_name: "c5n.large",
                                   version: nil,
                                },
                      }
@@ -203,7 +203,7 @@ describe Ohai::System, "Linux virtualization platform" do
     it "sets empty virtualization attributes if nothing is detected" do
       plugin[:dmi] = { system: {
                                   manufacturer: "Supermicro",
-                                  product: "X10SLH-N6-ST031",
+                                  product_name: "X10SLH-N6-ST031",
                                   version: "0123456789",
                                },
                      }


### PR DESCRIPTION
Backport from master