### PR TITLE
Use rubocop-performance to enforce some best practices

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   TargetRubyVersion: 2.5
   Exclude:
@@ -10,3 +12,6 @@ Layout/IndentationStyle:
   Exclude:
     - "lib/ohai/plugins/mono.rb"
     - "lib/ohai/plugins/darwin/hardware.rb"
+
+Performance/Caller:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
   gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
+  gem "rubocop-performance", "1.7.1"
   gem "rake", ">= 10.1.0"
   gem "rspec-core", "~> 3.0"
   gem "rspec-expectations", "~> 3.0"


### PR DESCRIPTION
I've already fixed all the warnings. This will keep it that way.

Signed-off-by: Tim Smith <tsmith@chef.io>