### PR TITLE
Remove redundant file encoding in spec

### DIFF
--- a/spec/unit/mixin/command_spec.rb
+++ b/spec/unit/mixin/command_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Author:: Diego Algorta (diego@oboxodo.com)
 # Copyright:: Copyright (c) 2009 Diego Algorta


### PR DESCRIPTION
In Ruby 2+ this is the default.

Signed-off-by: Tim Smith <tsmith@chef.io>