### PR TITLE
Avoid constant warnings when reloading ohai plugins

### DIFF
--- a/lib/ohai/plugins/windows/dmi.rb
+++ b/lib/ohai/plugins/windows/dmi.rb
@@ -20,7 +20,7 @@ Ohai.plugin(:DMI) do
   provides "dmi"
 
   # Map the linux component types to their rough Windows API equivalents
-  DMI_TO_WIN32OLE = {
+  DMI_TO_WIN32OLE ||= {
     chassis: "SystemEnclosure",
     processor: "Processor",
     bios: "Bios",
@@ -36,9 +36,9 @@ Ohai.plugin(:DMI) do
   #
   # This cannot handle some property names, eg SMBIOSBIOSVersion.
   # https://rubular.com/r/FBNtXod4wkZGAG
-  SPLIT_REGEX = /[A-Z][a-z0-9]+|[A-Z]{2,}(?=[A-Z][a-z0-9])|[A-Z]{2,}/.freeze
+  SPLIT_REGEX ||= /[A-Z][a-z0-9]+|[A-Z]{2,}(?=[A-Z][a-z0-9])|[A-Z]{2,}/.freeze
 
-  WINDOWS_TO_UNIX_KEYS = [
+  WINDOWS_TO_UNIX_KEYS ||= [
     %w{vendor manufacturer},
     %w{identifying_number serial_number},
     %w{name family},


### PR DESCRIPTION
```
/opt/chef/embedded/lib/ruby/gems/2.7.0/gems/ohai-16.0.19/lib/ohai/plugins/windows/dmi.rb:23: warning: previous definition of DMI_TO_WIN32OLE was here
/opt/chef/embedded/lib/ruby/gems/2.7.0/gems/ohai-16.0.19/lib/ohai/plugins/windows/dmi.rb:39: warning: already initialized constant SPLIT_REGEX
/opt/chef/embedded/lib/ruby/gems/2.7.0/gems/ohai-16.0.19/lib/ohai/plugins/windows/dmi.rb:39: warning: previous definition of SPLIT_REGEX was here
/opt/chef/embedded/lib/ruby/gems/2.7.0/gems/ohai-16.0.19/lib/ohai/plugins/windows/dmi.rb:41: warning: already initialized constant WINDOWS_TO_UNIX_KEYS
/opt/chef/embedded/lib/ruby/gems/2.7.0/gems/ohai-16.0.19/lib/ohai/plugins/windows/dmi.rb:41: warning: previous definition of WINDOWS_TO_UNIX_KEYS was here
```

Signed-off-by: Tim Smith <tsmith@chef.io>