### PR TITLE
Add missing require for windows network plugin

### DIFF
--- a/lib/ohai/plugins/windows/network.rb
+++ b/lib/ohai/plugins/windows/network.rb
@@ -117,7 +117,7 @@ Ohai.plugin(:Network) do
   end
 
   collect_data(:windows) do
-
+    require "ipaddress" unless defined?(IPAddress)
     require "wmi-lite/wmi" unless defined?(WmiLite::Wmi)
 
     iface = Mash.new


### PR DESCRIPTION
This was missed since the windows network plugin just mocks out the IP
data. I'll see what I can do to make these more real world tests in a
followup PR

Signed-off-by: Tim Smith <tsmith@chef.io>