### PR TITLE
Speed up the AIX hostname spec

### DIFF
--- a/spec/unit/plugins/aix/filesystem_spec.rb
+++ b/spec/unit/plugins/aix/filesystem_spec.rb
@@ -98,7 +98,6 @@ describe Ohai::System, "AIX filesystem plugin" do
     end
 
     describe "df -Pk" do
-
       it "returns the filesystem block size" do
         expect(@plugin[:filesystem]["by_pair"]["/dev/hd4,/"]["kb_size"]).to eq("2097152")
         expect(@plugin[:filesystem2]["by_pair"]["/dev/hd4,/"]["kb_size"]).to eq("2097152")
@@ -126,7 +125,6 @@ describe Ohai::System, "AIX filesystem plugin" do
     end
 
     describe "mount" do
-
       it "returns the filesystem mount location" do
         expect(@plugin[:filesystem]["by_pair"]["/dev/hd4,/"]["mount"]).to eq("/")
         expect(@plugin[:filesystem2]["by_pair"]["/dev/hd4,/"]["mount"]).to eq("/")
@@ -144,7 +142,6 @@ describe Ohai::System, "AIX filesystem plugin" do
 
       # For entries like 192.168.1.11 /stage/middleware1 /stage/middleware2 nfs3   Jul 17 13:24 ro,bg,hard,intr,sec=sys
       context "having node values" do
-
         it "returns the filesystem mount location" do
           expect(@plugin[:filesystem]["by_pair"]["192.168.1.11:/stage/middleware1,/stage/middleware2"]["mount"]).to eq("/stage/middleware2")
           expect(@plugin[:filesystem2]["by_pair"]["192.168.1.11:/stage/middleware1,/stage/middleware2"]["mount"]).to eq("/stage/middleware2")
@@ -171,7 +168,6 @@ describe Ohai::System, "AIX filesystem plugin" do
     end
 
     describe "df -Pk" do
-
       it "returns the filesystem block size" do
         expect(@plugin[:filesystem]["by_pair"]["Global:/,/"]["kb_size"]).to eq("10485760")
         expect(@plugin[:filesystem2]["by_pair"]["Global:/,/"]["kb_size"]).to eq("10485760")
@@ -199,7 +195,6 @@ describe Ohai::System, "AIX filesystem plugin" do
     end
 
     describe "mount" do
-
       it "returns the filesystem mount location" do
         expect(@plugin[:filesystem]["by_pair"]["Global:/,/"]["mount"]).to eq("/")
         expect(@plugin[:filesystem2]["by_pair"]["Global:/,/"]["mount"]).to eq("/")
@@ -217,7 +212,6 @@ describe Ohai::System, "AIX filesystem plugin" do
 
       # For entries like 192.168.1.11 /stage/middleware3 /stage/middleware4 nfs3   Jul 17 13:24 ro,bg,hard,intr,sec=sys
       context "having node values" do
-
         it "returns the filesystem mount location" do
           expect(@plugin[:filesystem]["by_pair"]["192.168.1.11:/stage/middleware3,/stage/middleware4"]["mount"]).to eq("/stage/middleware4")
           expect(@plugin[:filesystem2]["by_pair"]["192.168.1.11:/stage/middleware3,/stage/middleware4"]["mount"]).to eq("/stage/middleware4")

--- a/spec/unit/plugins/aix/hostname_spec.rb
+++ b/spec/unit/plugins/aix/hostname_spec.rb
@@ -22,6 +22,7 @@ describe Ohai::System, "AIX hostname plugin" do
   before do
     @plugin = get_plugin("hostname")
     allow(@plugin).to receive(:collect_os).and_return(:aix)
+    allow(@plugin).to receive(:resolve_fqdn).and_return("katie.bethell")
     allow(@plugin).to receive(:from_cmd).with("hostname -s").and_return("aix_admin")
     allow(@plugin).to receive(:from_cmd).with("hostname").and_return("aix_admin.ponyville.com")
     @plugin.run

--- a/spec/unit/plugins/aix/kernel_spec.rb
+++ b/spec/unit/plugins/aix/kernel_spec.rb
@@ -56,6 +56,5 @@ describe Ohai::System, "AIX kernel plugin" do
     expect(@plugin[:kernel][:modules]["/usr/lib/drivers/cluster"]["data"]).to eq({ "address" => "f1000000c0390000", "size" => "1ec8c" })
     expect(@plugin[:kernel][:modules]["/usr/lib/drivers/if_en"]["text"]).to eq({ "address" => "6390000", "size" => "20000" })
     expect(@plugin[:kernel][:modules]["/usr/lib/drivers/if_en"]["data"]).to eq({ "address" => "63a0000", "size" => "ba8" })
-
   end
 end

--- a/spec/unit/plugins/aix/network_spec.rb
+++ b/spec/unit/plugins/aix/network_spec.rb
@@ -19,7 +19,6 @@
 require "spec_helper"
 
 describe Ohai::System, "AIX network plugin" do
-
   before do
     @netstat_rn_grep_default = <<~NETSTAT_RN_GREP_DEFAULT
       default            172.31.8.1        UG        2    121789 en0      -      -
@@ -107,7 +106,6 @@ describe Ohai::System, "AIX network plugin" do
   end
 
   describe "when running on an LPAR" do
-
     describe "sets the top-level attribute correctly" do
       before do
         @plugin.run
@@ -264,7 +262,6 @@ describe Ohai::System, "AIX network plugin" do
     end
 
     context "inet6" do
-
       it "detects the route destinations" do
         expect(@plugin["network"]["interfaces"]["en0"][:routes][4][:destination]).to eq("::1%1")
       end

--- a/spec/unit/plugins/aix/uptime_spec.rb
+++ b/spec/unit/plugins/aix/uptime_spec.rb
@@ -19,7 +19,6 @@
 require "spec_helper"
 
 describe Ohai::System, "Aix plugin uptime" do
-
   before do
     @plugin = get_plugin("aix/uptime")
     allow(@plugin).to receive(:collect_os).and_return(:aix)

--- a/spec/unit/plugins/aix/virtualization_spec.rb
+++ b/spec/unit/plugins/aix/virtualization_spec.rb
@@ -19,9 +19,7 @@
 require "spec_helper"
 
 describe Ohai::System, "AIX virtualization plugin" do
-
   context "when inside an LPAR" do
-
     let(:plugin) do
       p = get_plugin("aix/virtualization")
       allow(p).to receive(:collect_os).and_return(:aix)
@@ -245,7 +243,6 @@ describe Ohai::System, "AIX virtualization plugin" do
 
 
       LSWPAR_L
-
     end
 
     it "uname -L detects the LPAR number and name" do
@@ -315,5 +312,4 @@ describe Ohai::System, "AIX virtualization plugin" do
       expect(plugin[:virtualization][:wpar_no]).to eq("42")
     end
   end
-
 end


### PR DESCRIPTION
Mock out #resolve_fqdn like we do in all the other plugins to avoid actually checking the fqdn on the host running the specs.

This was our #2 slowest spec:

```
  Ohai::System AIX hostname plugin sets the machinename
    0.85031 seconds ./spec/unit/plugins/aix/hostname_spec.rb:30
```

Signed-off-by: Tim Smith <tsmith@chef.io>