### PR TITLE
Use .match? when we don't need the result

### DIFF
--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -65,7 +65,7 @@ module Ohai
   #
   # @return [String]
   def self.dev_null
-    if RUBY_PLATFORM =~ /mswin|mingw|windows/
+    if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
       "NUL"
     else
       "/dev/null"

--- a/lib/ohai/mixin/command.rb
+++ b/lib/ohai/mixin/command.rb
@@ -30,7 +30,7 @@ module Ohai
         options = options.dup
         # unless specified by the caller timeout after configured timeout (default 30 seconds)
         options[:timeout] ||= Ohai::Config.ohai[:shellout_timeout]
-        unless RUBY_PLATFORM =~ /mswin|mingw32|windows/
+        unless RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
           options[:env] = options.key?(:env) ? options[:env].dup : {}
           options[:env]["PATH"] ||= ((ENV["PATH"] || "").split(":") + %w{/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin}).join(":")
         end

--- a/lib/ohai/mixin/dmi_decode.rb
+++ b/lib/ohai/mixin/dmi_decode.rb
@@ -26,7 +26,7 @@ module ::Ohai::Mixin::DmiDecode
     when /VMware/
       return "vmware"
     when /Microsoft/
-      return "hyperv" if product =~ /Virtual Machine/
+      return "hyperv" if /Virtual Machine/.match?(product)
     when /Amazon EC2/
       return "amazonec2"
     when /QEMU/

--- a/lib/ohai/plugins/aix/virtualization.rb
+++ b/lib/ohai/plugins/aix/virtualization.rb
@@ -57,7 +57,7 @@ Ohai.plugin(:Virtualization) do
           sections.each do |line|
             case title
             when "network"
-              next if line =~ /^Interface|^---/
+              next if /^Interface|^---/.match?(line)
 
               splat = line.strip.split
               key   = splat[0].downcase
@@ -68,7 +68,7 @@ Ohai.plugin(:Virtualization) do
                       }
               wpars[wpar_name][title][key] = value
             when "user-specified routes"
-              next if line =~ /^Type|^---/
+              next if /^Type|^---/.match?(line)
 
               splat = line.strip.split
               key   = splat[2].downcase
@@ -78,7 +78,7 @@ Ohai.plugin(:Virtualization) do
                       }
               wpars[wpar_name][title][key] = value
             when "file systems"
-              next if line =~ /^MountPoint|^---/
+              next if /^MountPoint|^---/.match?(line)
 
               splat = line.strip.split
               key = splat[1].downcase
@@ -93,7 +93,7 @@ Ohai.plugin(:Virtualization) do
               privileges ||= ""
               wpars[wpar_name][title]["Privileges"] ||= []
 
-              if line =~ /^Privileges/
+              if /^Privileges/.match?(line)
                 privileges << line.split(":")[1].strip
               else
                 privileges << line.strip
@@ -101,7 +101,7 @@ Ohai.plugin(:Virtualization) do
 
               wpars[wpar_name][title]["Privileges"] += privileges.split(",")
             when "device exports"
-              next if line =~ /^Name|^---/
+              next if /^Name|^---/.match?(line)
 
               splat = line.strip.split
               key = splat[0].downcase

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -57,7 +57,7 @@ Ohai.plugin(:Azure) do
     has_245 = false
     if File.exist?("/var/lib/dhcp/dhclient.eth0.leases")
       File.open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
-        if line =~ /unknown-245/
+        if /unknown-245/.match?(line)
           logger.trace("Plugin Azure: Found unknown-245 DHCP option used by Azure.")
           has_245 = true
           break

--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -76,7 +76,7 @@ Ohai.plugin(:Virtualization) do
     # Detect KVM/QEMU paravirt guests from cpu, report as KVM
     # hw.model: QEMU Virtual CPU version 0.9.1
     so = shell_out("sysctl -n hw.model")
-    if so.stdout =~ /QEMU Virtual CPU|KVM processor/
+    if /QEMU Virtual CPU|KVM processor/.match?(so.stdout)
       virtualization[:system] = "kvm"
       virtualization[:role] = "guest"
       virtualization[:systems][:kvm] = "guest"
@@ -96,7 +96,7 @@ Ohai.plugin(:Virtualization) do
                    "xen"
                  when /kvm/
                    so = shell_out("sysctl -n kern.hostuuid")
-                   so.stdout =~ /^ec2/ ? "amazonec2" : "kvm"
+                   /^ec2/.match?(so.stdout) ? "amazonec2" : "kvm"
                  when /bhyve/
                    "bhyve"
                  end

--- a/lib/ohai/plugins/cpu.rb
+++ b/lib/ohai/plugins/cpu.rb
@@ -305,7 +305,7 @@ Ohai.plugin(:CPU) do
         cpu[index] = Mash.new
         cpu[index][:status] = status
         cpu[index][:location] = location
-        if status =~ /Available/
+        if /Available/.match?(status)
           cpu[:available] += 1
           lsattr = shell_out("lsattr -El #{name}").stdout.lines
           lsattr.each do |attribute|

--- a/lib/ohai/plugins/darwin/network.rb
+++ b/lib/ohai/plugins/darwin/network.rb
@@ -66,8 +66,8 @@ Ohai.plugin(:Network) do
 
   def scope_lookup(scope)
     return "Node" if scope.eql?("::1")
-    return "Link" if scope =~ /^fe80\:/
-    return "Site" if scope =~ /^fec0\:/
+    return "Link" if /^fe80\:/.match?(scope)
+    return "Site" if /^fec0\:/.match?(scope)
 
     "Global"
   end
@@ -79,7 +79,7 @@ Ohai.plugin(:Network) do
   def locate_interface(ifaces, ifname, mac)
     return ifname unless ifaces[ifname].nil?
     # oh well, time to go hunting!
-    return ifname.chop if ifname =~ /\*$/
+    return ifname.chop if /\*$/.match?(ifname)
 
     ifaces.each_key do |ifc|
       ifaces[ifc][:addresses].each_key do |addr|

--- a/lib/ohai/plugins/darwin/virtualization.rb
+++ b/lib/ohai/plugins/darwin/virtualization.rb
@@ -82,7 +82,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:systems][:parallels] = "host"
     elsif ioreg_exists?
       so = shell_out("ioreg -l")
-      if so.stdout =~ /pci1ab8,4000/
+      if /pci1ab8,4000/.match?(so.stdout)
         virtualization[:system] = "parallels"
         virtualization[:role] = "guest"
         virtualization[:systems][:parallels] = "guest"

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -41,7 +41,7 @@ Ohai.plugin(:EC2) do
   # @return [Boolean] do we have Amazon DMI data?
   def has_ec2_amazon_dmi?
     # detect a version of '4.2.amazon'
-    if file_val_if_exists("/sys/class/dmi/id/bios_vendor") =~ /Amazon/
+    if /Amazon/.match?(file_val_if_exists("/sys/class/dmi/id/bios_vendor"))
       logger.trace("Plugin EC2: has_ec2_amazon_dmi? == true")
       true
     else
@@ -56,7 +56,7 @@ Ohai.plugin(:EC2) do
   # @return [Boolean] do we have Amazon DMI data?
   def has_ec2_xen_dmi?
     # detect a version of '4.2.amazon'
-    if file_val_if_exists("/sys/class/dmi/id/bios_version") =~ /amazon/
+    if /amazon/.match?(file_val_if_exists("/sys/class/dmi/id/bios_version"))
       logger.trace("Plugin EC2: has_ec2_xen_dmi? == true")
       true
     else
@@ -68,7 +68,7 @@ Ohai.plugin(:EC2) do
   # looks for a xen UUID that starts with ec2 from within the Linux sys tree
   # @return [Boolean] do we have a Xen UUID or not?
   def has_ec2_xen_uuid?
-    if file_val_if_exists("/sys/hypervisor/uuid") =~ /^ec2/
+    if /^ec2/.match?(file_val_if_exists("/sys/hypervisor/uuid"))
       logger.trace("Plugin EC2: has_ec2_xen_uuid? == true")
       return true
     end
@@ -81,10 +81,10 @@ Ohai.plugin(:EC2) do
   # linux hosts
   # @return [Boolean] do we have a Xen Identifying Number or not?
   def has_ec2_identifying_number?
-    if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+    if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
       require "wmi-lite/wmi"
       wmi = WmiLite::Wmi.new
-      if wmi.first_of("Win32_ComputerSystemProduct")["identifyingnumber"] =~ /^ec2/
+      if /^ec2/.match?(wmi.first_of("Win32_ComputerSystemProduct")["identifyingnumber"])
         logger.trace("Plugin EC2: has_ec2_identifying_number? == true")
         true
       end

--- a/lib/ohai/plugins/eucalyptus.rb
+++ b/lib/ohai/plugins/eucalyptus.rb
@@ -42,7 +42,7 @@ Ohai.plugin(:Eucalyptus) do
   def has_euca_mac?
     network[:interfaces].each_value do |iface|
       mac = get_mac_address(iface[:addresses])
-      if mac =~ /^[dD]0:0[dD]:/
+      if /^[dD]0:0[dD]:/.match?(mac)
         logger.trace("Plugin Eucalyptus: has_euca_mac? == true (#{mac})")
         return true
       end

--- a/lib/ohai/plugins/gce.rb
+++ b/lib/ohai/plugins/gce.rb
@@ -27,7 +27,7 @@ Ohai.plugin(:GCE) do
   # this works even if the system lacks dmidecode use by the Dmi plugin
   # @return [Boolean] do we have Google Compute Engine DMI data?
   def has_gce_dmi?
-    if file_val_if_exists("/sys/class/dmi/id/product_name") =~ /Google Compute Engine/
+    if /Google Compute Engine/.match?(file_val_if_exists("/sys/class/dmi/id/product_name"))
       logger.trace("Plugin GCE: has_gce_dmi? == true")
       true
     else
@@ -48,7 +48,7 @@ Ohai.plugin(:GCE) do
   # looks at the Manufacturer and Model WMI values to see if they starts with Google.
   # @return [Boolean] Are the manufacturer and model Google?
   def has_gce_system_info?
-    if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+    if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
       require "wmi-lite/wmi"
       wmi = WmiLite::Wmi.new
       computer_system = wmi.first_of("Win32_ComputerSystem")

--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -171,14 +171,14 @@ Ohai.plugin(:Hostname) do
     machinename host["name"].to_s
 
     info = Socket.gethostbyname(Socket.gethostname)
-    if info.first =~ /.+?\.(.*)/
+    if /.+?\.(.*)/.match?(info.first)
       fqdn info.first
     else
       # host is not in dns. optionally use:
       # C:\WINDOWS\system32\drivers\etc\hosts
       info[3..info.length].reverse_each do |addr|
         hostent = Socket.gethostbyaddr(addr)
-        if hostent.first =~ /.+?\.(.*)/
+        if /.+?\.(.*)/.match?(hostent.first)
           fqdn hostent.first
           break
         end

--- a/lib/ohai/plugins/linux/interrupts.rb
+++ b/lib/ohai/plugins/linux/interrupts.rb
@@ -65,7 +65,7 @@ Ohai.plugin(:Interrupts) do
         interrupts[:irq][irqn][:events_by_cpu][cpu] = fields[cpu].to_i
       end
       # Only regular IRQs have extra fields and affinity settings
-      if /^\d+$/.match(irqn)
+      if /^\d+$/.match?(irqn)
         interrupts[:irq][irqn][:type],
         interrupts[:irq][irqn][:vector],
         interrupts[:irq][irqn][:device] =

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -78,7 +78,7 @@ Ohai.plugin(:Network) do
     so.stdout.lines do |line|
       line.strip!
       logger.trace("Plugin Network: Parsing #{line}")
-      if line =~ /\\/
+      if /\\/.match?(line)
         parts = line.split('\\')
         route_dest = parts.shift.strip
         route_endings = parts
@@ -191,11 +191,11 @@ Ohai.plugin(:Network) do
         next if line.start_with?("Ring parameters for")
         next if line.strip.nil?
 
-        if line =~ /Pre-set maximums/
+        if /Pre-set maximums/.match?(line)
           type = "max"
           next
         end
-        if line =~ /Current hardware settings/
+        if /Current hardware settings/.match?(line)
           type = "current"
           next
         end
@@ -224,11 +224,11 @@ Ohai.plugin(:Network) do
         next if line.start_with?("Channel parameters for")
         next if line.strip.nil?
 
-        if line =~ /Pre-set maximums/
+        if /Pre-set maximums/.match?(line)
           type = "max"
           next
         end
-        if line =~ /Current hardware settings/
+        if /Current hardware settings/.match?(line)
           type = "current"
           next
         end
@@ -308,7 +308,7 @@ Ohai.plugin(:Network) do
         net_counters[tmp_int] ||= Mash.new
       end
 
-      if line =~ /^\s+(ip6tnl|ipip)/
+      if /^\s+(ip6tnl|ipip)/.match?(line)
         iface[tmp_int][:tunnel_info] = {}
         words = line.split
         words.each_with_index do |word, index|

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -195,7 +195,7 @@ Ohai.plugin(:Platform) do
     elsif File.exist?("/etc/debian_version")
       # Ubuntu and Debian both have /etc/debian_version
       # Ubuntu should always have a working lsb, debian does not by default
-      if lsb[:id] =~ /Ubuntu/i
+      if /Ubuntu/i.match?(lsb[:id])
         platform "ubuntu"
         platform_version lsb[:release]
       else
@@ -222,7 +222,7 @@ Ohai.plugin(:Platform) do
       suse_version = suse_release.scan(/VERSION = (\d+)\nPATCHLEVEL = (\d+)/).flatten.join(".")
       suse_version = suse_release[/VERSION = ([\d\.]{2,})/, 1] if suse_version == ""
       platform_version suse_version
-      if suse_release =~ /^openSUSE/
+      if /^openSUSE/.match?(suse_release)
         # opensuse releases >= 42 are openSUSE Leap
         if platform_version.to_i < 42
           platform "opensuse"
@@ -256,23 +256,23 @@ Ohai.plugin(:Platform) do
       platform_version shell_out("/bin/uname -r").stdout.strip
     elsif File.exist?("/usr/lib/os-release")
       contents = File.read("/usr/lib/os-release")
-      if /clear-linux-os/ =~ contents # Clear Linux https://clearlinux.org/
+      if /clear-linux-os/.match?(contents) # Clear Linux https://clearlinux.org/
         platform "clearlinux"
         platform_version contents[/VERSION_ID=(\d+)/, 1]
       end
-    elsif lsb[:id] =~ /RedHat/i
+    elsif /RedHat/i.match?(lsb[:id])
       platform "redhat"
       platform_version lsb[:release]
-    elsif lsb[:id] =~ /Amazon/i
+    elsif /Amazon/i.match?(lsb[:id])
       platform "amazon"
       platform_version lsb[:release]
-    elsif lsb[:id] =~ /ScientificSL/i
+    elsif /ScientificSL/i.match?(lsb[:id])
       platform "scientific"
       platform_version lsb[:release]
-    elsif lsb[:id] =~ /XenServer/i
+    elsif /XenServer/i.match?(lsb[:id])
       platform "xenserver"
       platform_version lsb[:release]
-    elsif lsb[:id] =~ /XCP/i
+    elsif /XCP/i.match?(lsb[:id])
       platform "xcp"
       platform_version lsb[:release]
     elsif lsb[:id] # LSB can provide odd data that changes between releases, so we currently fall back on it rather than dealing with its subtleties

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -59,7 +59,7 @@ Ohai.plugin(:Virtualization) do
 
       # This file should exist on most Xen systems, normally empty for guests
       if File.exist?("/proc/xen/capabilities")
-        if File.read("/proc/xen/capabilities") =~ /control_d/i
+        if /control_d/i.match?(File.read("/proc/xen/capabilities"))
           logger.trace("Plugin Virtualization: /proc/xen/capabilities contains control_d. Detecting as Xen host")
           virtualization[:role] = "host"
           virtualization[:systems][:xen] = "host"
@@ -70,12 +70,12 @@ Ohai.plugin(:Virtualization) do
     # Detect Virtualbox from kernel module
     if File.exist?("/proc/modules")
       modules = File.read("/proc/modules")
-      if modules =~ /^vboxdrv/
+      if /^vboxdrv/.match?(modules)
         logger.trace("Plugin Virtualization: /proc/modules contains vboxdrv. Detecting as vbox host")
         virtualization[:system] = "vbox"
         virtualization[:role] = "host"
         virtualization[:systems][:vbox] = "host"
-      elsif modules =~ /^vboxguest/
+      elsif /^vboxguest/.match?(modules)
         logger.trace("Plugin Virtualization: /proc/modules contains vboxguest. Detecting as vbox guest")
         virtualization[:system] = "vbox"
         virtualization[:role] = "guest"
@@ -93,7 +93,7 @@ Ohai.plugin(:Virtualization) do
 
     # Detect paravirt KVM/QEMU from cpuinfo, report as KVM
     if File.exist?("/proc/cpuinfo")
-      if File.read("/proc/cpuinfo") =~ /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/
+      if /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/.match?(File.read("/proc/cpuinfo"))
         logger.trace("Plugin Virtualization: /proc/cpuinfo lists a KVM paravirt CPU string. Detecting as kvm guest")
         virtualization[:system] = "kvm"
         virtualization[:role] = "guest"
@@ -105,7 +105,7 @@ Ohai.plugin(:Virtualization) do
     # guests will have the hypervisor cpu feature that hosts don't have
     if File.exist?("/sys/devices/virtual/misc/kvm")
       virtualization[:system] = "kvm"
-      if File.read("/proc/cpuinfo") =~ /hypervisor/
+      if /hypervisor/.match?(File.read("/proc/cpuinfo"))
         logger.trace("Plugin Virtualization: /sys/devices/virtual/misc/kvm present and /proc/cpuinfo lists the hypervisor feature. Detecting as kvm guest")
         virtualization[:role] = "guest"
         virtualization[:systems][:kvm] = "guest"
@@ -199,12 +199,12 @@ Ohai.plugin(:Virtualization) do
         virtualization[:system] = $1
         virtualization[:role] = "guest"
         virtualization[:systems][$1.to_sym] = "guest"
-      elsif File.read("/proc/1/environ") =~ /container=lxc/
+      elsif /container=lxc/.match?(File.read("/proc/1/environ"))
         logger.trace("Plugin Virtualization: /proc/1/environ indicates lxc container. Detecting as lxc guest")
         virtualization[:system] = "lxc"
         virtualization[:role] = "guest"
         virtualization[:systems][:lxc] = "guest"
-      elsif File.read("/proc/1/environ") =~ /container=systemd-nspawn/
+      elsif /container=systemd-nspawn/.match?(File.read("/proc/1/environ"))
         logger.trace("Plugin Virtualization: /proc/1/environ indicates nspawn container. Detecting as nspawn guest")
         virtualization[:system] = "nspawn"
         virtualization[:role] = "guest"

--- a/lib/ohai/plugins/openstack.rb
+++ b/lib/ohai/plugins/openstack.rb
@@ -49,7 +49,7 @@ Ohai.plugin(:Openstack) do
   # https://help.dreamhost.com/hc/en-us/articles/228377408-How-to-find-the-default-user-of-an-image
   def openstack_provider
     # dream host doesn't support windows so bail early if we're on windows
-    return "openstack" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+    return "openstack" if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
 
     if Etc::Passwd.entries.map(&:name).include?("dhc-user")
       "dreamhost"

--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -48,7 +48,7 @@ Ohai.plugin(:Rackspace) do
   # true:: If the rackspace cloud can be identified
   # false:: Otherwise
   def has_rackspace_manufacturer?
-    return false unless RUBY_PLATFORM =~ /mswin|mingw32|windows/
+    return false unless RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
 
     require "wmi-lite/wmi"
     wmi = WmiLite::Wmi.new
@@ -102,7 +102,7 @@ Ohai.plugin(:Rackspace) do
     so = shell_out("xenstore-ls vm-data/provider_data")
     if so.exitstatus == 0
       so.stdout.split("\n").each do |line|
-        rackspace[:region] = line.split[2].delete('\"') if line =~ /^region/
+        rackspace[:region] = line.split[2].delete('\"') if /^region/.match?(line)
       end
     end
   rescue Ohai::Exceptions::Exec

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -38,7 +38,7 @@ Ohai.plugin(:Virtualization) do
     psrinfo_path = Ohai.abs_path( "/usr/sbin/psrinfo" )
     if File.exist?(psrinfo_path)
       so = shell_out("#{psrinfo_path} -pv")
-      if so.stdout =~ /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/
+      if /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/.match?(so.stdout)
         virtualization[:system] = "kvm"
         virtualization[:role] = "guest"
         virtualization[:systems][:kvm] = "guest"

--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -51,7 +51,7 @@ Ohai.plugin(:SSHHostKey) do
     if sshd_config
       File.open(sshd_config) do |conf|
         conf.each_line do |line|
-          if line =~ /^hostkey\s/i
+          if /^hostkey\s/i.match?(line)
             pub_file = "#{line.split[1]}.pub"
             content = IO.read(pub_file).split
             key_type, key_subtype = extract_keytype?(content)

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -51,7 +51,7 @@ Ohai.plugin(:VMware) do
         # to attribute "vmware[:<parameter>]"
         %w{hosttime speed sessionid balloon swap memlimit memres cpures cpulimit}.each do |param|
           vmware[param] = from_cmd("#{vmtools_path} stat #{param}")
-          if vmware[param] =~ /UpdateInfo failed/
+          if /UpdateInfo failed/.match?(vmware[param])
             vmware[param] = nil
           end
         end

--- a/lib/ohai/plugins/windows/network.rb
+++ b/lib/ohai/plugins/windows/network.rb
@@ -171,7 +171,7 @@ Ohai.plugin(:Network) do
           iface[cint][:addresses][ip] = Mash.new(prefixlen: ip2.prefix)
           if ip2.ipv6?
             iface[cint][:addresses][ip][:family] = "inet6"
-            iface[cint][:addresses][ip][:scope] = "Link" if ip =~ /^fe80/i
+            iface[cint][:addresses][ip][:scope] = "Link" if /^fe80/i.match?(ip)
           else
             if iface[cint][:configuration][:ip_subnet]
               iface[cint][:addresses][ip][:netmask] = ip2.netmask.to_s

--- a/lib/ohai/provides_map.rb
+++ b/lib/ohai/provides_map.rb
@@ -136,8 +136,8 @@ module Ohai
     private
 
     def normalize_and_validate(attribute)
-      raise Ohai::Exceptions::AttributeSyntaxError, "Attribute contains duplicate '/' characters: #{attribute}" if attribute =~ %r{//+}
-      raise Ohai::Exceptions::AttributeSyntaxError, "Attribute contains a trailing '/': #{attribute}" if attribute =~ %r{/$}
+      raise Ohai::Exceptions::AttributeSyntaxError, "Attribute contains duplicate '/' characters: #{attribute}" if %r{//+}.match?(attribute)
+      raise Ohai::Exceptions::AttributeSyntaxError, "Attribute contains a trailing '/': #{attribute}" if %r{/$}.match?(attribute)
 
       parts = attribute.split("/")
       parts.shift if parts.length != 0 && parts[0].length == 0 # attribute begins with a '/'

--- a/lib/ohai/util/win32.rb
+++ b/lib/ohai/util/win32.rb
@@ -19,7 +19,7 @@
 module Ohai
   module Util
     module Win32
-      if RUBY_PLATFORM =~ /mswin|mingw|windows/
+      if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
 
         require "ffi" unless defined?(FFI)
 


### PR DESCRIPTION
Avoid creating a bunch of match objects when we're not going to use the match results.

Signed-off-by: Tim Smith <tsmith@chef.io>