### PR TITLE
Fix spec stub for the latest mixlib-shellout

### DIFF
--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -51,7 +51,7 @@ describe Ohai::Mixin::ShellOut, "shell_out" do
     }
   end
 
-  let(:logger) { instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil, debug?: false) }
+  let(:logger) { instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil, trace?: false) }
 
   class DummyPlugin
     include Ohai::Mixin::ShellOut


### PR DESCRIPTION
No impact to users here, but the new mixlib-shellout changed the log
level of streaming from debug to trace so we need to update this stub.

Signed-off-by: Tim Smith <tsmith@chef.io>