### PR TITLE
Fix docker detection in ohai virtualization

### DIFF
--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -190,8 +190,11 @@ Ohai.plugin(:Virtualization) do
     # Kernel docs, https://www.kernel.org/doc/Documentation/cgroups
     if File.exist?("/proc/self/cgroup")
       cgroup_content = File.read("/proc/self/cgroup")
-      if cgroup_content =~ %r{^\d+:[^:]+:/(lxc|docker)/.+$} ||
-          cgroup_content =~ %r{^\d+:[^:]+:/[^/]+/(lxc|docker)-?.+$}
+      # These two REs catch many different examples. Here's a specific one
+      # from when it is docker and there is no subsystem name.
+      # https://rubular.com/r/dV13hiU9KxmiWB
+      if cgroup_content =~ %r{^\d+:[^:]*:/(lxc|docker)/.+$} ||
+          cgroup_content =~ %r{^\d+:[^:]*:/[^/]+/(lxc|docker)-?.+$}
         logger.trace("Plugin Virtualization: /proc/self/cgroup indicates #{$1} container. Detecting as #{$1} guest")
         virtualization[:system] = $1
         virtualization[:role] = "guest"


### PR DESCRIPTION
We ran into an issue where when running in docker containers on GH
Actions (which is on azure which is on HyperV), we were getting detected
as being run on a hyperv guest... which is indirectly true, but not
really the most correct answer.

It turns out we were being a bit too strict in this regex. I think.

So here's the `/proc/self/cgroup`:

```
12:blkio:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
11:devices:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
10:memory:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
9:freezer:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
8:cpuset:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
7:pids:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
6:rdma:/
5:hugetlb:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
4:perf_event:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
3:cpu,cpuacct:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
2:net_cls,net_prio:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
1:name=systemd:/actions_job/4ab5ebdc794956d804d03db04557c8b79fa985cbf54bc25f51f2b0848e3f58bd
0::/system.slice/docker.service
```

As you can see the second field (or 1st field if you 0-index) is empty,
and it's still docker.