### PR TITLE
Add new selinux plugin for Linux

### DIFF
--- a/lib/ohai/plugins/linux/selinux.rb
+++ b/lib/ohai/plugins/linux/selinux.rb
@@ -51,8 +51,9 @@ Ohai.plugin(:Selinux) do
           end
         end
 
-        key, val = line.split(%r{:?\s\s+}, 2)
+        key, val = line.split(/:?\s\s+/, 2)
         next if key.nil?
+
         unless key.start_with?("/")
           key.downcase!
           key.tr!(" ", "_")

--- a/lib/ohai/plugins/linux/selinux.rb
+++ b/lib/ohai/plugins/linux/selinux.rb
@@ -62,7 +62,7 @@ Ohai.plugin(:Selinux) do
         selinux[section][key] = val
       end
     else
-      logger.trace("Plugin Selinux: Could not find sestatus. Skipping plugin.")
+      logger.debug("Plugin Selinux: Could not find sestatus. Skipping plugin.")
     end
   end
 end

--- a/lib/ohai/plugins/linux/selinux.rb
+++ b/lib/ohai/plugins/linux/selinux.rb
@@ -1,0 +1,67 @@
+#
+# Author:: Davide Cavalca <dcavalca@fb.com>
+# Copyright:: Copyright (c) 2020 Facebook
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:Selinux) do
+  provides "selinux/status", "selinux/policy_booleans", "selinux/process_contexts", "selinux/file_contexts"
+  optional true
+
+  collect_data(:linux) do
+    sestatus_path = which("sestatus")
+    if sestatus_path
+      sestatus = shell_out("#{sestatus_path} -v -b")
+
+      selinux Mash.new unless selinux
+      selinux[:status] ||= Mash.new
+      selinux[:policy_booleans] ||= Mash.new
+      selinux[:process_contexts] ||= Mash.new
+      selinux[:file_contexts] ||= Mash.new
+      section = nil
+
+      sestatus.stdout.split("\n").each do |line|
+        line.chomp!
+
+        case line
+        when "Policy booleans:"
+          section = :policy_booleans
+          next
+        when "Process contexts:"
+          section = :process_contexts
+          next
+        when "File contexts:"
+          section = :file_contexts
+          next
+        else
+          if section.nil?
+            section = :status
+          end
+        end
+
+        key, val = line.split(%r{:?\s\s+}, 2)
+        next if key.nil?
+        unless key.start_with?("/")
+          key.downcase!
+          key.tr!(" ", "_")
+        end
+
+        selinux[section][key] = val
+      end
+    else
+      logger.trace("Plugin Selinux: Could not find sestatus. Skipping plugin.")
+    end
+  end
+end

--- a/spec/unit/plugins/linux/selinux_spec.rb
+++ b/spec/unit/plugins/linux/selinux_spec.rb
@@ -69,7 +69,7 @@ Controlling terminal:           system_u:object_r:file_t
          "/sbin/agetty" => "user_u:object_r:file_t",
          "/sbin/init" => "user_u:object_r:file_t -> user_u:object_r:init_exec_t",
          "/usr/sbin/sshd" => "user_u:object_r:file_t",
-         "controlling_terminal" => "system_u:object_r:file_t"
+         "controlling_terminal" => "system_u:object_r:file_t",
        },
        "policy_booleans" => {
          "secure_mode_policyload" => "off",
@@ -77,7 +77,7 @@ Controlling terminal:           system_u:object_r:file_t
        "process_contexts" => {
          "/usr/sbin/sshd" => "system_u:base_r:base_t",
          "current_context" => "user_u:base_r:admin_t",
-         "init_context" => "system_u:system_r:init_t"
+         "init_context" => "system_u:system_r:init_t",
        },
        "status" => {
          "current_mode" => "permissive",

--- a/spec/unit/plugins/linux/selinux_spec.rb
+++ b/spec/unit/plugins/linux/selinux_spec.rb
@@ -1,0 +1,101 @@
+#
+# Author:: Davide Cavalca <dcavalca@fb.com>
+# Copyright:: Copyright (c) 2020 Facebook
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Ohai::System, "Linux selinux plugin" do
+  let(:plugin) { get_plugin("linux/selinux") }
+
+  before do
+    allow(plugin).to receive(:collect_os).and_return(:linux)
+  end
+
+  it "populates selinux if sestatus is found" do
+    sestatus_out = <<-SESTATUS_OUT
+SELinux status:                 enabled
+SELinuxfs mount:                /sys/fs/selinux
+SELinux root directory:         /etc/selinux
+Loaded policy name:             test
+Current mode:                   permissive
+Mode from config file:          permissive
+Policy MLS status:              disabled
+Policy deny_unknown status:     allowed
+Max kernel policy version:      31
+
+Policy booleans:
+secure_mode_policyload          off
+
+Process contexts:
+Current context:                user_u:base_r:admin_t
+Init context:                   system_u:system_r:init_t
+/usr/sbin/sshd                  system_u:base_r:base_t
+
+File contexts:
+Controlling terminal:           system_u:object_r:file_t
+/etc/passwd                     user_u:object_r:file_t
+/etc/shadow                     user_u:object_r:file_t
+/bin/bash                       user_u:object_r:file_t
+/bin/login                      user_u:object_r:file_t
+/bin/sh                         user_u:object_r:file_t -> user_u:object_r:file_t
+/sbin/agetty                    user_u:object_r:file_t
+/sbin/init                      user_u:object_r:file_t -> user_u:object_r:init_exec_t
+/usr/sbin/sshd                  user_u:object_r:file_t
+    SESTATUS_OUT
+    allow(plugin).to receive(:which).with("sestatus").and_return("/usr/sbin/sestatus")
+    allow(plugin).to receive(:shell_out).with("/usr/sbin/sestatus -v -b").and_return(mock_shell_out(0, sestatus_out, ""))
+    plugin.run
+    expect(plugin[:selinux].to_hash).to eq({
+       "file_contexts" => {
+         "/bin/bash" => "user_u:object_r:file_t",
+         "/bin/login" => "user_u:object_r:file_t",
+         "/bin/sh" => "user_u:object_r:file_t -> user_u:object_r:file_t",
+         "/etc/passwd" => "user_u:object_r:file_t",
+         "/etc/shadow" => "user_u:object_r:file_t",
+         "/sbin/agetty" => "user_u:object_r:file_t",
+         "/sbin/init" => "user_u:object_r:file_t -> user_u:object_r:init_exec_t",
+         "/usr/sbin/sshd" => "user_u:object_r:file_t",
+         "controlling_terminal" => "system_u:object_r:file_t"
+       },
+       "policy_booleans" => {
+         "secure_mode_policyload" => "off",
+       },
+       "process_contexts" => {
+         "/usr/sbin/sshd" => "system_u:base_r:base_t",
+         "current_context" => "user_u:base_r:admin_t",
+         "init_context" => "system_u:system_r:init_t"
+       },
+       "status" => {
+         "current_mode" => "permissive",
+         "loaded_policy_name" => "test",
+         "max_kernel_policy_version" => "31",
+         "mode_from_config_file" => "permissive",
+         "policy_deny_unknown_status" => "allowed",
+         "policy_mls_status" => "disabled",
+         "selinux_root_directory" => "/etc/selinux",
+         "selinux_status" => "enabled",
+         "selinuxfs_mount" => "/sys/fs/selinux",
+      },
+    })
+  end
+
+  it "does not populate selinux if sestatus is not found" do
+    allow(plugin).to receive(:which).with("sestatus").and_return(false)
+    plugin.run
+    expect(plugin[:selinux]).to be(nil)
+  end
+end


### PR DESCRIPTION
## Description
Add a basic plugin to expose SELinux status information. FYI, I have very little experience with SELinux and I'm definitely open for better ways to do this. We mostly need this for `current_mode` and `loaded_policy_name`, but I figured covering everything reported by `sestatus` could be useful.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
