### PR TITLE
Prefer __dir__ to __FILE__ used to get the dir

### DIFF
--- a/bin/ohai
+++ b/bin/ohai
@@ -18,7 +18,7 @@
 #
 
 # if we're in a source code checkout, we want to run the code from that.
-$:.unshift File.expand_path("../../lib", __FILE__)
+$:.unshift File.expand_path("../lib", __dir__)
 require "ohai/application"
 
 Ohai::Application.new.run

--- a/lib/ohai/config.rb
+++ b/lib/ohai/config.rb
@@ -27,14 +27,13 @@ module Ohai
   # Reopens ChefConfig::Config to add Ohai configuration settings.
   # see: https://github.com/chef/chef/blob/master/lib/chef/config.rb
   class Config
-
     config_context :ohai do
       default :disabled_plugins, []
       default :hints_path, [ ChefConfig::Config.platform_specific_path("/etc/chef/ohai/hints") ]
       default :log_level, :auto
       default :log_location, STDERR
       default :plugin, ( Ohai::PluginConfig.new { |h, k| h[k] = Ohai::PluginConfig.new } )
-      default :plugin_path, [ File.expand_path(File.join(File.dirname(__FILE__), "plugins")), ChefConfig::Config.platform_specific_path("/etc/chef/ohai/plugins") ]
+      default :plugin_path, [ File.expand_path(File.join(__dir__, "plugins")), ChefConfig::Config.platform_specific_path("/etc/chef/ohai/plugins") ]
       default :critical_plugins, []
       # causes all optional plugins to be run.
       default :run_all_plugins, false

--- a/lib/ohai/version.rb
+++ b/lib/ohai/version.rb
@@ -17,6 +17,6 @@
 #
 
 module Ohai
-  OHAI_ROOT = File.expand_path(File.dirname(__FILE__))
+  OHAI_ROOT = File.expand_path(__dir__)
   VERSION = "16.5.0".freeze
 end

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -1,5 +1,4 @@
-
-$:.unshift File.expand_path("../lib", __FILE__)
+$:.unshift File.expand_path("lib", __dir__)
 require "ohai/version"
 
 Gem::Specification.new do |s|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,8 @@ require "rspec/collection_matchers"
 # require 'pry-debugger'
 # require 'pry-stack_explorer'
 
-$:.unshift(File.expand_path("../..", __FILE__))
-$:.unshift(File.dirname(__FILE__) + "/../lib")
+$:.unshift(File.expand_path("..", __dir__))
+$:.unshift(__dir__ + "/../lib")
 
 require "spec/support/platform_helpers"
 require "spec/support/integration_helper"
@@ -12,8 +12,8 @@ require "wmi-lite"
 require "ohai"
 Ohai.config[:log_level] = :error
 
-PLUGIN_PATH = File.expand_path("../../lib/ohai/plugins", __FILE__)
-SPEC_PLUGIN_PATH = File.expand_path("../data/plugins", __FILE__)
+PLUGIN_PATH = File.expand_path("../lib/ohai/plugins", __dir__)
+SPEC_PLUGIN_PATH = File.expand_path("data/plugins", __dir__)
 
 RSpec.configure do |config|
   config.before { @object_pristine = Object.clone }

--- a/spec/unit/plugins/linux/systemd_paths_spec.rb
+++ b/spec/unit/plugins/linux/systemd_paths_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../../spec_helper.rb")
+require File.expand_path(__dir__ + "/../../../spec_helper.rb")
 
 describe Ohai::System, "Linux systemd paths plugin" do
   let(:plugin) { get_plugin("linux/systemd_paths") }


### PR DESCRIPTION
This avoids some File.dirname calls

Signed-off-by: Tim Smith <tsmith@chef.io>