### PR TITLE
Remove detection of EOL NexentaCore

### DIFF
--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -50,8 +50,6 @@ Ohai.plugin(:Platform) do
           platform "solaris2"
         when /^\s*(Solaris)\s.*$/
           platform "solaris2"
-        when /^\s*(NexentaCore)\s.*$/
-          platform "nexentacore"
         end
       end
     end


### PR DESCRIPTION
This was EOL'd October 31, 2012

Signed-off-by: Tim Smith <tsmith@chef.io>