### PR TITLE
Use match? instead of =~ when MatchData is not used

### DIFF
--- a/lib/ohai/plugins/scaleway.rb
+++ b/lib/ohai/plugins/scaleway.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Scaleway) do
   # looks for `scaleway` keyword in kernel command line
   # @return [Boolean] do we have the keyword or not?
   def has_scaleway_cmdline?
-    if /scaleway/.match?(::File.read("/proc/cmdline"))
+    if ::File.exist?("/proc/cmdline") && /scaleway/.match?(::File.read("/proc/cmdline"))
       logger.trace("Plugin Scaleway: has_scaleway_cmdline? == true")
       return true
     end

--- a/lib/ohai/plugins/scaleway.rb
+++ b/lib/ohai/plugins/scaleway.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Scaleway) do
   # looks for `scaleway` keyword in kernel command line
   # @return [Boolean] do we have the keyword or not?
   def has_scaleway_cmdline?
-    if ::File.read("/proc/cmdline") =~ /scaleway/
+    if /scaleway/.match?(::File.read("/proc/cmdline"))
       logger.trace("Plugin Scaleway: has_scaleway_cmdline? == true")
       return true
     end

--- a/spec/unit/plugins/scaleway_spec.rb
+++ b/spec/unit/plugins/scaleway_spec.rb
@@ -22,7 +22,7 @@ describe Ohai::System, "plugin scaleway" do
 
   before do
     allow(plugin).to receive(:hint?).with("scaleway").and_return(false)
-    allow(File).to receive(:read).with("/proc/cmdline").and_return(false)
+    allow(File).to receive(:exist?).with("/proc/cmdline").and_return(false)
   end
 
   shared_examples_for "!scaleway" do
@@ -84,6 +84,7 @@ describe Ohai::System, "plugin scaleway" do
 
   describe "with scaleway cmdline" do
     before do
+      allow(File).to receive(:exist?).with("/proc/cmdline").and_return(true)
       allow(File).to receive(:read).with("/proc/cmdline").and_return("initrd=initrd showopts console=ttyS0,115200 nousb vga=0 root=/dev/vda scaleway boot=local")
     end
 


### PR DESCRIPTION
We don't need this data.

Signed-off-by: Tim Smith <tsmith@chef.io>