### PR TITLE
Remove the yard task for generating docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,12 +15,6 @@ group :development do
   gem "rubocop-rspec"
 end
 
-group :docs do
-  gem "github-markup"
-  gem "redcarpet"
-  gem "yard"
-end
-
 group :debug do
   gem "pry"
   gem "pry-byebug"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ bundle exec rake -T
 rake build               # Build ohai-$VERSION.gem into the pkg directory
 rake clean               # Remove any temporary products
 rake clobber             # Remove any generated files
-rake docs                # Generate YARD Documentation
 rake install             # Build and install ohai-$VERSION.gem into system gems
 rake install:local       # Build and install ohai-$VERSION.gem into system gems without network access
 rake release[remote]     # Create tag $VERSION and build and push ohai-$VERSION.gem to rubygems.org

--- a/Rakefile
+++ b/Rakefile
@@ -25,13 +25,6 @@ rescue LoadError
   puts "chefstyle gem is not installed. bundle install first to make sure all dependencies are installed."
 end
 
-begin
-  require "yard"
-  YARD::Rake::YardocTask.new(:docs)
-rescue LoadError
-  puts "yard is not available. bundle install first to make sure all dependencies are installed."
-end
-
 task :console do
   require "irb"
   require "irb/completion"


### PR DESCRIPTION
If someone wants to generate docs they can just run yard against the
repo. This is overengineered

Signed-off-by: Tim Smith <tsmith@chef.io>