### PR TITLE
Ohai Target Mode aka Remote Ohai

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -9,6 +9,9 @@ export LANG=C.UTF-8 LANGUAGE=C.UTF-8
 
 echo "--- bundle install"
 
+# we need the ruby 2.7 version of bundler, the 2.5/2.6 versions cannot pull our Gemfile correctly
+gem update --system
+gem install bundler
 bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
 

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -26,14 +26,6 @@ steps:
       docker:
         image: ruby:2.7-buster
 
-- label: run-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh rspec
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-buster
-
 - label: run-specs-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh rspec
@@ -52,6 +44,9 @@ steps:
 
 - label: run-specs-windows
   command:
+    # we need the ruby 2.7 version of bundler, the 2.5/2.6 versions cannot pull our Gemfile correctly
+    - gem update --system
+    - gem install bundler
     - bundle config --local path vendor/bundle
     - bundle install --jobs=7 --retry=3 --without=profile
     - bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source "https://rubygems.org"
 
 gemspec
 
+# pull these gems from master of chef/chef so that we're testing against what we will release
+gem "chef-config", git: "https://github.com/chef/chef", glob: "chef-config/chef-config.gemspec"
+gem "chef-utils", git: "https://github.com/chef/chef", glob: "chef-utils/chef-utils.gemspec"
+
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
   gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -22,6 +22,7 @@ require_relative "../mixin/os"
 require_relative "../mixin/shell_out"
 require_relative "../mixin/seconds_to_human"
 require_relative "../mixin/which"
+require_relative "../mixin/train_helpers"
 require_relative "../hints"
 
 module Ohai
@@ -86,16 +87,22 @@ module Ohai
       include Ohai::Mixin::ShellOut
       include Ohai::Mixin::SecondsToHuman
       include Ohai::Mixin::Which
+      include Ohai::Mixin::TrainHelpers
 
       attr_reader :data
       attr_reader :failed
       attr_reader :logger
+      attr_accessor :transport_connection
 
       def initialize(data, logger)
         @data = data
         @logger = logger.with_child({ subsystem: "plugin", plugin: name })
         @has_run = false
         @failed = false
+      end
+
+      def target_mode?
+        !!@transport_connection
       end
 
       def run

--- a/lib/ohai/dsl/plugin/versionvii.rb
+++ b/lib/ohai/dsl/plugin/versionvii.rb
@@ -46,7 +46,8 @@ module Ohai
           :version7
         end
 
-        # the source of the plugin on disk. This is an array since a plugin may exist for multiple platforms and this would include each of those platform specific file paths
+        # The source of the plugin on disk. This is an array since a plugin may exist for multiple
+        # oses and this would include each of those os specific file paths
         #
         # @return [Array]
         def self.sources
@@ -61,7 +62,7 @@ module Ohai
           @depends_attrs ||= []
         end
 
-        # A block per platform for actually performing data collection constructed
+        # A block per os for actually performing data collection constructed
         # by the collect_data method
         #
         # @return [Mash]
@@ -101,15 +102,16 @@ module Ohai
           !!@optional
         end
 
-        # define data collection methodology per platform
+        # define data collection methodology per os
         #
-        # @param platform [Symbol] the platform to collect data for
-        # @param other_platforms [Array] additional platforms to collect data for
-        # @param block [block] the actual code to collect data for the specified platforms
-        def self.collect_data(platform = :default, *other_platforms, &block)
-          [platform, other_platforms].flatten.each do |plat|
-            Ohai::Log.warn("collect_data already defined on platform '#{plat}' for #{self}, last plugin seen will be used") if data_collector.key?(plat)
-            data_collector[plat] = block
+        # @param os [Array<Symbol>] the list of oses to collect data for
+        # @param block [block] the actual code to collect data for the specified os
+        #
+        def self.collect_data(*os_list, &block)
+          os_list = [ :default ] if os_list.empty?
+          os_list.flatten.each do |os|
+            Ohai::Log.warn("collect_data already defined on os '#{os}' for #{self}, last plugin seen will be used") if data_collector.key?(os)
+            data_collector[os] = block
           end
         end
 
@@ -120,12 +122,22 @@ module Ohai
 
         def run_plugin
           collector = self.class.data_collector
-          platform = collect_os
+          os = collect_os
 
-          if collector.key?(platform)
-            instance_eval(&collector[platform])
-          elsif collector.key?(:default)
+          # :default - means any remote or local unix or windows host
+          # :target  - means any remote API which is not unix/windows or otherwise rubyable (cisco switches, IPMI console, HTTP API, etc)
+          #
+          # Do not be confused by the fact that collectors tagged :target do not run against e.g. target-mode ubuntu boxes, that is not
+          # what :target is intended for.  Also, do not be confused by the fact that collectors tagged :default do not run by default against
+          # pure-target mode targets like switches.  That is all intended behavior, the names are problematic.  The :default nomenclature was
+          # invented 10 years before target mode and we are stuck with it.
+          #
+          if collector.key?(os)
+            instance_eval(&collector[os])
+          elsif collector.key?(:default) && !nonruby_target?
             instance_eval(&collector[:default])
+          elsif collector.key?(:target) && nonruby_target?
+            instance_eval(&collector[:target])
           else
             logger.trace("Plugin #{name}: No data to collect. Skipping...")
           end

--- a/lib/ohai/mixin/chef_utils_wiring.rb
+++ b/lib/ohai/mixin/chef_utils_wiring.rb
@@ -36,7 +36,7 @@ module Ohai
         transport_connection
       end
 
-      # beause of target mode we cache the PATH to avoid massive amounts of `echo $PATH` remote queries
+      # because of target mode we cache the PATH to avoid massive amounts of `echo $PATH` remote queries
       #
       def __env_path
         PathCache.instance.path_cache ||= super

--- a/lib/ohai/mixin/chef_utils_wiring.rb
+++ b/lib/ohai/mixin/chef_utils_wiring.rb
@@ -16,6 +16,7 @@
 #
 
 require_relative "../config"
+require "singleton" unless defined?(Singleton)
 
 module Ohai
   module Mixin
@@ -32,7 +33,18 @@ module Ohai
       end
 
       def __transport_connection
-        #        Chef.run_context&.transport_connection
+        transport_connection
+      end
+
+      # beause of target mode we cache the PATH to avoid massive amounts of `echo $PATH` remote queries
+      #
+      def __env_path
+        PathCache.instance.path_cache ||= super
+      end
+
+      class PathCache
+        include Singleton
+        attr_accessor :path_cache
       end
     end
   end

--- a/lib/ohai/mixin/os.rb
+++ b/lib/ohai/mixin/os.rb
@@ -73,7 +73,7 @@ module Ohai
           # if it was not caught above, we MUST translate whatever train uses as the 'os' into the proper ruby host_os
           # string.  If it is not unix and not caught above we assume it is something like a REST API which cannot run
           # ruby.  If these assumptions are incorrect then it is a bug, which should be submitted to fix it, and the
-          # values should not be relied upon until that bug is fixed.  The train os is NEVER considered authoritataive
+          # values should not be relied upon until that bug is fixed.  The train os is NEVER considered authoritative
           # for any target which can run ruby.
           #
         when transport_connection.os.unix?

--- a/lib/ohai/mixin/os.rb
+++ b/lib/ohai/mixin/os.rb
@@ -27,6 +27,71 @@ module Ohai
       #
       # @return [String] the OS
       def collect_os
+        if target_mode?
+          collect_os_target
+        else
+          collect_os_local
+        end
+      end
+
+      # This should exactly preserve the semantics of collect_os_local below, which is authoritative
+      # for the API and must adhere to pre-existing ohai semantics and not follow inspec's notion of
+      # os/family/hierarchy.
+      #
+      # Right or wrong the ohai `os` variable has matched the ruby `host_os` definition for the past
+      # 10+ years, preceding inspec/train's definitions and this is the documented correct API of
+      # these methods.  Mismatches between the ruby notion and the train version will be fixed as
+      # bugfixes in these methods and may not be considered semver violating even though they make
+      # break downstream consumers.  Please ensure that both methods produce the same results if
+      # you are on a platform which supports running ruby (train is considered authoritative for
+      # any "OS" which cannot run ruby -- server consoles, REST APIs, etc...)
+      #
+      # @api private
+      def collect_os_target
+        case
+        when transport_connection.os.aix?
+          "aix"
+        when transport_connection.os.darwin?
+          "darwin"
+        when transport_connection.os.linux?
+          "linux"
+        when transport_connection.os.family == "freebsd"
+          "freebsd"
+        when transport_connection.os.family == "openbsd"
+          "openbsd"
+        when transport_connection.os.family == "netbsd"
+          "netbsd"
+        when transport_connection.os.family == "dragonflybsd"
+          "dragonflybsd"
+        when transport_connection.os.solaris?
+          "solaris2"
+        when transport_connection.os.windows?
+          "windows"
+
+          #
+          # The purpose of the next two lines is that anything which runs Unix is presumed to be able to run ruby, and
+          # if it was not caught above, we MUST translate whatever train uses as the 'os' into the proper ruby host_os
+          # string.  If it is not unix and not caught above we assume it is something like a REST API which cannot run
+          # ruby.  If these assumptions are incorrect then it is a bug, which should be submitted to fix it, and the
+          # values should not be relied upon until that bug is fixed.  The train os is NEVER considered authoritataive
+          # for any target which can run ruby.
+          #
+        when transport_connection.os.unix?
+          raise "Target mode unsupported on this Unix-like host, please update the collect_os_target case statement with the correct ruby host_os value."
+        else
+          # now we have something like an IPMI console that isn't Unix-like or Windows, presumably cannot run ruby, and
+          # so we just trust the train O/S information.
+          transport_connection.os
+        end
+      end
+
+      # @api private
+      def nonruby_target?
+        transport_connection && !transport_connection.os.unix? && !transport_connection.os.windows
+      end
+
+      # @api private
+      def collect_os_local
         case ::RbConfig::CONFIG["host_os"]
         when /aix(.+)$/
           "aix"
@@ -56,7 +121,7 @@ module Ohai
         end
       end
 
-      module_function :collect_os
+      extend self
     end
   end
 end

--- a/lib/ohai/mixin/train_helpers.rb
+++ b/lib/ohai/mixin/train_helpers.rb
@@ -1,5 +1,4 @@
 #
-# Author:: Tim Smith (<tsmith@chef.io>)
 # Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
@@ -14,17 +13,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-Ohai.plugin(:Shells) do
-  provides "shells"
+require "chef-utils/dsl/train_helpers" unless defined?(ChefUtils::DSL::TrainHelpers)
+require_relative "chef_utils_wiring" unless defined?(Ohai::Mixin::ChefUtilsWiring)
 
-  collect_data do
-    if file_exist?("/etc/shells")
-      shells []
-      file_open("/etc/shells").readlines.each do |line|
-        # remove carriage returns and skip over comments / empty lines
-        shells << line.chomp if line[0] == "/"
+module Ohai
+  module Mixin
+    module TrainHelpers
+      include ChefUtils::DSL::TrainHelpers
+      include ChefUtilsWiring
+
+      # anything added to this file temporarily should be pushed back up
+      # into ChefUtils::DSL::TrainHelpers
+
+      # XXX: this needs better support directly in train
+      def dir_glob(path)
+        shell_out!("ls -d #{path}").stdout.split
       end
     end
   end

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -47,7 +47,7 @@ Ohai.plugin(:Azure) do
   # check for either the waagent or the unknown-245 DHCP option that Azure uses
   # http://blog.mszcool.com/index.php/2015/04/detecting-if-a-virtual-machine-runs-in-microsoft-azure-linux-windows-to-protect-your-software-when-distributed-via-the-azure-marketplace/
   def has_waagent?
-    if File.exist?("/usr/sbin/waagent") || Dir.exist?('C:\WindowsAzure')
+    if file_exist?("/usr/sbin/waagent") || dir_exist?('C:\WindowsAzure')
       logger.trace("Plugin Azure: Found waagent used by Azure.")
       true
     end
@@ -55,8 +55,8 @@ Ohai.plugin(:Azure) do
 
   def has_dhcp_option_245?
     has_245 = false
-    if File.exist?("/var/lib/dhcp/dhclient.eth0.leases")
-      File.open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
+    if file_exist?("/var/lib/dhcp/dhclient.eth0.leases")
+      file_open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
         if /unknown-245/.match?(line)
           logger.trace("Plugin Azure: Found unknown-245 DHCP option used by Azure.")
           has_245 = true

--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -66,7 +66,7 @@ Ohai.plugin(:Virtualization) do
     end
 
     # Detect bhyve by presence of /dev/vmm
-    if File.exist?("/dev/vmm")
+    if file_exist?("/dev/vmm")
       virtualization[:system] = "bhyve"
       virtualization[:role] = "host"
       virtualization[:systems][:bhyve] = "host"

--- a/lib/ohai/plugins/chef.rb
+++ b/lib/ohai/plugins/chef.rb
@@ -19,7 +19,7 @@
 Ohai.plugin(:Chef) do
   provides "chef_packages/chef"
 
-  collect_data do
+  collect_data(:default, :target) do
     begin
       require "chef/version"
     rescue Gem::LoadError

--- a/lib/ohai/plugins/cpu.rb
+++ b/lib/ohai/plugins/cpu.rb
@@ -30,7 +30,7 @@ Ohai.plugin(:CPU) do
   def parse_bsd_dmesg(&block)
     cpuinfo = Mash.new
     cpuinfo["flags"] = []
-    File.open("/var/run/dmesg.boot").each do |line|
+    file_open("/var/run/dmesg.boot").each do |line|
       case line
       when /CPU:\s+(.+) \(([\d.]+).+\)/
         cpuinfo["model_name"] = $1
@@ -53,7 +53,7 @@ Ohai.plugin(:CPU) do
     cpu_number = 0
     current_cpu = nil
 
-    File.open("/proc/cpuinfo").each do |line|
+    file_open("/proc/cpuinfo").each do |line|
       case line
       when /processor\s+:\s(.+)/
         cpuinfo[$1] = Mash.new
@@ -212,7 +212,7 @@ Ohai.plugin(:CPU) do
     # to scrape from dmesg.boot is the cpu feature list.
     # cpu0: FPU,V86,DE,PSE,TSC,MSR,MCE,CX8,SEP,MTRR,PGE,MCA,CMOV,PAT,CFLUSH,DS,ACPI,MMX,FXSR,SSE,SSE2,SS,TM,SBF,EST,TM2
 
-    File.open("/var/run/dmesg.boot").each do |line|
+    file_open("/var/run/dmesg.boot").each do |line|
       case line
       when /cpu\d+:\s+([A-Z]+$|[A-Z]+,.*$)/
         cpuinfo["flags"] = $1.downcase.split(",")
@@ -235,7 +235,7 @@ Ohai.plugin(:CPU) do
     # available instruction set
     # cpu0 at mainbus0 apid 0: Intel 686-class, 2134MHz, id 0x6f6
 
-    File.open("/var/run/dmesg.boot").each do |line|
+    file_open("/var/run/dmesg.boot").each do |line|
       case line
       when /cpu[\d\w\s]+:\s([\w\s\-]+),\s+(\w+),/
         cpuinfo[:model_name] = $1

--- a/lib/ohai/plugins/darwin/virtualization.rb
+++ b/lib/ohai/plugins/darwin/virtualization.rb
@@ -35,7 +35,7 @@ Ohai.plugin(:Virtualization) do
   end
 
   def fusion_exists?
-    ::File.exist?("/Applications/VMware\ Fusion.app/")
+    file_exist?("/Applications/VMware\ Fusion.app/")
   end
 
   def docker_exists?

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -97,8 +97,8 @@ Ohai.plugin(:EC2) do
   # @param path[String] abs path to the file
   # @return [String] contents of the file if it exists
   def file_val_if_exists(path)
-    if ::File.exist?(path)
-      ::File.read(path)
+    if file_exist?(path)
+      file_read(path)
     end
   end
 

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -29,7 +29,7 @@ Ohai.plugin(:Filesystem) do
   def find_device(name)
     %w{/dev /dev/mapper}.each do |dir|
       path = File.join(dir, name)
-      return path if File.exist?(path)
+      return path if file_exist?(path)
     end
     name
   end
@@ -371,11 +371,11 @@ Ohai.plugin(:Filesystem) do
     end
 
     # Grab any missing mount information from /proc/mounts
-    if File.exist?("/proc/mounts")
+    if file_exist?("/proc/mounts")
       mounts = ""
       # Due to https://tickets.opscode.com/browse/OHAI-196
       # we have to non-block read dev files. Ew.
-      f = File.open("/proc/mounts")
+      f = file_open("/proc/mounts")
       loop do
         data = f.read_nonblock(4096)
         mounts << data

--- a/lib/ohai/plugins/gce.rb
+++ b/lib/ohai/plugins/gce.rb
@@ -40,8 +40,8 @@ Ohai.plugin(:GCE) do
   # @param path[String] abs path to the file
   # @return [String] contents of the file if it exists
   def file_val_if_exists(path)
-    if ::File.exist?(path)
-      ::File.read(path)
+    if file_exist?(path)
+      file_read(path)
     end
   end
 

--- a/lib/ohai/plugins/init_package.rb
+++ b/lib/ohai/plugins/init_package.rb
@@ -20,6 +20,6 @@ Ohai.plugin(:InitPackage) do
   provides "init_package"
 
   collect_data(:linux) do
-    init_package File.exist?("/proc/1/comm") ? File.open("/proc/1/comm").gets.chomp : "init"
+    init_package file_exist?("/proc/1/comm") ? file_open("/proc/1/comm").gets.chomp : "init"
   end
 end

--- a/lib/ohai/plugins/joyent.rb
+++ b/lib/ohai/plugins/joyent.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Joyent) do
   depends "os", "platform", "virtualization"
 
   def collect_product_file
-    data = ::File.read("/etc/product") rescue nil
+    data = file_read("/etc/product") rescue nil
     if data
       data.strip.split("\n")
     else
@@ -34,7 +34,7 @@ Ohai.plugin(:Joyent) do
   end
 
   def collect_pkgsrc
-    data = ::File.read("/opt/local/etc/pkg_install.conf") rescue nil
+    data = file_read("/opt/local/etc/pkg_install.conf") rescue nil
     if data
       /PKG_PATH=(.*)/.match(data)[1] rescue nil
     end

--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -156,6 +156,10 @@ Ohai.plugin(:Kernel) do
     ].include?(name)
   end
 
+  collect_data(:target) do
+    # intentionally left blank
+  end
+
   collect_data(:default) do
     kernel init_kernel
   end
@@ -204,8 +208,8 @@ Ohai.plugin(:Kernel) do
       if line =~ /([a-zA-Z0-9\_]+)\s+(\d+)\s+(\d+)/
         modules[$1] = { size: $2, refcount: $3 }
         # Making sure to get the module version that has been loaded
-        if File.exist?("/sys/module/#{$1}/version")
-          version = File.read("/sys/module/#{$1}/version").chomp.strip
+        if file_exist?("/sys/module/#{$1}/version")
+          version = file_read("/sys/module/#{$1}/version").chomp.strip
           modules[$1]["version"] = version unless version.empty?
         end
       end
@@ -230,7 +234,7 @@ Ohai.plugin(:Kernel) do
     so = shell_out("uname -s")
     kernel[:os] = so.stdout.split($/)[0]
 
-    so = File.open("/etc/release", &:gets)
+    so = file_open("/etc/release", &:gets)
     md = /(?<update>\d.*\d)/.match(so)
     kernel[:update] = md[:update] if md
 

--- a/lib/ohai/plugins/linux/block_device.rb
+++ b/lib/ohai/plugins/linux/block_device.rb
@@ -20,24 +20,24 @@ Ohai.plugin(:BlockDevice) do
   provides "block_device"
 
   collect_data(:linux) do
-    if File.exist?("/sys/block")
+    if file_exist?("/sys/block")
       block = Mash.new
-      Dir["/sys/block/*"].each do |block_device_dir|
+      dir_glob("/sys/block/*").each do |block_device_dir|
         dir = File.basename(block_device_dir)
         block[dir] = Mash.new
         %w{size removable}.each do |check|
-          if File.exist?("/sys/block/#{dir}/#{check}")
-            File.open("/sys/block/#{dir}/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+          if file_exist?("/sys/block/#{dir}/#{check}")
+            file_open("/sys/block/#{dir}/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
         %w{model rev state timeout vendor queue_depth}.each do |check|
-          if File.exist?("/sys/block/#{dir}/device/#{check}")
-            File.open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+          if file_exist?("/sys/block/#{dir}/device/#{check}")
+            file_open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
         %w{rotational physical_block_size logical_block_size}.each do |check|
-          if File.exist?("/sys/block/#{dir}/queue/#{check}")
-            File.open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+          if file_exist?("/sys/block/#{dir}/queue/#{check}")
+            file_open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
       end

--- a/lib/ohai/plugins/linux/interrupts.rb
+++ b/lib/ohai/plugins/linux/interrupts.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Interrupts) do
   # format: comma-separate list of 32bit bitmask in hex
   # each bit is a CPU, right to left ordering (i.e. CPU0 is rightmost)
   def parse_smp_affinity(path, cpus)
-    masks = File.read(path).strip
+    masks = file_read(path).strip
     bit_masks = []
     masks.split(",").each do |mask|
       bit_masks << mask.rjust(8, "0").to_i(16).to_s(2)
@@ -47,7 +47,7 @@ Ohai.plugin(:Interrupts) do
       parse_smp_affinity("/proc/irq/default_smp_affinity", cpus)
 
     interrupts[:irq] = Mash.new
-    File.open("/proc/interrupts").each do |line|
+    file_open("/proc/interrupts").each do |line|
       # Documentation: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
       # format is "{irqn}: {CPUn...} [type] [vector] [device]"
       irqn, fields = line.split(":", 2)
@@ -70,7 +70,7 @@ Ohai.plugin(:Interrupts) do
         interrupts[:irq][irqn][:vector],
         interrupts[:irq][irqn][:device] =
           fields[cpus].split
-        if File.exist?("/proc/irq/#{irqn}/smp_affinity")
+        if file_exist?("/proc/irq/#{irqn}/smp_affinity")
           interrupts[:irq][irqn][:smp_affinity_by_cpu] =
             parse_smp_affinity("/proc/irq/#{irqn}/smp_affinity", cpus)
         end

--- a/lib/ohai/plugins/linux/lsb.rb
+++ b/lib/ohai/plugins/linux/lsb.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:LSB) do
   collect_data(:linux) do
     lsb Mash.new
 
-    if File.exist?("/usr/bin/lsb_release")
+    if file_exist?("/usr/bin/lsb_release")
       # From package redhat-lsb on Fedora/Redhat, lsb-release on Debian/Ubuntu
       shell_out("lsb_release -a").stdout.lines do |line|
         case line
@@ -38,9 +38,9 @@ Ohai.plugin(:LSB) do
           lsb[:id] = line
         end
       end
-    elsif File.exist?("/etc/lsb-release")
+    elsif file_exist?("/etc/lsb-release")
       # Old, non-standard Debian support
-      File.open("/etc/lsb-release").each do |line|
+      file_open("/etc/lsb-release").each do |line|
         case line
         when /^DISTRIB_ID=["']?(.+?)["']?$/
           lsb[:id] = $1

--- a/lib/ohai/plugins/linux/machineid.rb
+++ b/lib/ohai/plugins/linux/machineid.rb
@@ -20,10 +20,10 @@ Ohai.plugin(:Machineid) do
   provides "machine_id"
 
   collect_data(:linux) do
-    if ::File.exist?("/etc/machine-id")
-      mid = ::File.read("/etc/machine-id").chomp
-    elsif ::File.exist?("/var/lib/dbus/machine-id")
-      mid = ::File.read("/var/lib/dbus/machine-id").chomp
+    if file_exist?("/etc/machine-id")
+      mid = file_read("/etc/machine-id").chomp
+    elsif file_exist?("/var/lib/dbus/machine-id")
+      mid = file_read("/var/lib/dbus/machine-id").chomp
     else
       mid = nil
     end

--- a/lib/ohai/plugins/linux/mdadm.rb
+++ b/lib/ohai/plugins/linux/mdadm.rb
@@ -53,9 +53,9 @@ Ohai.plugin(:Mdadm) do
 
   collect_data(:linux) do
     # gather a list of all raid arrays
-    if File.exist?("/proc/mdstat")
+    if file_exist?("/proc/mdstat")
       devices = {}
-      File.open("/proc/mdstat").each do |line|
+      file_open("/proc/mdstat").each do |line|
         if line =~ /(md[0-9]+)/
           device = Regexp.last_match[1]
           pieces = line.split(/\s+/)

--- a/lib/ohai/plugins/linux/memory.rb
+++ b/lib/ohai/plugins/linux/memory.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Memory) do
     memory[:hugepages] = Mash.new
     memory[:directmap] = Mash.new
 
-    File.open("/proc/meminfo").each do |line|
+    file_open("/proc/meminfo").each do |line|
       case line
       when /^MemTotal:\s+(\d+) (.+)$/
         memory[:total] = "#{$1}#{$2}"

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -35,7 +35,7 @@ Ohai.plugin(:Network) do
   end
 
   def ipv6_enabled?
-    File.exist? "/proc/net/if_inet6"
+    file_exist? "/proc/net/if_inet6"
   end
 
   def ethtool_binary_path
@@ -43,11 +43,11 @@ Ohai.plugin(:Network) do
   end
 
   def is_openvz?
-    @openvz ||= ::File.directory?("/proc/vz")
+    @openvz ||= file_directory?("/proc/vz")
   end
 
   def is_openvz_host?
-    is_openvz? && ::File.directory?("/proc/bc")
+    is_openvz? && file_directory?("/proc/bc")
   end
 
   def extract_neighbors(family, iface, neigh_attr)

--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -43,9 +43,9 @@ Ohai.plugin(:Platform) do
   # @returns [Hash] the file parsed into a Hash or nil
   #
   def read_os_release_info(file)
-    return nil unless File.exist?(file)
+    return nil unless file_exist?(file)
 
-    File.read(file).split.inject({}) do |map, line|
+    file_read(file).split.inject({}) do |map, line|
       key, value = line.split("=")
       map[key] = value.gsub(/\A"|"\Z/, "") if value
       map
@@ -64,7 +64,7 @@ Ohai.plugin(:Platform) do
       begin
         os_release_info = read_os_release_info("/etc/os-release")
         cisco_release_info = os_release_info["CISCO_RELEASE_INFO"] if os_release_info
-        if cisco_release_info && File.exist?(cisco_release_info)
+        if cisco_release_info && file_exist?(cisco_release_info)
           os_release_info.merge!(read_os_release_info(cisco_release_info))
         end
         os_release_info
@@ -77,7 +77,7 @@ Ohai.plugin(:Platform) do
   # @returns [Boolean] if we are Cisco according to /etc/os-release
   #
   def os_release_file_is_cisco?
-    File.exist?("/etc/os-release") && os_release_info["CISCO_RELEASE_INFO"]
+    file_exist?("/etc/os-release") && os_release_info["CISCO_RELEASE_INFO"]
   end
 
   #
@@ -88,7 +88,7 @@ Ohai.plugin(:Platform) do
   # @returns [String] bigip Linux version from /etc/f5-release
   #
   def bigip_version
-    release_contents = File.read("/etc/f5-release")
+    release_contents = file_read("/etc/f5-release")
     release_contents.match(/BIG-IP release (\S*)/)[1] # http://rubular.com/r/O8nlrBVqSb
   rescue NoMethodError, Errno::ENOENT, Errno::EACCES # rescue regex failure, file missing, or permission denied
     logger.warn("Detected F5 Big-IP, but /etc/f5-release could not be parsed to determine platform_version")
@@ -178,18 +178,18 @@ Ohai.plugin(:Platform) do
   # @deprecated
   def legacy_platform_detection
     # platform [ and platform_version ? ] should be lower case to avoid dealing with RedHat/Redhat/redhat matching
-    if File.exist?("/etc/oracle-release")
-      contents = File.read("/etc/oracle-release").chomp
+    if file_exist?("/etc/oracle-release")
+      contents = file_read("/etc/oracle-release").chomp
       platform "oracle"
       platform_version get_redhatish_version(contents)
-    elsif File.exist?("/etc/enterprise-release")
-      contents = File.read("/etc/enterprise-release").chomp
+    elsif file_exist?("/etc/enterprise-release")
+      contents = file_read("/etc/enterprise-release").chomp
       platform "oracle"
       platform_version get_redhatish_version(contents)
-    elsif File.exist?("/etc/f5-release")
+    elsif file_exist?("/etc/f5-release")
       platform "bigip"
       platform_version bigip_version
-    elsif File.exist?("/etc/debian_version")
+    elsif file_exist?("/etc/debian_version")
       # Ubuntu and Debian both have /etc/debian_version
       # Ubuntu should always have a working lsb, debian does not by default
       if /Ubuntu/i.match?(lsb[:id])
@@ -197,25 +197,25 @@ Ohai.plugin(:Platform) do
         platform_version lsb[:release]
       else
         platform "debian"
-        platform_version File.read("/etc/debian_version").chomp
+        platform_version file_read("/etc/debian_version").chomp
       end
-    elsif File.exist?("/etc/parallels-release")
-      contents = File.read("/etc/parallels-release").chomp
+    elsif file_exist?("/etc/parallels-release")
+      contents = file_read("/etc/parallels-release").chomp
       platform get_redhatish_platform(contents)
       platform_version contents.match(/(\d\.\d\.\d)/)[0]
-    elsif File.exist?("/etc/Eos-release")
+    elsif file_exist?("/etc/Eos-release")
       platform "arista_eos"
-      platform_version File.read("/etc/Eos-release").strip.split[-1]
-    elsif File.exist?("/etc/redhat-release")
-      contents = File.read("/etc/redhat-release").chomp
+      platform_version file_read("/etc/Eos-release").strip.split[-1]
+    elsif file_exist?("/etc/redhat-release")
+      contents = file_read("/etc/redhat-release").chomp
       platform get_redhatish_platform(contents)
       platform_version get_redhatish_version(contents)
-    elsif File.exist?("/etc/system-release")
-      contents = File.read("/etc/system-release").chomp
+    elsif file_exist?("/etc/system-release")
+      contents = file_read("/etc/system-release").chomp
       platform get_redhatish_platform(contents)
       platform_version get_redhatish_version(contents)
-    elsif File.exist?("/etc/SuSE-release")
-      suse_release = File.read("/etc/SuSE-release")
+    elsif file_exist?("/etc/SuSE-release")
+      suse_release = file_read("/etc/SuSE-release")
       suse_version = suse_release.scan(/VERSION = (\d+)\nPATCHLEVEL = (\d+)/).flatten.join(".")
       suse_version = suse_release[/VERSION = ([\d\.]{2,})/, 1] if suse_version == ""
       platform_version suse_version
@@ -243,16 +243,16 @@ Ohai.plugin(:Platform) do
       end
 
       platform_version os_release_info["VERSION"]
-    elsif File.exist?("/etc/slackware-version")
+    elsif file_exist?("/etc/slackware-version")
       platform "slackware"
-      platform_version File.read("/etc/slackware-version").scan(/(\d+|\.+)/).join
-    elsif File.exist?("/etc/exherbo-release")
+      platform_version file_read("/etc/slackware-version").scan(/(\d+|\.+)/).join
+    elsif file_exist?("/etc/exherbo-release")
       platform "exherbo"
       # no way to determine platform_version in a rolling release distribution
       # kernel release will be used - ex. 3.13
       platform_version shell_out("/bin/uname -r").stdout.strip
-    elsif File.exist?("/usr/lib/os-release")
-      contents = File.read("/usr/lib/os-release")
+    elsif file_exist?("/usr/lib/os-release")
+      contents = file_read("/usr/lib/os-release")
       if /clear-linux-os/.match?(contents) # Clear Linux https://clearlinux.org/
         platform "clearlinux"
         platform_version contents[/VERSION_ID=(\d+)/, 1]
@@ -285,14 +285,14 @@ Ohai.plugin(:Platform) do
   def determine_os_version
     # centos only includes the major version in os-release for some reason
     if os_release_info["ID"] == "centos"
-      get_redhatish_version(File.read("/etc/redhat-release").chomp)
+      get_redhatish_version(file_read("/etc/redhat-release").chomp)
     else
       os_release_info["VERSION_ID"] || shell_out("/bin/uname -r").stdout.strip
     end
   end
 
   collect_data(:linux) do
-    if ::File.exist?("/etc/os-release")
+    if file_exist?("/etc/os-release")
       logger.trace("Plugin platform: Using /etc/os-release for platform detection")
 
       # fixup os-release names to ohai platform names

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -51,15 +51,15 @@ Ohai.plugin(:Virtualization) do
     # - may be able to determine if under paravirt from /dev/xen/evtchn (See OHAI-253)
     # - Additional edge cases likely should not change the above assumptions
     #   but rather be additive - btm
-    if File.exist?("/proc/xen")
+    if file_exist?("/proc/xen")
       virtualization[:system] = "xen"
       # Assume guest
       virtualization[:role] = "guest"
       virtualization[:systems][:xen] = "guest"
 
       # This file should exist on most Xen systems, normally empty for guests
-      if File.exist?("/proc/xen/capabilities")
-        if /control_d/i.match?(File.read("/proc/xen/capabilities"))
+      if file_exist?("/proc/xen/capabilities")
+        if /control_d/i.match?(file_read("/proc/xen/capabilities"))
           logger.trace("Plugin Virtualization: /proc/xen/capabilities contains control_d. Detecting as Xen host")
           virtualization[:role] = "host"
           virtualization[:systems][:xen] = "host"
@@ -68,8 +68,8 @@ Ohai.plugin(:Virtualization) do
     end
 
     # Detect Virtualbox from kernel module
-    if File.exist?("/proc/modules")
-      modules = File.read("/proc/modules")
+    if file_exist?("/proc/modules")
+      modules = file_read("/proc/modules")
       if /^vboxdrv/.match?(modules)
         logger.trace("Plugin Virtualization: /proc/modules contains vboxdrv. Detecting as vbox host")
         virtualization[:system] = "vbox"
@@ -92,8 +92,8 @@ Ohai.plugin(:Virtualization) do
     end
 
     # Detect paravirt KVM/QEMU from cpuinfo, report as KVM
-    if File.exist?("/proc/cpuinfo")
-      if /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/.match?(File.read("/proc/cpuinfo"))
+    if file_exist?("/proc/cpuinfo")
+      if /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/.match?(file_read("/proc/cpuinfo"))
         logger.trace("Plugin Virtualization: /proc/cpuinfo lists a KVM paravirt CPU string. Detecting as kvm guest")
         virtualization[:system] = "kvm"
         virtualization[:role] = "guest"
@@ -103,9 +103,9 @@ Ohai.plugin(:Virtualization) do
 
     # Detect KVM systems via /sys
     # guests will have the hypervisor cpu feature that hosts don't have
-    if File.exist?("/sys/devices/virtual/misc/kvm")
+    if file_exist?("/sys/devices/virtual/misc/kvm")
       virtualization[:system] = "kvm"
-      if /hypervisor/.match?(File.read("/proc/cpuinfo"))
+      if /hypervisor/.match?(file_read("/proc/cpuinfo"))
         logger.trace("Plugin Virtualization: /sys/devices/virtual/misc/kvm present and /proc/cpuinfo lists the hypervisor feature. Detecting as kvm guest")
         virtualization[:role] = "guest"
         virtualization[:systems][:kvm] = "guest"
@@ -129,12 +129,12 @@ Ohai.plugin(:Virtualization) do
 
     # Detect OpenVZ / Virtuozzo.
     # http://wiki.openvz.org/BC_proc_entries
-    if File.exist?("/proc/bc/0")
+    if file_exist?("/proc/bc/0")
       logger.trace("Plugin Virtualization: /proc/bc/0 exists. Detecting as openvz host")
       virtualization[:system] = "openvz"
       virtualization[:role] = "host"
       virtualization[:systems][:openvz] = "host"
-    elsif File.exist?("/proc/vz")
+    elsif file_exist?("/proc/vz")
       logger.trace("Plugin Virtualization: /proc/vz exists. Detecting as openvz guest")
       virtualization[:system] = "openvz"
       virtualization[:role] = "guest"
@@ -142,9 +142,9 @@ Ohai.plugin(:Virtualization) do
     end
 
     # Detect Hyper-V guest and the hostname of the host
-    if File.exist?("/var/lib/hyperv/.kvp_pool_3")
+    if file_exist?("/var/lib/hyperv/.kvp_pool_3")
       logger.trace("Plugin Virtualization: /var/lib/hyperv/.kvp_pool_3 contains string indicating Hyper-V guest")
-      data = File.read("/var/lib/hyperv/.kvp_pool_3")
+      data = file_read("/var/lib/hyperv/.kvp_pool_3")
       hyperv_host = data[/\HostName(.*?)HostingSystemEditionId/, 1].scan(/[[:print:]]/).join.downcase
       virtualization[:system] = "hyperv"
       virtualization[:role] = "guest"
@@ -153,8 +153,8 @@ Ohai.plugin(:Virtualization) do
     end
 
     # Detect Linux-VServer
-    if File.exist?("/proc/self/status")
-      proc_self_status = File.read("/proc/self/status")
+    if file_exist?("/proc/self/status")
+      proc_self_status = file_read("/proc/self/status")
       vxid = proc_self_status.match(/^(s_context|VxID):\s*(\d+)$/)
       if vxid && vxid[2]
         virtualization[:system] = "linux-vserver"
@@ -188,8 +188,8 @@ Ohai.plugin(:Virtualization) do
     #
     # Full notes, https://tickets.opscode.com/browse/OHAI-551
     # Kernel docs, https://www.kernel.org/doc/Documentation/cgroups
-    if File.exist?("/proc/self/cgroup")
-      cgroup_content = File.read("/proc/self/cgroup")
+    if file_exist?("/proc/self/cgroup")
+      cgroup_content = file_read("/proc/self/cgroup")
       # These two REs catch many different examples. Here's a specific one
       # from when it is docker and there is no subsystem name.
       # https://rubular.com/r/dV13hiU9KxmiWB
@@ -199,17 +199,17 @@ Ohai.plugin(:Virtualization) do
         virtualization[:system] = $1
         virtualization[:role] = "guest"
         virtualization[:systems][$1.to_sym] = "guest"
-      elsif /container=lxc/.match?(File.read("/proc/1/environ"))
+      elsif /container=lxc/.match?(file_read("/proc/1/environ"))
         logger.trace("Plugin Virtualization: /proc/1/environ indicates lxc container. Detecting as lxc guest")
         virtualization[:system] = "lxc"
         virtualization[:role] = "guest"
         virtualization[:systems][:lxc] = "guest"
-      elsif /container=systemd-nspawn/.match?(File.read("/proc/1/environ"))
+      elsif /container=systemd-nspawn/.match?(file_read("/proc/1/environ"))
         logger.trace("Plugin Virtualization: /proc/1/environ indicates nspawn container. Detecting as nspawn guest")
         virtualization[:system] = "nspawn"
         virtualization[:role] = "guest"
         virtualization[:systems][:nspawn] = "guest"
-      elsif lxc_version_exists? && File.read("/proc/self/cgroup") =~ %r{\d:[^:]+:/$}
+      elsif lxc_version_exists? && file_read("/proc/self/cgroup") =~ %r{\d:[^:]+:/$}
         # lxc-version shouldn't be installed by default
         # Even so, it is likely we are on an LXC capable host that is not being used as such
         # So we're cautious here to not overwrite other existing values (OHAI-573)
@@ -224,7 +224,7 @@ Ohai.plugin(:Virtualization) do
         # If so, we may need to look further for a differentiator (OHAI-573)
         virtualization[:systems][:lxc] = "host"
       end
-    elsif File.exist?("/.dockerenv") || File.exist?("/.dockerinit")
+    elsif file_exist?("/.dockerenv") || file_exist?("/.dockerinit")
       logger.trace("Plugin Virtualization: .dockerenv or .dockerinit exist. Detecting as docker guest")
       virtualization[:system] = "docker"
       virtualization[:role] = "guest"
@@ -233,7 +233,7 @@ Ohai.plugin(:Virtualization) do
 
     # Detect LXD
     # See https://github.com/lxc/lxd/blob/master/doc/dev-lxd.md
-    if File.exist?("/dev/lxd/sock")
+    if file_exist?("/dev/lxd/sock")
       logger.trace("Plugin Virtualization: /dev/lxd/sock exists. Detecting as lxd guest")
       virtualization[:system] = "lxd"
       virtualization[:role] = "guest"
@@ -248,7 +248,7 @@ Ohai.plugin(:Virtualization) do
       # Snap based installations utilize '/var/snap/lxd/common/lxd/'
       #   - includes all future releases starting with 2.21, and will be the only source of 3.1+ feature releases post-bionic
       ["/var/lib/lxd/devlxd", "/var/snap/lxd/common/lxd/devlxd"].each do |devlxd|
-        if File.exist?(devlxd)
+        if file_exist?(devlxd)
           logger.trace("Plugin Virtualization: #{devlxd} exists. Detecting as lxd host")
           virtualization[:system] = "lxd"
           virtualization[:role] = "host"

--- a/lib/ohai/plugins/ohai_time.rb
+++ b/lib/ohai/plugins/ohai_time.rb
@@ -19,7 +19,7 @@
 Ohai.plugin(:OhaiTime) do
   provides "ohai_time"
 
-  collect_data do
+  collect_data(:default, :target) do
     ohai_time Time.now.to_f
   end
 end

--- a/lib/ohai/plugins/os.rb
+++ b/lib/ohai/plugins/os.rb
@@ -37,6 +37,10 @@ Ohai.plugin(:OS) do
     os_version shell_out("sysctl -n kern.osreldate").stdout.split($/)[0]
   end
 
+  collect_data(:target) do
+    os collect_os
+  end
+
   collect_data do
     os collect_os
     os_version kernel[:release]

--- a/lib/ohai/plugins/scaleway.rb
+++ b/lib/ohai/plugins/scaleway.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Scaleway) do
   # looks for `scaleway` keyword in kernel command line
   # @return [Boolean] do we have the keyword or not?
   def has_scaleway_cmdline?
-    if ::File.exist?("/proc/cmdline") && /scaleway/.match?(::File.read("/proc/cmdline"))
+    if file_exist?("/proc/cmdline") && /scaleway/.match?(file_read("/proc/cmdline"))
       logger.trace("Plugin Scaleway: has_scaleway_cmdline? == true")
       return true
     end

--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -20,7 +20,7 @@ Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_build", "platform_family"
 
   collect_data(:solaris2) do
-    if File.exist?("/sbin/uname")
+    if file_exist?("/sbin/uname")
       uname_exec = "/sbin/uname"
     else
       uname_exec = "uname"
@@ -35,7 +35,7 @@ Ohai.plugin(:Platform) do
       end
     end
 
-    File.open("/etc/release") do |file|
+    file_open("/etc/release") do |file|
       while ( line = file.gets )
         case line
         when /^.*(SmartOS).*$/

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Virtualization) do
 
     # Detect paravirt KVM/QEMU from cpuinfo, report as KVM
     psrinfo_path = Ohai.abs_path( "/usr/sbin/psrinfo" )
-    if File.exist?(psrinfo_path)
+    if file_exist?(psrinfo_path)
       so = shell_out("#{psrinfo_path} -pv")
       if /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/.match?(so.stdout)
         virtualization[:system] = "kvm"

--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -38,9 +38,9 @@ Ohai.plugin(:SSHHostKey) do
   collect_data do
     keys[:ssh] = Mash.new
 
-    sshd_config = if File.exist?("/etc/ssh/sshd_config")
+    sshd_config = if file_exist?("/etc/ssh/sshd_config")
                     "/etc/ssh/sshd_config"
-                  elsif File.exist?("/etc/sshd_config")
+                  elsif file_exist?("/etc/sshd_config")
                     # Darwin
                     "/etc/sshd_config"
                   else
@@ -49,11 +49,11 @@ Ohai.plugin(:SSHHostKey) do
                   end
 
     if sshd_config
-      File.open(sshd_config) do |conf|
+      file_open(sshd_config) do |conf|
         conf.each_line do |line|
           if /^hostkey\s/i.match?(line)
             pub_file = "#{line.split[1]}.pub"
-            content = IO.read(pub_file).split
+            content = file_read(pub_file).split
             key_type, key_subtype = extract_keytype?(content)
             keys[:ssh]["host_#{key_type}_public"] = content[1] unless key_type.nil?
             keys[:ssh]["host_#{key_type}_type"] = key_subtype unless key_subtype.nil?
@@ -62,22 +62,22 @@ Ohai.plugin(:SSHHostKey) do
       end
     end
 
-    if keys[:ssh][:host_dsa_public].nil? && File.exist?("/etc/ssh/ssh_host_dsa_key.pub")
-      keys[:ssh][:host_dsa_public] = IO.read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
+    if keys[:ssh][:host_dsa_public].nil? && file_exist?("/etc/ssh/ssh_host_dsa_key.pub")
+      keys[:ssh][:host_dsa_public] = file_read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
     end
 
-    if keys[:ssh][:host_rsa_public].nil? && File.exist?("/etc/ssh/ssh_host_rsa_key.pub")
-      keys[:ssh][:host_rsa_public] = IO.read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
+    if keys[:ssh][:host_rsa_public].nil? && file_exist?("/etc/ssh/ssh_host_rsa_key.pub")
+      keys[:ssh][:host_rsa_public] = file_read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
     end
 
-    if keys[:ssh][:host_ecdsa_public].nil? && File.exist?("/etc/ssh/ssh_host_ecdsa_key.pub")
-      content = IO.read("/etc/ssh/ssh_host_ecdsa_key.pub")
+    if keys[:ssh][:host_ecdsa_public].nil? && file_exist?("/etc/ssh/ssh_host_ecdsa_key.pub")
+      content = file_read("/etc/ssh/ssh_host_ecdsa_key.pub")
       keys[:ssh][:host_ecdsa_public] = content.split[1]
       keys[:ssh][:host_ecdsa_type] = content.split[0]
     end
 
-    if keys[:ssh][:host_ed25519_public].nil? && File.exist?("/etc/ssh/ssh_host_ed25519_key.pub")
-      keys[:ssh][:host_ed25519_public] = IO.read("/etc/ssh/ssh_host_ed25519_key.pub").split[1]
+    if keys[:ssh][:host_ed25519_public].nil? && file_exist?("/etc/ssh/ssh_host_ed25519_key.pub")
+      keys[:ssh][:host_ed25519_public] = file_read("/etc/ssh/ssh_host_ed25519_key.pub").split[1]
     end
   end
 end

--- a/lib/ohai/plugins/train.rb
+++ b/lib/ohai/plugins/train.rb
@@ -1,5 +1,4 @@
 #
-# Author:: Tim Smith (<tsmith@chef.io>)
 # Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
@@ -16,15 +15,20 @@
 # limitations under the License.
 #
 
-Ohai.plugin(:Shells) do
-  provides "shells"
+Ohai.plugin(:Train) do
+  provides "train"
 
   collect_data do
-    if file_exist?("/etc/shells")
-      shells []
-      file_open("/etc/shells").readlines.each do |line|
-        # remove carriage returns and skip over comments / empty lines
-        shells << line.chomp if line[0] == "/"
+    if transport_connection
+      train Mash.new
+      train["family_hierarchy"] = transport_connection.platform.family_hierarchy
+      train["family"] = transport_connection.platform.family
+      train["platform"] = transport_connection.platform.platform
+      train["backend"] = transport_connection.backend_type
+      if transport_connection.respond_to?(:uri)
+        train["scheme"] = URI.parse(transport_connection.uri).scheme
+        train["uri"] = transport_connection.uri
+      else
       end
     end
   end

--- a/lib/ohai/plugins/uptime.rb
+++ b/lib/ohai/plugins/uptime.rb
@@ -54,7 +54,7 @@ Ohai.plugin(:Uptime) do
   end
 
   collect_data(:linux) do
-    uptime, idletime = File.open("/proc/uptime").gets.split(" ")
+    uptime, idletime = file_open("/proc/uptime").gets.split(" ")
     uptime_seconds uptime.to_i
     uptime seconds_to_human(uptime.to_i)
     idletime_seconds idletime.to_i

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -41,7 +41,7 @@ Ohai.plugin(:VMware) do
   end
 
   def get_vm_attributes(vmtools_path)
-    if !File.exist?(vmtools_path)
+    if !file_exist?(vmtools_path)
       logger.trace("Plugin VMware: #{vmtools_path} not found")
     else
       vmware Mash.new

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -24,6 +24,9 @@ module Ohai
   class Runner
 
     attr_reader :failed_plugins, :logger
+
+    attr_accessor :transport_connection
+
     # safe_run: set to true if this runner will run plugins in
     # safe-mode. default false.
     def initialize(controller, safe_run = false)
@@ -93,6 +96,7 @@ module Ohai
         end
 
         if dependency_providers.empty?
+          next_plugin.transport_connection = transport_connection
           @safe_run ? next_plugin.safe_run : next_plugin.run
           if next_plugin.failed
             @failed_plugins << next_plugin.name

--- a/lib/ohai/train_transport.rb
+++ b/lib/ohai/train_transport.rb
@@ -1,5 +1,4 @@
-#
-# Author:: Tim Smith (<tsmith@chef.io>)
+# Author:: Bryan McLellan <btm@loftninjas.org>
 # Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
@@ -16,16 +15,14 @@
 # limitations under the License.
 #
 
-Ohai.plugin(:Shells) do
-  provides "shells"
+require "chef-config/mixin/train_transport" unless defined?(ChefConfig::Mixin::TrainTransport)
 
-  collect_data do
-    if file_exist?("/etc/shells")
-      shells []
-      file_open("/etc/shells").readlines.each do |line|
-        # remove carriage returns and skip over comments / empty lines
-        shells << line.chomp if line[0] == "/"
-      end
+module Ohai
+  class TrainTransport
+    include ChefConfig::Mixin::TrainTransport
+
+    def config
+      Ohai::Config
     end
   end
 end

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://github.com/chef/ohai/"
 
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 2.6"
 
   s.add_dependency "chef-config", ">= 12.8", "< 17"
   s.add_dependency "chef-utils", ">= 16.0", "< 17"
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   s.add_dependency "plist", "~> 3.1"
   s.add_dependency "wmi-lite", "~> 1.0"
+  s.add_dependency "train-core"
   # Note for ohai developers: If chef-config causes you grief, try:
   #     bundle install --with development
   # this should work as long as chef is a development dependency in Gemfile.

--- a/spec/functional/plugins/linux/interrupts_spec.rb
+++ b/spec/functional/plugins/linux/interrupts_spec.rb
@@ -26,7 +26,7 @@ describe Ohai::System, "Linux interrupts plugin" do
   end
 
   it "parses smp_affinity (partial mask, all)" do
-    allow(::File).to receive(:read).with("/affinity").and_return("f")
+    allow(plugin).to receive(:file_read).with("/affinity").and_return("f")
     expect(plugin.parse_smp_affinity("/affinity", 2)).to eq({
                                                               0 => true,
                                                               1 => true,
@@ -34,7 +34,7 @@ describe Ohai::System, "Linux interrupts plugin" do
   end
 
   it "parses smp_affinity (partial mask, one)" do
-    allow(::File).to receive(:read).with("/affinity").and_return("e")
+    allow(plugin).to receive(:file_read).with("/affinity").and_return("e")
     expect(plugin.parse_smp_affinity("/affinity", 2)).to eq({
                                                               0 => false,
                                                               1 => true,
@@ -42,7 +42,7 @@ describe Ohai::System, "Linux interrupts plugin" do
   end
 
   it "parses smp_affinity (full mask, all)" do
-    allow(::File).to receive(:read).with("/affinity").and_return("ff")
+    allow(plugin).to receive(:file_read).with("/affinity").and_return("ff")
     expect(plugin.parse_smp_affinity("/affinity", 2)).to eq({
                                                               0 => true,
                                                               1 => true,
@@ -50,7 +50,7 @@ describe Ohai::System, "Linux interrupts plugin" do
   end
 
   it "parses smp_affinity (full mask, one)" do
-    allow(::File).to receive(:read).with("/affinity").and_return("fe")
+    allow(plugin).to receive(:file_read).with("/affinity").and_return("fe")
     expect(plugin.parse_smp_affinity("/affinity", 2)).to eq({
                                                               0 => false,
                                                               1 => true,
@@ -62,7 +62,7 @@ describe Ohai::System, "Linux interrupts plugin" do
     (0..47).each do |i|
       cpus[i] = true
     end
-    allow(::File).to receive(:read).with("/affinity")
+    allow(plugin).to receive(:file_read).with("/affinity")
       .and_return("ffff,ffffffff")
     expect(plugin.parse_smp_affinity("/affinity", 48)).to eq(cpus)
   end
@@ -74,7 +74,7 @@ describe Ohai::System, "Linux interrupts plugin" do
     end
     cpus[12] = false
     cpus[32] = false
-    allow(::File).to receive(:read).with("/affinity")
+    allow(plugin).to receive(:file_read).with("/affinity")
       .and_return("fffe,ffffefff")
     expect(plugin.parse_smp_affinity("/affinity", 48)).to eq(cpus)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,10 +22,6 @@ end
 
 include Ohai::Mixin::ConstantHelper
 
-if Ohai::Mixin::OS.collect_os == /mswin|mingw32|windows/
-  ENV["PATH"] = ""
-end
-
 def get_plugin(plugin, ohai = Ohai::System.new, path = PLUGIN_PATH)
   loader = Ohai::Loader.new(ohai)
   loader.load_plugin(File.join(path, "#{plugin}.rb"))

--- a/spec/unit/dsl/plugin_spec.rb
+++ b/spec/unit/dsl/plugin_spec.rb
@@ -521,7 +521,7 @@ describe Ohai::DSL::Plugin::VersionVII do
 
     it "fails a platform has already been defined in the same plugin" do
       Ohai.plugin(:Test) { collect_data {} }
-      expect(Ohai::Log).to receive(:warn).with(/collect_data already defined on platform/).twice
+      expect(Ohai::Log).to receive(:warn).with(/collect_data already defined on os/).twice
       Ohai.plugin(:Test) do
         collect_data {}
         collect_data {}
@@ -530,7 +530,7 @@ describe Ohai::DSL::Plugin::VersionVII do
 
     it "fails if a platform has already been defined in another plugin file" do
       Ohai.plugin(:Test) { collect_data {} }
-      expect(Ohai::Log).to receive(:warn).with(/collect_data already defined on platform/)
+      expect(Ohai::Log).to receive(:warn).with(/collect_data already defined on os/)
       Ohai.plugin(:Test) do
         collect_data {}
       end

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -130,7 +130,7 @@ describe Ohai::Loader do
 
       describe "when the plugin defines collect_data on the same platform more than once" do
         it "shoud log an illegal plugin definition warning" do
-          expect(Ohai::Log).to receive(:warn).with(/collect_data already defined on platform/)
+          expect(Ohai::Log).to receive(:warn).with(/collect_data already defined on os/)
           loader.load_plugin(path_to("illegal_def.rb"))
         end
 

--- a/spec/unit/mixin/which_spec.rb
+++ b/spec/unit/mixin/which_spec.rb
@@ -20,19 +20,20 @@ require "spec_helper"
 
 class FileHelperMock
   include Ohai::Mixin::Which
+  def transport_connection
+    nil
+  end
 end
 
 describe "Ohai::Mixin::Which" do
   let(:file_helper) { FileHelperMock.new }
 
   before do
-    old_env = ENV
-    ENV["Path"] = ENV["PATH"] = "/usr/bin"
+    Ohai::Mixin::ChefUtilsWiring::PathCache.instance.path_cache = "/usr/bin"
     allow(file_helper).to receive(:name).and_return("Fakeclass")
     logger = instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil)
     allow(file_helper).to receive(:logger).and_return(logger)
     allow(File).to receive(:executable?).and_return(false)
-    ENV = old_env
   end
 
   describe "which" do

--- a/spec/unit/plugins/azure_spec.rb
+++ b/spec/unit/plugins/azure_spec.rb
@@ -134,9 +134,9 @@ describe Ohai::System, "plugin azure" do
   describe "without azure hint file or agent or dhcp options" do
     before do
       allow(plugin).to receive(:hint?).with("azure").and_return(false)
-      allow(File).to receive(:exist?).with("/usr/sbin/waagent").and_return(false)
-      allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
-      allow(File).to receive(:exist?).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(true)
+      allow(plugin).to receive(:file_exist?).with("/usr/sbin/waagent").and_return(false)
+      allow(plugin).to receive(:dir_exist?).with('C:\WindowsAzure').and_return(false)
+      allow(plugin).to receive(:file_exist?).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(true)
       @double_file = double("/var/lib/dhcp/dhclient.eth0.leases")
       allow(@double_file).to receive(:each)
         .and_yield("lease {")
@@ -158,7 +158,7 @@ describe Ohai::System, "plugin azure" do
         .and_yield("  rebind 2 2016/03/01 13:22:07;")
         .and_yield("  expire 2 2016/03/01 16:40:56;")
         .and_yield("}")
-      allow(File).to receive(:open).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(@double_file)
+      allow(plugin).to receive(:file_open).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(@double_file)
     end
 
     it_behaves_like "!azure"
@@ -168,9 +168,9 @@ describe Ohai::System, "plugin azure" do
     before do
       allow(plugin).to receive(:hint?).with("rackspace").and_return(true)
       allow(plugin).to receive(:hint?).with("azure").and_return(false)
-      allow(File).to receive(:exist?).with("/usr/sbin/waagent").and_return(false)
-      allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
-      allow(File).to receive(:exist?).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(false)
+      allow(plugin).to receive(:file_exist?).with("/usr/sbin/waagent").and_return(false)
+      allow(plugin).to receive(:dir_exist?).with('C:\WindowsAzure').and_return(false)
+      allow(plugin).to receive(:file_exist?).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(false)
     end
 
     it_behaves_like "!azure"
@@ -179,8 +179,8 @@ describe Ohai::System, "plugin azure" do
   describe "without azure hint file but with agent on linux" do
     before do
       allow(plugin).to receive(:hint?).with("azure").and_return(false)
-      allow(File).to receive(:exist?).with("/usr/sbin/waagent").and_return(true)
-      allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
+      allow(plugin).to receive(:file_exist?).with("/usr/sbin/waagent").and_return(true)
+      allow(plugin).to receive(:dir_exist?).with('C:\WindowsAzure').and_return(false)
     end
 
     it_behaves_like "azure"
@@ -189,8 +189,8 @@ describe Ohai::System, "plugin azure" do
   describe "without azure hint file but with agent on windows" do
     before do
       allow(plugin).to receive(:hint?).with("azure").and_return(false)
-      allow(File).to receive(:exist?).with("/usr/sbin/waagent").and_return(false)
-      allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(true)
+      allow(plugin).to receive(:file_exist?).with("/usr/sbin/waagent").and_return(false)
+      allow(plugin).to receive(:dir_exist?).with('C:\WindowsAzure').and_return(true)
     end
 
     it_behaves_like "azure"
@@ -199,9 +199,9 @@ describe Ohai::System, "plugin azure" do
   describe "without azure hint or agent but with dhcp option" do
     before do
       allow(plugin).to receive(:hint?).with("azure").and_return(false)
-      allow(File).to receive(:exist?).with("/usr/sbin/waagent").and_return(false)
-      allow(Dir).to receive(:exist?).with('C:\WindowsAzure').and_return(false)
-      allow(File).to receive(:exist?).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(true)
+      allow(plugin).to receive(:file_exist?).with("/usr/sbin/waagent").and_return(false)
+      allow(plugin).to receive(:dir_exist?).with('C:\WindowsAzure').and_return(false)
+      allow(plugin).to receive(:file_exist?).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(true)
       @double_file = double("/var/lib/dhcp/dhclient.eth0.leases")
       allow(@double_file).to receive(:each)
         .and_yield("lease {")
@@ -223,7 +223,7 @@ describe Ohai::System, "plugin azure" do
         .and_yield("  rebind 5 2152/03/10 09:03:39;")
         .and_yield("  expire 5 2152/03/10 09:03:39;")
         .and_yield("}")
-      allow(File).to receive(:open).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(@double_file)
+      allow(plugin).to receive(:file_open).with("/var/lib/dhcp/dhclient.eth0.leases").and_return(@double_file)
     end
 
     it_behaves_like "azure"

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -25,9 +25,9 @@ describe Ohai::System, "plugin ec2" do
 
   before do
     allow(plugin).to receive(:hint?).with("ec2").and_return(false)
-    allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(false)
-    allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_vendor").and_return(false)
-    allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_version").and_return(false)
+    allow(plugin).to receive(:file_exist?).with("/sys/hypervisor/uuid").and_return(false)
+    allow(plugin).to receive(:file_exist?).with("/sys/class/dmi/id/bios_vendor").and_return(false)
+    allow(plugin).to receive(:file_exist?).with("/sys/class/dmi/id/bios_version").and_return(false)
   end
 
   shared_examples_for "!ec2" do
@@ -334,8 +334,8 @@ describe Ohai::System, "plugin ec2" do
 
   describe "with amazon dmi bios version data" do
     before do
-      allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_version").and_return(true)
-      allow(File).to receive(:read).with("/sys/class/dmi/id/bios_version").and_return("4.2.amazon\n")
+      allow(plugin).to receive(:file_exist?).with("/sys/class/dmi/id/bios_version").and_return(true)
+      allow(plugin).to receive(:file_read).with("/sys/class/dmi/id/bios_version").and_return("4.2.amazon\n")
     end
 
     it_behaves_like "ec2"
@@ -344,8 +344,8 @@ describe Ohai::System, "plugin ec2" do
 
   describe "with non-amazon dmi bios version data" do
     before do
-      allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_version").and_return(true)
-      allow(File).to receive(:read).with("/sys/class/dmi/id/bios_version").and_return("1.0\n")
+      allow(plugin).to receive(:file_exist?).with("/sys/class/dmi/id/bios_version").and_return(true)
+      allow(plugin).to receive(:file_read).with("/sys/class/dmi/id/bios_version").and_return("1.0\n")
     end
 
     it_behaves_like "!ec2"
@@ -354,8 +354,8 @@ describe Ohai::System, "plugin ec2" do
 
   describe "with amazon dmi bios vendor data" do
     before do
-      allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_vendor").and_return(true)
-      allow(File).to receive(:read).with("/sys/class/dmi/id/bios_vendor").and_return("Amazon EC2\n")
+      allow(plugin).to receive(:file_exist?).with("/sys/class/dmi/id/bios_vendor").and_return(true)
+      allow(plugin).to receive(:file_read).with("/sys/class/dmi/id/bios_vendor").and_return("Amazon EC2\n")
     end
 
     it_behaves_like "ec2"
@@ -364,8 +364,8 @@ describe Ohai::System, "plugin ec2" do
 
   describe "with non-amazon dmi bios vendor data" do
     before do
-      allow(File).to receive(:exist?).with("/sys/class/dmi/id/bios_vendor").and_return(true)
-      allow(File).to receive(:read).with("/sys/class/dmi/id/bios_vendor").and_return("Xen\n")
+      allow(plugin).to receive(:file_exist?).with("/sys/class/dmi/id/bios_vendor").and_return(true)
+      allow(plugin).to receive(:file_read).with("/sys/class/dmi/id/bios_vendor").and_return("Xen\n")
     end
 
     it_behaves_like "!ec2"
@@ -374,8 +374,8 @@ describe Ohai::System, "plugin ec2" do
 
   describe "with EC2 Xen UUID" do
     before do
-      allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(true)
-      allow(File).to receive(:read).with("/sys/hypervisor/uuid").and_return("ec2a0561-e4d6-8e15-d9c8-2e0e03adcde8\n")
+      allow(plugin).to receive(:file_exist?).with("/sys/hypervisor/uuid").and_return(true)
+      allow(plugin).to receive(:file_read).with("/sys/hypervisor/uuid").and_return("ec2a0561-e4d6-8e15-d9c8-2e0e03adcde8\n")
     end
 
     it_behaves_like "ec2"
@@ -384,8 +384,8 @@ describe Ohai::System, "plugin ec2" do
 
   describe "with non-EC2 Xen UUID" do
     before do
-      allow(File).to receive(:exist?).with("/sys/hypervisor/uuid").and_return(true)
-      allow(File).to receive(:read).with("/sys/hypervisor/uuid").and_return("123a0561-e4d6-8e15-d9c8-2e0e03adcde8\n")
+      allow(plugin).to receive(:file_exist?).with("/sys/hypervisor/uuid").and_return(true)
+      allow(plugin).to receive(:file_read).with("/sys/hypervisor/uuid").and_return("123a0561-e4d6-8e15-d9c8-2e0e03adcde8\n")
     end
 
     it_behaves_like "!ec2"

--- a/spec/unit/plugins/joyent_spec.rb
+++ b/spec/unit/plugins/joyent_spec.rb
@@ -74,8 +74,8 @@ describe Ohai::System, "plugin joyent" do
           VERIFIED_INSTALLATION=trusted
         EOS
 
-        allow(::File).to receive(:read).with("/etc/product").and_return(etc_product)
-        allow(::File).to receive(:read).with("/opt/local/etc/pkg_install.conf").and_return(pkg_install_conf)
+        allow(plugin).to receive(:file_read).with("/etc/product").and_return(etc_product)
+        allow(plugin).to receive(:file_read).with("/opt/local/etc/pkg_install.conf").and_return(pkg_install_conf)
         plugin.run
       end
 

--- a/spec/unit/plugins/linux/block_device_spec.rb
+++ b/spec/unit/plugins/linux/block_device_spec.rb
@@ -46,7 +46,7 @@ describe Ohai::System, "Linux Block Device Plugin" do
     allow(@plugin).to receive(:collect_os).and_return(:linux)
 
     allow(File).to receive(:exist?).with("/sys/block").and_return(true)
-    allow(Dir).to receive(:[]).with("/sys/block/*") do
+    allow(@plugin).to receive(:dir_glob).with("/sys/block/*") do
       DISKS.collect { |disk, _files| "/sys/block/#{disk}" }
     end
 

--- a/spec/unit/plugins/linux/interrupts_spec.rb
+++ b/spec/unit/plugins/linux/interrupts_spec.rb
@@ -549,12 +549,12 @@ describe Ohai::System, "Linux interrupts plugin" do
     plugin[:cpu] = {
       "total" => 4,
     }
-    allow(File).to receive(:exist?).and_return(false)
-    allow(File).to receive(:open).with("/proc/interrupts").and_return(@proc_interrupts)
-    allow(File).to receive(:exist?).with("/proc/irq/default_smp_affinity").and_return(true)
-    allow(File).to receive(:read).with("/proc/irq/default_smp_affinity").and_return("ff")
-    allow(File).to receive(:exist?).with("/proc/irq/1/smp_affinity").and_return(true)
-    allow(File).to receive(:read).with("/proc/irq/1/smp_affinity").and_return("ff")
+    allow(plugin).to receive(:file_exist?).and_return(false)
+    allow(plugin).to receive(:file_open).with("/proc/interrupts").and_return(@proc_interrupts)
+    allow(plugin).to receive(:file_exist?).with("/proc/irq/default_smp_affinity").and_return(true)
+    allow(plugin).to receive(:file_read).with("/proc/irq/default_smp_affinity").and_return("ff")
+    allow(plugin).to receive(:file_exist?).with("/proc/irq/1/smp_affinity").and_return(true)
+    allow(plugin).to receive(:file_read).with("/proc/irq/1/smp_affinity").and_return("ff")
     plugin.run
     expect(plugin[:interrupts]).to eq(interrupts)
   end

--- a/spec/unit/plugins/linux/kernel_spec.rb
+++ b/spec/unit/plugins/linux/kernel_spec.rb
@@ -56,8 +56,8 @@ describe Ohai::System, "Linux kernel plugin" do
     allow(@plugin).to receive(:shell_out).with("uname -o").and_return(mock_shell_out(0, "Linux", ""))
     allow(@plugin).to receive(:shell_out).with("env lsmod").and_return(mock_shell_out(0, @env_lsmod, ""))
     @version_module.each do |mod, vers|
-      allow(File).to receive(:exist?).with("/sys/module/#{mod}/version").and_return(true)
-      allow(File).to receive(:read).with("/sys/module/#{mod}/version").and_return(vers)
+      allow(@plugin).to receive(:file_exist?).with("/sys/module/#{mod}/version").and_return(true)
+      allow(@plugin).to receive(:file_read).with("/sys/module/#{mod}/version").and_return(vers)
     end
     expect(@plugin).to receive(:shell_out).with("env lsmod").at_least(:once)
     @plugin.run

--- a/spec/unit/plugins/linux/machineid_spec.rb
+++ b/spec/unit/plugins/linux/machineid_spec.rb
@@ -28,8 +28,8 @@ describe Ohai::System, "Machine id plugin" do
   it "reads /etc/machine-id if available" do
     machine_id = "6f702523e2fc7499eb1dc68e5314dacf"
 
-    allow(::File).to receive(:exist?).with("/etc/machine-id").and_return(true)
-    allow(::File).to receive(:read).with("/etc/machine-id").and_return(machine_id)
+    allow(plugin).to receive(:file_exist?).with("/etc/machine-id").and_return(true)
+    allow(plugin).to receive(:file_read).with("/etc/machine-id").and_return(machine_id)
     plugin.run
     expect(plugin[:machine_id]).to eq(machine_id)
   end
@@ -37,9 +37,9 @@ describe Ohai::System, "Machine id plugin" do
   it "reads /var/lib/dbus/machine-id if available" do
     machine_id = "6f702523e2fc7499eb1dc68e5314dacf"
 
-    allow(::File).to receive(:exist?).with("/etc/machine-id").and_return(false)
-    allow(::File).to receive(:exist?).with("/var/lib/dbus/machine-id").and_return(true)
-    allow(::File).to receive(:read).with("/var/lib/dbus/machine-id").and_return(machine_id)
+    allow(plugin).to receive(:file_exist?).with("/etc/machine-id").and_return(false)
+    allow(plugin).to receive(:file_exist?).with("/var/lib/dbus/machine-id").and_return(true)
+    allow(plugin).to receive(:file_read).with("/var/lib/dbus/machine-id").and_return(machine_id)
     plugin.run
     expect(plugin[:machine_id]).to eq(machine_id)
   end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -25,13 +25,13 @@ describe Ohai::System, "Linux plugin platform" do
     let(:file_contents) { "COW=MOO\nDOG=\"BARK\"" }
 
     it "returns nil if the file does not exist" do
-      allow(File).to receive(:exist?).with("/etc/test-release").and_return(false)
+      allow(plugin).to receive(:file_exist?).with("/etc/test-release").and_return(false)
       expect(plugin.read_os_release_info("/etc/test-release")).to be nil
     end
 
     it "returns a hash of expected contents" do
-      allow(File).to receive(:exist?).with("/etc/test-release").and_return(true)
-      allow(File).to receive(:read).with("/etc/test-release").and_return(file_contents)
+      allow(plugin).to receive(:file_exist?).with("/etc/test-release").and_return(true)
+      allow(plugin).to receive(:file_read).with("/etc/test-release").and_return(file_contents)
       release_info = plugin.read_os_release_info("/etc/test-release")
 
       expect(release_info["COW"]).to eq("MOO")
@@ -44,7 +44,7 @@ describe Ohai::System, "Linux plugin platform" do
       let(:release_info) { { "ID" => "os_id" } }
 
       before do
-        allow(File).to receive(:exist?).with("/etc/os-release").and_return(true)
+        allow(plugin).to receive(:file_exist?).with("/etc/os-release").and_return(true)
         allow(plugin).to receive(:read_os_release_info).with("/etc/os-release").and_return(release_info)
       end
 
@@ -63,8 +63,8 @@ describe Ohai::System, "Linux plugin platform" do
       let(:cisco_release_info) { { "ID" => "cisco_id" } }
 
       before do
-        allow(File).to receive(:exist?).with("/etc/os-release").and_return(true)
-        allow(File).to receive(:exist?).with("/etc/cisco-release").and_return(true)
+        allow(plugin).to receive(:file_exist?).with("/etc/os-release").and_return(true)
+        allow(plugin).to receive(:file_exist?).with("/etc/cisco-release").and_return(true)
         allow(plugin).to receive(:read_os_release_info).with("/etc/os-release").and_return(release_info)
         allow(plugin).to receive(:read_os_release_info).with("/etc/cisco-release").and_return(cisco_release_info)
       end
@@ -160,10 +160,10 @@ describe Ohai::System, "Linux plugin platform" do
       end
 
       it "returns nexus_centos for centos os-release id" do
-        expect(File).to receive(:exist?).at_least(:once).with("/etc/shared/os-release").and_return(true)
-        expect(File).to receive(:exist?).at_least(:once).with("/etc/os-release").and_return(true)
-        expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
-        expect(File).to receive(:read).with("/etc/shared/os-release").and_return(cisco_release_content)
+        expect(plugin).to receive(:file_exist?).at_least(:once).with("/etc/shared/os-release").and_return(true)
+        expect(plugin).to receive(:file_exist?).at_least(:once).with("/etc/os-release").and_return(true)
+        expect(plugin).to receive(:file_read).with("/etc/os-release").and_return(os_release_content)
+        expect(plugin).to receive(:file_read).with("/etc/shared/os-release").and_return(cisco_release_content)
         expect(plugin.platform_id_remap("centos")).to eq("nexus_centos")
       end
     end
@@ -214,7 +214,7 @@ describe Ohai::System, "Linux plugin platform" do
   describe "on system with /etc/os-release" do
     before do
       allow(plugin).to receive(:collect_os).and_return(:linux)
-      allow(::File).to receive(:exist?).with("/etc/os-release").and_return(true)
+      allow(plugin).to receive(:file_exist?).with("/etc/os-release").and_return(true)
     end
 
     context "when os-release data is correct" do
@@ -230,7 +230,7 @@ describe Ohai::System, "Linux plugin platform" do
       end
 
       before do
-        expect(File).to receive(:read).with("/etc/os-release").and_return(os_data)
+        expect(plugin).to receive(:file_read).with("/etc/os-release").and_return(os_data)
       end
 
       it "sets platform, platform_family, and platform_version from os-release" do
@@ -252,7 +252,7 @@ describe Ohai::System, "Linux plugin platform" do
       end
 
       before do
-        expect(File).to receive(:read).with("/etc/os-release").and_return(os_data)
+        expect(plugin).to receive(:file_read).with("/etc/os-release").and_return(os_data)
       end
 
       it "sets platform_version using kernel version from uname" do
@@ -277,7 +277,7 @@ describe Ohai::System, "Linux plugin platform" do
       end
 
       before do
-        expect(File).to receive(:read).with("/etc/os-release").and_return(os_data)
+        expect(plugin).to receive(:file_read).with("/etc/os-release").and_return(os_data)
       end
 
       it "sets platform, platform_family, and platform_version from os-release" do
@@ -301,8 +301,8 @@ describe Ohai::System, "Linux plugin platform" do
       end
 
       before do
-        expect(File).to receive(:read).with("/etc/os-release").and_return(os_data)
-        expect(File).to receive(:read).with("/etc/redhat-release").and_return("CentOS Linux release 7.5.1804 (Core)")
+        expect(plugin).to receive(:file_read).with("/etc/os-release").and_return(os_data)
+        expect(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("CentOS Linux release 7.5.1804 (Core)")
       end
 
       it "sets platform, platform_family, and platform_version from os-release" do
@@ -334,22 +334,22 @@ describe Ohai::System, "Linux plugin platform" do
     before do
       allow(plugin).to receive(:collect_os).and_return(:linux)
       plugin[:lsb] = Mash.new
-      allow(File).to receive(:exist?).with("/etc/debian_version").and_return(have_debian_version)
-      allow(File).to receive(:exist?).with("/etc/redhat-release").and_return(have_redhat_release)
-      allow(File).to receive(:exist?).with("/etc/exherbo-release").and_return(have_exherbo_release)
-      allow(File).to receive(:exist?).with("/etc/Eos-release").and_return(have_eos_release)
-      allow(File).to receive(:exist?).with("/etc/SuSE-release").and_return(have_suse_release)
-      allow(File).to receive(:exist?).with("/etc/system-release").and_return(have_system_release)
-      allow(File).to receive(:exist?).with("/etc/slackware-version").and_return(have_slackware_version)
-      allow(File).to receive(:exist?).with("/etc/enterprise-release").and_return(have_enterprise_release)
-      allow(File).to receive(:exist?).with("/etc/oracle-release").and_return(have_oracle_release)
-      allow(File).to receive(:exist?).with("/etc/parallels-release").and_return(have_parallels_release)
-      allow(File).to receive(:exist?).with("/etc/os-release").and_return(have_os_release)
-      allow(File).to receive(:exist?).with("/etc/f5-release").and_return(have_f5_release)
-      allow(File).to receive(:exist?).with("/usr/lib/os-release").and_return(have_usr_lib_os_release)
-      allow(File).to receive(:exist?).with("/etc/shared/os-release").and_return(have_cisco_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/debian_version").and_return(have_debian_version)
+      allow(plugin).to receive(:file_exist?).with("/etc/redhat-release").and_return(have_redhat_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/exherbo-release").and_return(have_exherbo_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/Eos-release").and_return(have_eos_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/SuSE-release").and_return(have_suse_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/system-release").and_return(have_system_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/slackware-version").and_return(have_slackware_version)
+      allow(plugin).to receive(:file_exist?).with("/etc/enterprise-release").and_return(have_enterprise_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/oracle-release").and_return(have_oracle_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/parallels-release").and_return(have_parallels_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/os-release").and_return(have_os_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/f5-release").and_return(have_f5_release)
+      allow(plugin).to receive(:file_exist?).with("/usr/lib/os-release").and_return(have_usr_lib_os_release)
+      allow(plugin).to receive(:file_exist?).with("/etc/shared/os-release").and_return(have_cisco_release)
 
-      allow(File).to receive(:read).with("PLEASE STUB ALL File.read CALLS")
+      allow(plugin).to receive(:file_read).with("PLEASE STUB ALL plugin.read CALLS")
     end
 
     describe "on lsb compliant distributions" do
@@ -423,13 +423,13 @@ describe Ohai::System, "Linux plugin platform" do
       end
 
       it "reads the version from /etc/debian_version" do
-        expect(File).to receive(:read).with("/etc/debian_version").and_return("9.5")
+        expect(plugin).to receive(:file_read).with("/etc/debian_version").and_return("9.5")
         plugin.run
         expect(plugin[:platform_version]).to eq("9.5")
       end
 
       it "correctlies strip any newlines" do
-        expect(File).to receive(:read).with("/etc/debian_version").and_return("9.5\n")
+        expect(plugin).to receive(:file_read).with("/etc/debian_version").and_return("9.5\n")
         plugin.run
         expect(plugin[:platform_version]).to eq("9.5")
       end
@@ -452,14 +452,14 @@ describe Ohai::System, "Linux plugin platform" do
       end
 
       it "sets platform and platform_family to slackware" do
-        expect(File).to receive(:read).with("/etc/slackware-version").and_return("Slackware 12.0.0")
+        expect(plugin).to receive(:file_read).with("/etc/slackware-version").and_return("Slackware 12.0.0")
         plugin.run
         expect(plugin[:platform]).to eq("slackware")
         expect(plugin[:platform_family]).to eq("slackware")
       end
 
       it "sets platform_version on slackware" do
-        expect(File).to receive(:read).with("/etc/slackware-version").and_return("Slackware 12.0.0")
+        expect(plugin).to receive(:file_read).with("/etc/slackware-version").and_return("Slackware 12.0.0")
         plugin.run
         expect(plugin[:platform_version]).to eq("12.0.0")
       end
@@ -476,7 +476,7 @@ describe Ohai::System, "Linux plugin platform" do
       end
 
       it "sets platform to arista_eos" do
-        expect(File).to receive(:read).with("/etc/Eos-release").and_return("Arista Networks EOS 4.21.1.1F")
+        expect(plugin).to receive(:file_read).with("/etc/Eos-release").and_return("Arista Networks EOS 4.21.1.1F")
         plugin.run
         expect(plugin[:platform]).to eq("arista_eos")
         expect(plugin[:platform_family]).to eq("fedora")
@@ -493,7 +493,7 @@ describe Ohai::System, "Linux plugin platform" do
       end
 
       it "sets platform to bigip" do
-        expect(File).to receive(:read).with("/etc/f5-release").and_return("BIG-IP release 13.0.0 (Final)")
+        expect(plugin).to receive(:file_read).with("/etc/f5-release").and_return("BIG-IP release 13.0.0 (Final)")
         plugin.run
         expect(plugin[:platform]).to eq("bigip")
         expect(plugin[:platform_family]).to eq("rhel")
@@ -553,20 +553,20 @@ describe Ohai::System, "Linux plugin platform" do
         end
 
         it "reads the platform as centos and version as 7.5" do
-          expect(File).to receive(:read).with("/etc/redhat-release").and_return("CentOS Linux release 7.5.1804 (Core)")
+          expect(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("CentOS Linux release 7.5.1804 (Core)")
           plugin.run
           expect(plugin[:platform]).to eq("centos")
           expect(plugin[:platform_version]).to eq("7.5.1804")
         end
 
         it "reads platform of Red Hat with a space" do
-          expect(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.5 (Santiago)")
+          expect(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.5 (Santiago)")
           plugin.run
           expect(plugin[:platform]).to eq("redhat")
         end
 
         it "reads the platform as redhat without a space" do
-          expect(File).to receive(:read).with("/etc/redhat-release").and_return("RedHat release 5.3")
+          expect(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("RedHat release 5.3")
           plugin.run
           expect(plugin[:platform]).to eq("redhat")
           expect(plugin[:platform_version]).to eq("5.3")
@@ -585,8 +585,8 @@ describe Ohai::System, "Linux plugin platform" do
         it "reads the platform as parallels and version as 6.0.5" do
           plugin[:lsb][:id] = "CloudLinuxServer"
           plugin[:lsb][:release] = "6.5"
-          allow(File).to receive(:read).with("/etc/redhat-release").and_return("CloudLinux Server release 6.5 (Pavel Popovich)")
-          expect(File).to receive(:read).with("/etc/parallels-release").and_return("Parallels Cloud Server 6.0.5 (20007)")
+          allow(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("CloudLinux Server release 6.5 (Pavel Popovich)")
+          expect(plugin).to receive(:file_read).with("/etc/parallels-release").and_return("Parallels Cloud Server 6.0.5 (20007)")
           plugin.run
           expect(plugin[:platform]).to eq("parallels")
           expect(plugin[:platform_version]).to eq("6.0.5")
@@ -601,8 +601,8 @@ describe Ohai::System, "Linux plugin platform" do
         end
 
         it "reads the platform as parallels and version as 6.0.5" do
-          allow(File).to receive(:read).with("/etc/redhat-release").and_return("CloudLinux Server release 6.5 (Pavel Popovich)")
-          expect(File).to receive(:read).with("/etc/parallels-release").and_return("Parallels Cloud Server 6.0.5 (20007)")
+          allow(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("CloudLinux Server release 6.5 (Pavel Popovich)")
+          expect(plugin).to receive(:file_read).with("/etc/parallels-release").and_return("Parallels Cloud Server 6.0.5 (20007)")
           plugin.run
           expect(plugin[:platform]).to eq("parallels")
           expect(plugin[:platform_version]).to eq("6.0.5")
@@ -624,8 +624,8 @@ describe Ohai::System, "Linux plugin platform" do
           it "reads the platform as oracle and version as 5.7" do
             plugin[:lsb][:id] = "EnterpriseEnterpriseServer"
             plugin[:lsb][:release] = "5.7"
-            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 5.7 (Tikanga)")
-            expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.7 (Carthage)")
+            allow(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 5.7 (Tikanga)")
+            expect(plugin).to receive(:file_read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.7 (Carthage)")
             plugin.run
             expect(plugin[:platform]).to eq("oracle")
             expect(plugin[:platform_version]).to eq("5.7")
@@ -639,8 +639,8 @@ describe Ohai::System, "Linux plugin platform" do
           it "reads the platform as oracle and version as 6.1" do
             plugin[:lsb][:id] = "OracleServer"
             plugin[:lsb][:release] = "6.1"
-            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.1 (Santiago)")
-            expect(File).to receive(:read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.1")
+            allow(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.1 (Santiago)")
+            expect(plugin).to receive(:file_read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.1")
             plugin.run
             expect(plugin[:platform]).to eq("oracle")
             expect(plugin[:platform_version]).to eq("6.1")
@@ -659,24 +659,24 @@ describe Ohai::System, "Linux plugin platform" do
           let(:have_enterprise_release) { true }
 
           it "reads the platform as oracle and version as 5" do
-            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Enterprise Linux Enterprise Linux Server release 5 (Carthage)")
-            expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5 (Carthage)")
+            allow(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("Enterprise Linux Enterprise Linux Server release 5 (Carthage)")
+            expect(plugin).to receive(:file_read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5 (Carthage)")
             plugin.run
             expect(plugin[:platform]).to eq("oracle")
             expect(plugin[:platform_version]).to eq("5")
           end
 
           it "reads the platform as oracle and version as 5.1" do
-            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Enterprise Linux Enterprise Linux Server release 5.1 (Carthage)")
-            expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.1 (Carthage)")
+            allow(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("Enterprise Linux Enterprise Linux Server release 5.1 (Carthage)")
+            expect(plugin).to receive(:file_read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.1 (Carthage)")
             plugin.run
             expect(plugin[:platform]).to eq("oracle")
             expect(plugin[:platform_version]).to eq("5.1")
           end
 
           it "reads the platform as oracle and version as 5.7" do
-            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 5.7 (Tikanga)")
-            expect(File).to receive(:read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.7 (Carthage)")
+            allow(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 5.7 (Tikanga)")
+            expect(plugin).to receive(:file_read).with("/etc/enterprise-release").and_return("Enterprise Linux Enterprise Linux Server release 5.7 (Carthage)")
             plugin.run
             expect(plugin[:platform]).to eq("oracle")
             expect(plugin[:platform_version]).to eq("5.7")
@@ -689,16 +689,16 @@ describe Ohai::System, "Linux plugin platform" do
           let(:have_oracle_release) { true }
 
           it "reads the platform as oracle and version as 6.0" do
-            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.0 (Santiago)")
-            expect(File).to receive(:read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.0")
+            allow(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.0 (Santiago)")
+            expect(plugin).to receive(:file_read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.0")
             plugin.run
             expect(plugin[:platform]).to eq("oracle")
             expect(plugin[:platform_version]).to eq("6.0")
           end
 
           it "reads the platform as oracle and version as 6.1" do
-            allow(File).to receive(:read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.1 (Santiago)")
-            expect(File).to receive(:read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.1")
+            allow(plugin).to receive(:file_read).with("/etc/redhat-release").and_return("Red Hat Enterprise Linux Server release 6.1 (Santiago)")
+            expect(plugin).to receive(:file_read).with("/etc/oracle-release").and_return("Oracle Linux Server release 6.1")
             plugin.run
             expect(plugin[:platform]).to eq("oracle")
             expect(plugin[:platform_version]).to eq("6.1")
@@ -719,7 +719,7 @@ describe Ohai::System, "Linux plugin platform" do
 
           it "reads the platform as opensuse on openSUSE" do
             plugin[:lsb][:release] = "12.1"
-            expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 12.1 (x86_64)\nVERSION = 12.1\nCODENAME = Asparagus\n")
+            expect(plugin).to receive(:file_read).with("/etc/SuSE-release").and_return("openSUSE 12.1 (x86_64)\nVERSION = 12.1\nCODENAME = Asparagus\n")
             plugin.run
             expect(plugin[:platform]).to eq("opensuse")
             expect(plugin[:platform_family]).to eq("suse")
@@ -736,14 +736,14 @@ describe Ohai::System, "Linux plugin platform" do
           end
 
           it "sets platform and platform_family to suse and bogus verion to 10.0" do
-            expect(File).to receive(:read).with("/etc/SuSE-release").at_least(:once).and_return("VERSION = 10.0")
+            expect(plugin).to receive(:file_read).with("/etc/SuSE-release").at_least(:once).and_return("VERSION = 10.0")
             plugin.run
             expect(plugin[:platform]).to eq("suse")
             expect(plugin[:platform_family]).to eq("suse")
           end
 
           it "reads the version as 11.2" do
-            expect(File).to receive(:read).with("/etc/SuSE-release").and_return("SUSE Linux Enterprise Server 11.2 (i586)\nVERSION = 11\nPATCHLEVEL = 2\n")
+            expect(plugin).to receive(:file_read).with("/etc/SuSE-release").and_return("SUSE Linux Enterprise Server 11.2 (i586)\nVERSION = 11\nPATCHLEVEL = 2\n")
             plugin.run
             expect(plugin[:platform]).to eq("suse")
             expect(plugin[:platform_version]).to eq("11.2")
@@ -751,7 +751,7 @@ describe Ohai::System, "Linux plugin platform" do
           end
 
           it "[OHAI-272] should read the version as 11.3" do
-            expect(File).to receive(:read).with("/etc/SuSE-release").once.and_return("openSUSE 11.3 (x86_64)\nVERSION = 11.3")
+            expect(plugin).to receive(:file_read).with("/etc/SuSE-release").once.and_return("openSUSE 11.3 (x86_64)\nVERSION = 11.3")
             plugin.run
             expect(plugin[:platform]).to eq("opensuse")
             expect(plugin[:platform_version]).to eq("11.3")
@@ -759,7 +759,7 @@ describe Ohai::System, "Linux plugin platform" do
           end
 
           it "[OHAI-272] should read the version as 11.4" do
-            expect(File).to receive(:read).with("/etc/SuSE-release").once.and_return("openSUSE 11.4 (i586)\nVERSION = 11.4\nCODENAME = Celadon")
+            expect(plugin).to receive(:file_read).with("/etc/SuSE-release").once.and_return("openSUSE 11.4 (i586)\nVERSION = 11.4\nCODENAME = Celadon")
             plugin.run
             expect(plugin[:platform]).to eq("opensuse")
             expect(plugin[:platform_version]).to eq("11.4")
@@ -767,14 +767,14 @@ describe Ohai::System, "Linux plugin platform" do
           end
 
           it "reads the platform as opensuse on openSUSE" do
-            expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 12.2 (x86_64)\nVERSION = 12.2\nCODENAME = Mantis\n")
+            expect(plugin).to receive(:file_read).with("/etc/SuSE-release").and_return("openSUSE 12.2 (x86_64)\nVERSION = 12.2\nCODENAME = Mantis\n")
             plugin.run
             expect(plugin[:platform]).to eq("opensuse")
             expect(plugin[:platform_family]).to eq("suse")
           end
 
           it "reads the platform as opensuseleap on openSUSE Leap" do
-            expect(File).to receive(:read).with("/etc/SuSE-release").and_return("openSUSE 42.1 (x86_64)\nVERSION = 42.1\nCODENAME = Malachite\n")
+            expect(plugin).to receive(:file_read).with("/etc/SuSE-release").and_return("openSUSE 42.1 (x86_64)\nVERSION = 42.1\nCODENAME = Malachite\n")
             plugin.run
             expect(plugin[:platform]).to eq("opensuseleap")
             expect(plugin[:platform_family]).to eq("suse")
@@ -797,7 +797,7 @@ describe Ohai::System, "Linux plugin platform" do
       end
 
       before do
-        expect(File).to receive(:read).with("/usr/lib/os-release").and_return(usr_lib_os_release_content)
+        expect(plugin).to receive(:file_read).with("/usr/lib/os-release").and_return(usr_lib_os_release_content)
       end
 
       it "sets platform to clearlinux and platform_family to clearlinux" do

--- a/spec/unit/plugins/scaleway_spec.rb
+++ b/spec/unit/plugins/scaleway_spec.rb
@@ -22,7 +22,7 @@ describe Ohai::System, "plugin scaleway" do
 
   before do
     allow(plugin).to receive(:hint?).with("scaleway").and_return(false)
-    allow(File).to receive(:exist?).with("/proc/cmdline").and_return(false)
+    allow(plugin).to receive(:file_exist?).with("/proc/cmdline").and_return(false)
   end
 
   shared_examples_for "!scaleway" do
@@ -84,8 +84,8 @@ describe Ohai::System, "plugin scaleway" do
 
   describe "with scaleway cmdline" do
     before do
-      allow(File).to receive(:exist?).with("/proc/cmdline").and_return(true)
-      allow(File).to receive(:read).with("/proc/cmdline").and_return("initrd=initrd showopts console=ttyS0,115200 nousb vga=0 root=/dev/vda scaleway boot=local")
+      allow(plugin).to receive(:file_exist?).with("/proc/cmdline").and_return(true)
+      allow(plugin).to receive(:file_read).with("/proc/cmdline").and_return("initrd=initrd showopts console=ttyS0,115200 nousb vga=0 root=/dev/vda scaleway boot=local")
     end
 
     it_behaves_like "scaleway"

--- a/spec/unit/plugins/shells_spec.rb
+++ b/spec/unit/plugins/shells_spec.rb
@@ -32,18 +32,18 @@ describe Ohai::System, "plugin shells" do
                 "/bin/tcsh\n",
                 "/bin/zsh\n"]
 
-  let(:shell_file_content) { shell_file }
+  let(:shell_file_content) { shell_file.join }
 
   it "does not set shells attribute if /etc/shells does not exist" do
-    allow(::File).to receive(:exist?).with("/etc/shells").and_return(false)
+    allow(plugin).to receive(:file_exist?).with("/etc/shells").and_return(false)
     plugin.run
     expect(plugin).not_to have_key(:shells)
   end
 
   it "sets shells to an array of shells if /etc/shells exists" do
-    allow(::File).to receive(:readlines).with("/etc/shells").and_return(shell_file_content)
-    allow(::File).to receive(:exist?).and_call_original
-    allow(::File).to receive(:exist?).with("/etc/shells").and_return(true)
+    allow(plugin).to receive(:file_open).with("/etc/shells").and_return(StringIO.new(shell_file_content))
+    allow(plugin).to receive(:file_exist?).and_call_original
+    allow(plugin).to receive(:file_exist?).with("/etc/shells").and_return(true)
     plugin.run
     expect(plugin.shells).to match_array([
                                            "/bin/bash",

--- a/spec/unit/plugins/solaris2/virtualization_spec.rb
+++ b/spec/unit/plugins/solaris2/virtualization_spec.rb
@@ -31,16 +31,16 @@ describe Ohai::System, "Solaris virtualization platform" do
     allow(plugin).to receive(:collect_os).and_return(:solaris2)
 
     # default to all requested Files not existing
-    allow(File).to receive(:exist?).with("/usr/sbin/psrinfo").and_return(false)
-    allow(File).to receive(:exist?).with("/usr/sbin/smbios").and_return(false)
-    allow(File).to receive(:exist?).with("/usr/sbin/zoneadm").and_return(false)
+    allow(plugin).to receive(:file_exist?).with("/usr/sbin/psrinfo").and_return(false)
+    allow(plugin).to receive(:file_exist?).with("/usr/sbin/smbios").and_return(false)
+    allow(plugin).to receive(:file_exist?).with("/usr/sbin/zoneadm").and_return(false)
     allow(plugin).to receive(:shell_out).with("/usr/sbin/smbios").and_return(mock_shell_out(0, "", ""))
     allow(plugin).to receive(:shell_out).with("#{Ohai.abs_path( "/usr/sbin/psrinfo" )} -pv").and_return(mock_shell_out(0, "", ""))
   end
 
   describe "when we are checking for kvm" do
     before do
-      expect(File).to receive(:exist?).with("/usr/sbin/psrinfo").and_return(true)
+      expect(plugin).to receive(:file_exist?).with("/usr/sbin/psrinfo").and_return(true)
     end
 
     it "runs psrinfo -pv" do

--- a/spec/unit/plugins/ssh_host_keys_spec.rb
+++ b/spec/unit/plugins/ssh_host_keys_spec.rb
@@ -24,27 +24,23 @@ describe Ohai::System, "ssh_host_key plugin" do
     @plugin = get_plugin("ssh_host_key")
     @plugin[:keys] = Mash.new
 
-    allow(File).to receive(:exist?).with("/etc/ssh/sshd_config").and_return(true)
-    allow(File).to receive(:open).with("/etc/ssh/sshd_config").and_yield(sshd_config_file)
-    allow(File).to receive(:exist?).and_return(true)
-    allow(File).to receive(:exist?).with("/etc/ssh/ssh_host_dsa_key.pub").and_return(true)
-    allow(File).to receive(:exist?).with("/etc/ssh/ssh_host_rsa_key.pub").and_return(true)
-    allow(File).to receive(:exist?).with("/etc/ssh/ssh_host_ecdsa_key.pub").and_return(true)
-    allow(File).to receive(:exist?).with("/etc/ssh/ssh_host_ed25519_key.pub").and_return(true)
-
-    # Ensure we can still use IO.read
-    io_read = IO.method(:read)
-    allow(IO).to receive(:read) { |file| io_read.call(file) }
+    allow(@plugin).to receive(:file_exist?).with("/etc/ssh/sshd_config").and_return(true)
+    allow(@plugin).to receive(:file_open).with("/etc/ssh/sshd_config").and_yield(sshd_config_file)
+    allow(@plugin).to receive(:file_exist?).and_return(true)
+    allow(@plugin).to receive(:file_exist?).with("/etc/ssh/ssh_host_dsa_key.pub").and_return(true)
+    allow(@plugin).to receive(:file_exist?).with("/etc/ssh/ssh_host_rsa_key.pub").and_return(true)
+    allow(@plugin).to receive(:file_exist?).with("/etc/ssh/ssh_host_ecdsa_key.pub").and_return(true)
+    allow(@plugin).to receive(:file_exist?).with("/etc/ssh/ssh_host_ed25519_key.pub").and_return(true)
 
     # Return fake public key files so we don't have to go digging for them in unit tests
     @dsa_key = "ssh-dss AAAAB3NzaC1kc3MAAACBAMHlT02xN8kietxPfhcb98xHueTzKCOTz6dZlP/dmKILHrQOAExuSEeNiA2uvmhHNVQvs/cBsRiDxgSKux3ie2q8+MB6vHCiSpSkoPjrL75iT57YDilCB4/sytt6IJpj+H42wRDWTX0/QRybMHUvmnmEL0cwZXykSvrIum0BKB6hAAAAFQDsi6WUCClhtZIiTY9uh8eAre+SbQAAAIEAgNnuw0uEuqtcVif+AYd/bCZvL9FPqg7DrmTkamNEcVinhUGwsPGJTLJf+o5ens1X4RzQoi1R6Y6zCTL2FN/hZgINJNO0z9BN402wWrZmQd+Vb1U5DyDtveuvipqyQS+fm9neRwdLuv36Fc9f9nkZ7YHpkGPJp+yJpG4OoeREhwgAAACBAIf9kKLf2XiXnlByzlJ2Naa55d/hp2E059VKCRsBS++xFKYKvSqjnDQBFiMtAUhb8EdTyBGyalqOgqogDQVtwHfTZWZwqHAhry9aM06y92Eu/xSey4tWjKeknOsnRe640KC4zmKDBRTrjjkuAdrKPN9k3jl+OCc669JHlIfo6kqf oppa"
     @rsa_key = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAuhcVXV+nNapkyUC5p4TH1ymRxUjtMBKqYWmwyI29gVFnUNeHkKFHWon0KFeGJP2Rm8BfTiZa9ER9e8pRr4Nd+z1C1o0kVoxEEfB9tpSdTlpk1GG83D94l57fij8THRVIwuCEosViUlg1gDgC4SpxbqfdBkUN2qyf6JDOh7t2QpYh7berpDEWeBpb7BKdLEDT57uw7ijKzSNyaXqq8KkB9I+UFrRwpuos4W7ilX+PQ+mWLi2ZZJfTYZMxxVS+qJwiDtNxGCRwTOQZG03kI7eLBZG+igupr0uD4o6qeftPOr0kxgjoPU4nEKvYiGq8Rqd2vYrhiaJHLk9QB6xStQvS3Q== oppa"
     @ecdsa_key = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBx8VgvxmHxs/sIn/ATh0iUcuz1I2Xc0e1ejXCGHBMZ98IE3FBt1ezlqCpNMcHVV2skQQ8vyLbKxzweyZuNSDU8= oppa"
     @ed25519_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFYGnIM5K5JaRxbMCqz8cPMmLp57ZoJQvA5Tlj18EO6H djb"
-    allow(IO).to receive(:read).with("/etc/ssh/ssh_host_dsa_key.pub").and_return(@dsa_key)
-    allow(IO).to receive(:read).with("/etc/ssh/ssh_host_rsa_key.pub").and_return(@rsa_key)
-    allow(IO).to receive(:read).with("/etc/ssh/ssh_host_ecdsa_key.pub").and_return(@ecdsa_key)
-    allow(IO).to receive(:read).with("/etc/ssh/ssh_host_ed25519_key.pub").and_return(@ed25519_key)
+    allow(@plugin).to receive(:file_read).with("/etc/ssh/ssh_host_dsa_key.pub").and_return(@dsa_key)
+    allow(@plugin).to receive(:file_read).with("/etc/ssh/ssh_host_rsa_key.pub").and_return(@rsa_key)
+    allow(@plugin).to receive(:file_read).with("/etc/ssh/ssh_host_ecdsa_key.pub").and_return(@ecdsa_key)
+    allow(@plugin).to receive(:file_read).with("/etc/ssh/ssh_host_ed25519_key.pub").and_return(@ed25519_key)
   end
 
   shared_examples "loads keys" do
@@ -107,8 +103,8 @@ describe Ohai::System, "ssh_host_key plugin" do
     end
 
     before do
-      allow(File).to receive(:exist?).with("/etc/ssh/sshd_config").and_return(false)
-      allow(File).to receive(:exist?).with("/etc/sshd_config").and_return(false)
+      allow(@plugin).to receive(:file_exist?).with("/etc/ssh/sshd_config").and_return(false)
+      allow(@plugin).to receive(:file_exist?).with("/etc/sshd_config").and_return(false)
     end
 
     it_behaves_like "loads keys"

--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -146,7 +146,7 @@ describe "Ohai::System" do
             message("default")
           end
 
-          collect_data(:#{Ohai::Mixin::OS.collect_os}) do
+          collect_data(:#{Ohai::Mixin::OS.collect_os_local}) do
             message("platform_specific_message")
           end
         end
@@ -212,7 +212,7 @@ describe "Ohai::System" do
         Ohai.config[:plugin_path] = [ path_to(".") ]
         # Make sure the stubbing of runner is not overriden with reset_system during test
         allow(ohai).to receive(:reset_system)
-        allow(ohai.instance_variable_get("@runner")).to receive(:run_plugin).and_raise(Ohai::Exceptions::AttributeNotFound)
+        allow(ohai.runner).to receive(:run_plugin).and_raise(Ohai::Exceptions::AttributeNotFound)
         expect(ohai.logger).to receive(:error).with(/Encountered error while running plugins/)
         expect { ohai.all_plugins }.to raise_error(Ohai::Exceptions::AttributeNotFound)
       end


### PR DESCRIPTION
This implements remote ohai, inspired originally by http://github.com/burtlo/ohbye

1.  When targeting remote unix-like or windows systems it preserves the semantics of ohai run locally (apart from a few known bugs)
2.  It implements a "train" plugin with data in `node['train']` about the remote connection
3.  For non-unix/windows systems it disables most default plugins other than os, ohai_time + chef_version, and introduces a `:target` type which is the default that is used for those kinds of targets
4.  It supports URLs in the `--target` option on the command line and also uses chef-client's code for parsing credentials files
5.  With the chef-client PR this integrates seamlessly with chef-client
6.  Existing plugins have been converted to use the train helpers to enable remote collection (mostly)

Adds train data to ohai when running remotely:

```
  "train": {
    "family_hierarchy": [
      "debian",
      "linux",
      "unix",
      "os"
    ],
    "family": "debian",
    "platform": {
      "arch": "x86_64",
      "release": "18.04"
    },
    "backend": "unknown",
    "scheme": "ssh",
    "uri": "ssh://root@crash.scriptkiddie.org:747"
  },
```