### PR TITLE
Make sure Darwin hosts are always mac_os_x

### DIFF
--- a/lib/ohai/plugins/darwin/hardware.rb
+++ b/lib/ohai/plugins/darwin/hardware.rb
@@ -41,8 +41,8 @@ Ohai.plugin(:Hardware) do
     hardware.merge!(hw_hash[0]["_items"][0])
 
     # ProductName:	Mac OS X
-    # ProductVersion:	10.12.5
-    # BuildVersion:	16F73
+    # ProductVersion:	10.15.6
+    # BuildVersion:	19G46c
     shell_out("sw_vers").stdout.lines.each do |line|
       case line
       when /^ProductName:\s*(.*)$/

--- a/lib/ohai/plugins/darwin/platform.rb
+++ b/lib/ohai/plugins/darwin/platform.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,11 +23,6 @@ Ohai.plugin(:Platform) do
     so = shell_out((Ohai.abs_path( "/usr/bin/sw_vers" )).to_s)
     so.stdout.lines do |line|
       case line
-      when /^ProductName:\s+(.+)$/
-        macname = $1
-        macname.downcase!
-        macname.tr!(" ", "_")
-        platform macname
       when /^ProductVersion:\s+(.+)$/
         platform_version $1
       when /^BuildVersion:\s+(.+)$/
@@ -35,6 +30,8 @@ Ohai.plugin(:Platform) do
       end
     end
 
+    # if we're on darwin assume we're on mac_os_x
+    platform "mac_os_x"
     platform_family "mac_os_x"
   end
 end

--- a/spec/unit/plugins/darwin/platform_spec.rb
+++ b/spec/unit/plugins/darwin/platform_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright (c) 2008-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ describe Ohai::System, "Darwin plugin platform" do
   before do
     @plugin = get_plugin("darwin/platform")
     allow(@plugin).to receive(:collect_os).and_return(:darwin)
-    @stdout = "ProductName:	Mac OS X\nProductVersion:	10.5.5\nBuildVersion:	9F33"
+    @stdout = "ProductName:	Mac OS X\nProductVersion:	10.15.6\nBuildVersion:	19G46c"
     allow(@plugin).to receive(:shell_out).with("/usr/bin/sw_vers").and_return(mock_shell_out(0, @stdout, ""))
   end
 
@@ -38,34 +38,16 @@ describe Ohai::System, "Darwin plugin platform" do
 
   it "sets platform_version to ProductVersion" do
     @plugin.run
-    expect(@plugin[:platform_version]).to eq("10.5.5")
+    expect(@plugin[:platform_version]).to eq("10.15.6")
   end
 
   it "sets platform_build to BuildVersion" do
     @plugin.run
-    expect(@plugin[:platform_build]).to eq("9F33")
+    expect(@plugin[:platform_build]).to eq("19G46c")
   end
 
   it "sets platform_family to mac_os_x" do
     @plugin.run
     expect(@plugin[:platform_family]).to eq("mac_os_x")
-  end
-
-  describe "on os x server" do
-    before do
-      @plugin[:os] = "darwin"
-      @stdout = "ProductName:	Mac OS X Server\nProductVersion:	10.6.8\nBuildVersion:	10K549"
-      allow(@plugin).to receive(:shell_out).with("/usr/bin/sw_vers").and_return(mock_shell_out(0, @stdout, ""))
-    end
-
-    it "sets platform to mac_os_x_server" do
-      @plugin.run
-      expect(@plugin[:platform]).to eq("mac_os_x_server")
-    end
-
-    it "sets platform_family to mac_os_x" do
-      @plugin.run
-      expect(@plugin[:platform_family]).to eq("mac_os_x")
-    end
   end
 end


### PR DESCRIPTION
mac_os_x_server isn't a thing anymore and no third party darwin based
operating systems ever took off. Fix this detectio and speed things up
a tiny bit by assuming darwin == mac_os_x just like we already do with
the platform_family

Signed-off-by: Tim Smith <tsmith@chef.io>
