### PR TITLE
Handle IP to int conversion for inet + inet6

### DIFF
--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -54,7 +54,7 @@ Ohai.plugin(:NetworkAddresses) do
     ipaddresses.sort_by do |v|
       [ ( scope_prio.index(v[:scope]) || 999999 ),
         128 - v[:ipaddress].prefix.to_i,
-        v[:ipaddress].respond_to?(:to_u32) ? v[:ipaddress].to_u32 : v[:ipaddress].to_u128,
+        v[:ipaddress].to_i,
       ]
     end
   end

--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -27,11 +27,9 @@ Ohai.plugin(:NetworkAddresses) do
 
   # Try to u32 an IPv4 and fallback to u128 if it fails before throwing
   def int_an_ip(ipaddress)
-    begin
-      return ipaddress.to_u32
-    rescue NoMethodError
-      return ipaddress.to_u128
-    end
+    ipaddress.to_u32
+  rescue NoMethodError
+    ipaddress.to_u128
   end
 
   # from interface data create array of hashes with ipaddress, scope, and iface
@@ -63,7 +61,7 @@ Ohai.plugin(:NetworkAddresses) do
     ipaddresses.sort_by do |v|
       [ ( scope_prio.index(v[:scope]) || 999999 ),
         128 - v[:ipaddress].prefix.to_i,
-        int_an_ip(v[:ipaddress])
+        int_an_ip(v[:ipaddress]),
       ]
     end
   end

--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -25,13 +25,6 @@ Ohai.plugin(:NetworkAddresses) do
 
   depends "network/interfaces"
 
-  # Try to u32 an IPv4 and fallback to u128 if it fails before throwing
-  def int_an_ip(ipaddress)
-    ipaddress.to_u32
-  rescue NoMethodError
-    ipaddress.to_u128
-  end
-
   # from interface data create array of hashes with ipaddress, scope, and iface
   # sorted by scope, prefixlen and then ipaddress where longest prefixes first
   def sorted_ips(family = "inet")
@@ -61,7 +54,7 @@ Ohai.plugin(:NetworkAddresses) do
     ipaddresses.sort_by do |v|
       [ ( scope_prio.index(v[:scope]) || 999999 ),
         128 - v[:ipaddress].prefix.to_i,
-        int_an_ip(v[:ipaddress]),
+        ipaddress.respond_to?(:to_u32) ? ipaddress.to_u32 : ipaddress.to_u128,
       ]
     end
   end

--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -54,7 +54,7 @@ Ohai.plugin(:NetworkAddresses) do
     ipaddresses.sort_by do |v|
       [ ( scope_prio.index(v[:scope]) || 999999 ),
         128 - v[:ipaddress].prefix.to_i,
-        ipaddress.respond_to?(:to_u32) ? ipaddress.to_u32 : ipaddress.to_u128,
+        v[:ipaddress].respond_to?(:to_u32) ? v[:ipaddress].to_u32 : v[:ipaddress].to_u128,
       ]
     end
   end

--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -25,6 +25,15 @@ Ohai.plugin(:NetworkAddresses) do
 
   depends "network/interfaces"
 
+  # Try to u32 an IPv4 and fallback to u128 if it fails before throwing
+  def int_an_ip(ipaddress)
+    begin
+      return ipaddress.to_u32
+    rescue NoMethodError
+      return ipaddress.to_u128
+    end
+  end
+
   # from interface data create array of hashes with ipaddress, scope, and iface
   # sorted by scope, prefixlen and then ipaddress where longest prefixes first
   def sorted_ips(family = "inet")
@@ -54,7 +63,7 @@ Ohai.plugin(:NetworkAddresses) do
     ipaddresses.sort_by do |v|
       [ ( scope_prio.index(v[:scope]) || 999999 ),
         128 - v[:ipaddress].prefix.to_i,
-        ( family == "inet" ? v[:ipaddress].to_u32 : v[:ipaddress].to_u128 ),
+        int_an_ip(v[:ipaddress])
       ]
     end
   end


### PR DESCRIPTION
- IPv4 can have IPv6 next hops, so we could use the wrong `.to_u*` method
- Lets try both before throwing on int conversions for sorting purposes

Addresses more for #1474

Signed-off-by: Cooper Lees <me@cooperlees.com>