### PR TITLE
Remove ruby 2.5 from CI.

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -26,14 +26,6 @@ steps:
       docker:
         image: ruby:2.7-buster
 
-- label: run-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh rspec
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-buster
-
 - label: run-specs-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh rspec


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Infra client does not support ruby 2.5 so this CI job will never pass. chef/chef#10463