### PR TITLE
Add Address Family Check to route_is_valid_default_route?

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -516,8 +516,16 @@ Ohai.plugin(:Network) do
     # if the route destination is a default route, it's good
     return true if route[:destination] == "default"
 
+    return false if default_route[:via].nil?
+
+    dest_ipaddr = IPAddress(route[:destination])
+    default_route_via = IPAddress(default_route[:via])
+
+    # check if nexthop is the same address family
+    return false if dest_ipaddr.ipv4? != default_route_via.ipv4?
+
     # the default route has a gateway and the route matches the gateway
-    !default_route[:via].nil? && IPAddress(route[:destination]).include?(IPAddress(default_route[:via]))
+    dest_ipaddr.include?(default_route_via)
   end
 
   # ipv4/ipv6 routes are different enough that having a single algorithm to select the favored route for both creates unnecessary complexity

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -608,6 +608,15 @@ describe Ohai::System, "Linux Network Plugin" do
           expect(plugin.route_is_valid_default_route?(route, default_route)).to eq(false)
         end
       end
+
+      context "when route and default_route via have different address family" do
+        let(:route) { { destination: "10.0.0.0/24" } }
+        let(:default_route) { { via: "fe80::69" } }
+
+        it "returns false" do
+          expect(plugin.route_is_valid_default_route?(route, default_route)).to eq(false)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
- We can now have IPv6 next hops for IPv4 routes in Linux
- We don't have enough information to validate the route as valid if they are differen address families

Test:
- Add an rspec test to show it returning false like we'd hoped
- Have also tested on Facebook servers internally

Signed-off-by: Cooper Lees <me@cooperlees.com>

Fixes #1474 