### PR TITLE
Remove non-Ohai requires from specs to prevent false positives

### DIFF
--- a/spec/unit/plugins/azure_spec.rb
+++ b/spec/unit/plugins/azure_spec.rb
@@ -17,7 +17,6 @@
 #
 
 require "spec_helper"
-require "open-uri"
 
 describe Ohai::System, "plugin azure" do
   let(:plugin) { get_plugin("azure") }

--- a/spec/unit/plugins/chef_spec.rb
+++ b/spec/unit/plugins/chef_spec.rb
@@ -20,7 +20,6 @@
 
 begin
   require "spec_helper"
-  require "chef/version"
 
   describe Ohai::System, "plugin chef" do
     before do

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -16,7 +16,6 @@
 #
 
 require "spec_helper"
-require "ipaddr" unless defined?(IPAddr)
 
 describe "CloudAttrs object" do
   before do

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -18,8 +18,6 @@
 #
 
 require "spec_helper"
-require "open-uri"
-require "base64"
 
 describe Ohai::System, "plugin ec2" do
 

--- a/spec/unit/plugins/hostname_spec.rb
+++ b/spec/unit/plugins/hostname_spec.rb
@@ -17,8 +17,6 @@
 #
 
 require "spec_helper"
-require "wmi-lite/wmi" unless defined?(WmiLite::Wmi)
-require "socket"
 
 describe Ohai::System, "hostname plugin" do
   before do

--- a/spec/unit/plugins/windows/network_spec.rb
+++ b/spec/unit/plugins/windows/network_spec.rb
@@ -17,7 +17,6 @@
 #
 
 require "spec_helper"
-require "ipaddress" unless defined?(IPAddress)
 
 describe Ohai::System, "Windows Network Plugin" do
   let(:plugin) { get_plugin("windows/network") }

--- a/spec/unit/util/ip_helper_spec.rb
+++ b/spec/unit/util/ip_helper_spec.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "ipaddress" unless defined?(IPAddress)
 require "spec_helper"
 require "ohai/util/ip_helper"
 


### PR DESCRIPTION
The plugins should require everything they need unless we're using those libraries to mock out objects as we do in some Windows specs. This way we rely on the requires in the plugins and specs fail if those requires are removed.

Signed-off-by: Tim Smith <tsmith@chef.io>