### PR TITLE
Linux network plugin: Handle IPv6 next hops for IPv4 routes

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -108,6 +108,7 @@ Ohai.plugin(:Network) do
           # http://rubular.com/r/pwTNp65VFf
           route_entry[k] = $1 if route_ending =~ /\b#{k}\s+([^\s]+)/
         end
+        # https://rubular.com/r/k1sMrRn5yLjgVi
         route_entry["via"] = $1 if route_ending =~ /\bvia\s+inet6\s+([^\s]+)/
 
         # a sanity check, especially for Linux-VServer, OpenVZ and LXC:

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -105,7 +105,7 @@ Ohai.plugin(:Network) do
         route_entry = Mash.new(destination: route_dest,
                                family: family[:name])
         %w{via scope metric proto src}.each do |k|
-          if k == 'via' && route_ending =~ /\bvia\sinet6\s+([^\s]+)/
+          if k == "via" && route_ending =~ /\bvia\sinet6\s+([^\s]+)/
             route_entry[k] = $1
             next
           end

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -105,6 +105,10 @@ Ohai.plugin(:Network) do
         route_entry = Mash.new(destination: route_dest,
                                family: family[:name])
         %w{via scope metric proto src}.each do |k|
+          if k == 'via' && route_ending =~ /\bvia\sinet6\s+([^\s]+)/
+            route_entry[k] = $1
+            next
+          end
           # http://rubular.com/r/pwTNp65VFf
           route_entry[k] = $1 if route_ending =~ /\b#{k}\s+([^\s]+)/
         end

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -108,7 +108,7 @@ Ohai.plugin(:Network) do
           # http://rubular.com/r/pwTNp65VFf
           route_entry[k] = $1 if route_ending =~ /\b#{k}\s+([^\s]+)/
         end
-        route_entry["via"] = $1 if route_ending =~ /\bvia\s+inet6\s+([^\s]+)/          
+        route_entry["via"] = $1 if route_ending =~ /\bvia\s+inet6\s+([^\s]+)/
 
         # a sanity check, especially for Linux-VServer, OpenVZ and LXC:
         # don't report the route entry if the src address isn't set on the node

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -105,13 +105,10 @@ Ohai.plugin(:Network) do
         route_entry = Mash.new(destination: route_dest,
                                family: family[:name])
         %w{via scope metric proto src}.each do |k|
-          if k == "via" && route_ending =~ /\bvia\sinet6\s+([^\s]+)/
-            route_entry[k] = $1
-            next
-          end
           # http://rubular.com/r/pwTNp65VFf
           route_entry[k] = $1 if route_ending =~ /\b#{k}\s+([^\s]+)/
         end
+        route_entry["via"] = $1 if route_ending =~ /\bvia\s+inet6\s+([^\s]+)/          
 
         # a sanity check, especially for Linux-VServer, OpenVZ and LXC:
         # don't report the route entry if the src address isn't set on the node

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -1512,8 +1512,8 @@ describe Ohai::System, "Linux Network Plugin" do
         it "expect an IPv6 next hop and not keyword inet6" do
           expect(plugin["network"]["interfaces"]["eth0"]["routes"]).to eq(
             [
-              {"destination"=>"default", "family"=>"inet", "metric" => "69", "via"=>"fe80::69"},
-              {"destination"=>"fe80::/64", "family"=>"inet6", "metric"=>"256", "proto"=>"kernel"},
+              { "destination" => "default", "family" => "inet", "metric" => "69", "via" => "fe80::69" },
+              { "destination" => "fe80::/64", "family" => "inet6", "metric" => "256", "proto" => "kernel" },
             ]
           )
         end

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -1500,6 +1500,24 @@ describe Ohai::System, "Linux Network Plugin" do
           expect(plugin["network"]["interfaces"]["eth0.11"]["vlan"]["flags"]).to eq([ "REORDER_HDR" ])
         end
       end
+
+      # Test we can handle IPv4 with inet6 IPv6 next hops
+      describe "using IPv6 next hops for IPv4 routes" do
+        let(:linux_ip_route) do
+          <<~EOM
+            default via inet6 fe80::69 dev eth0 metric 69
+          EOM
+        end
+
+        it "expect an IPv6 next hop and not keyword inet6" do
+          expect(plugin["network"]["interfaces"]["eth0"]["routes"]).to eq(
+            [
+              {"destination"=>"default", "family"=>"inet", "metric" => "69", "via"=>"fe80::69"},
+              {"destination"=>"fe80::/64", "family"=>"inet6", "metric"=>"256", "proto"=>"kernel"},
+            ]
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description
- Add handling for `via` where the inet6 address family is specified
- Add rspec test to show working

I suspect this only fixes part of the issue for #1474 

## Related Issue
Issue: https://github.com/chef/ohai/issues/1474

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)

Signed-off-by: Cooper Lees <me@cooperlees.com>
