### PR TITLE
Update network plugin to use ipaddr not ipaddress gem

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -518,8 +518,8 @@ Ohai.plugin(:Network) do
 
     return false if default_route[:via].nil?
 
-    dest_ipaddr = IPAddress(route[:destination])
-    default_route_via = IPAddress(default_route[:via])
+    dest_ipaddr = IPAddr.new(route[:destination])
+    default_route_via = IPAddr.new(default_route[:via])
 
     # check if nexthop is the same address family
     return false if dest_ipaddr.ipv4? != default_route_via.ipv4?

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -18,7 +18,6 @@
 #
 
 require "spec_helper"
-require "ipaddress" unless defined?(IPAddress)
 
 describe Ohai::System, "Linux Network Plugin" do
   let(:plugin) { get_plugin("linux/network") }


### PR DESCRIPTION
This broke because we never actually required ipaddress in the plugin, but the specs passed because we required it there.

Signed-off-by: Tim Smith <tsmith@chef.io>