### PR TITLE
Remove detection of opensolaris platform

### DIFF
--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -46,9 +46,6 @@ Ohai.plugin(:Platform) do
         when /^\s*(OpenIndiana).*oi_(\d+).*$/
           platform "openindiana"
           platform_version $2
-        when /^\s*(OpenSolaris).*snv_(\d+).*$/
-          platform "opensolaris"
-          platform_version $2
         when /^\s*(Oracle Solaris)/
           platform "solaris2"
         when /^\s*(Solaris)\s.*$/


### PR DESCRIPTION
OpenSolaris is beyond dead at this point and there's no reason to
continue running checks to see if we're on it.

Signed-off-by: Tim Smith <tsmith@chef.io>