### PR TITLE
Simplify FIPS plugin and use system fips status

### DIFF
--- a/lib/ohai/plugins/fips.rb
+++ b/lib/ohai/plugins/fips.rb
@@ -29,10 +29,6 @@ Ohai.plugin(:Fips) do
     fips Mash.new
 
     require "openssl" unless defined?(OpenSSL)
-    if defined?(OpenSSL.fips_mode) && OpenSSL.fips_mode && !$FIPS_TEST_MODE
-      fips["kernel"] = { "enabled" => true }
-    else
-      fips["kernel"] = { "enabled" => false }
-    end
+    fips["kernel"] = { "enabled" => OpenSSL::OPENSSL_FIPS }
   end
 end

--- a/spec/unit/plugins/fips_spec.rb
+++ b/spec/unit/plugins/fips_spec.rb
@@ -25,36 +25,23 @@ describe Ohai::System, "plugin fips" do
     plugin["fips"]["kernel"]["enabled"]
   end
 
-  let(:enabled) { 0 }
   let(:plugin) { get_plugin("fips") }
-  let(:openssl_test_mode) { false }
 
   before do
     allow(plugin).to receive(:collect_os).and_return(:linux)
   end
 
-  around do |ex|
-
-    $FIPS_TEST_MODE = openssl_test_mode
-    ex.run
-  ensure
-    $FIPS_TEST_MODE = false
-
-  end
-
-  context "with OpenSSL.fips_mode == false" do
-    before { allow(OpenSSL).to receive(:fips_mode).and_return(false) }
-
-    it "does not set fips plugin" do
-      expect(subject).to be(false)
+  context "when OpenSSL reports FIPS mode true" do
+    it "sets fips enabled true" do
+      stub_const("OpenSSL::OPENSSL_FIPS", true)
+      expect(subject).to be(true)
     end
   end
 
-  context "with OpenSSL.fips_mode == true" do
-    before { allow(OpenSSL).to receive(:fips_mode).and_return(true) }
-
-    it "sets fips plugin" do
-      expect(subject).to be(true)
+  context "when OpenSSL reports FIPS mode false" do
+    it "sets fips enabled false" do
+      stub_const("OpenSSL::OPENSSL_FIPS", false)
+      expect(subject).to be(false)
     end
   end
 end


### PR DESCRIPTION
Don't rely on fips being enabled by chef-config. Pull the system status instead.

Signed-off-by: Tim Smith <tsmith@chef.io>