### PR TITLE
Properly detect OpenIndiana and its version numbers

### DIFF
--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -38,17 +38,17 @@ Ohai.plugin(:Platform) do
     file_open("/etc/release") do |file|
       while ( line = file.gets )
         case line
-        when /^.*(SmartOS).*$/
+        when /.*SmartOS.*/
           platform "smartos"
-        when /^\s*(OmniOS).*r(\d+).*$/
+        when /^\s*OmniOS.*r(\d+).*$/
           platform "omnios"
-          platform_version $2
-        when /^\s*(OpenIndiana).*oi_(\d+).*$/
+          platform_version $1
+        when /^\s*OpenIndiana.*(Development oi_|Hipster )(\d\S*)/ # https://rubular.com/r/iMtOBwbnyqDz7u
           platform "openindiana"
           platform_version $2
-        when /^\s*(Oracle Solaris)/
+        when /^\s*Oracle Solaris/
           platform "solaris2"
-        when /^\s*(Solaris)\s.*$/
+        when /^\s*Solaris\s.*$/
           platform "solaris2"
         end
       end

--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -46,9 +46,7 @@ Ohai.plugin(:Platform) do
         when /^\s*OpenIndiana.*(Development oi_|Hipster )(\d\S*)/ # https://rubular.com/r/iMtOBwbnyqDz7u
           platform "openindiana"
           platform_version $2
-        when /^\s*Oracle Solaris/
-          platform "solaris2"
-        when /^\s*Solaris\s.*$/
+        when /^\s*(Oracle Solaris|Solaris)/
           platform "solaris2"
         end
       end

--- a/spec/unit/plugins/solaris2/platform_spec.rb
+++ b/spec/unit/plugins/solaris2/platform_spec.rb
@@ -19,10 +19,11 @@
 require "spec_helper"
 
 describe Ohai::System, "Solaris plugin platform" do
+  let(:plugin) { get_plugin("solaris2/platform") }
+
   before do
-    @plugin = get_plugin("solaris2/platform")
-    allow(@plugin).to receive(:collect_os).and_return(:solaris2)
-    allow(@plugin).to receive(:shell_out).with("/sbin/uname -X")
+    allow(plugin).to receive(:collect_os).and_return(:solaris2)
+    allow(plugin).to receive(:shell_out).with("/sbin/uname -X")
   end
 
   describe "on SmartOS" do
@@ -42,23 +43,23 @@ describe Ohai::System, "Solaris plugin platform" do
       UNAME_X
 
       allow(File).to receive(:exist?).with("/sbin/uname").and_return(true)
-      allow(@plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
+      allow(plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
 
       @release = StringIO.new("  SmartOS 20120130T201844Z x86_64\n")
       allow(File).to receive(:open).with("/etc/release").and_yield(@release)
-      @plugin.run
+      plugin.run
     end
 
     it "runs uname and set platform and build" do
-      expect(@plugin[:platform_build]).to eq("joyent_20120130T201844Z")
+      expect(plugin[:platform_build]).to eq("joyent_20120130T201844Z")
     end
 
     it "sets the platform" do
-      expect(@plugin[:platform]).to eq("smartos")
+      expect(plugin[:platform]).to eq("smartos")
     end
 
     it "sets the platform_version" do
-      expect(@plugin[:platform_version]).to eq("5.11")
+      expect(plugin[:platform_version]).to eq("5.11")
     end
 
   end
@@ -80,23 +81,23 @@ describe Ohai::System, "Solaris plugin platform" do
       UNAME_X
 
       allow(File).to receive(:exist?).with("/sbin/uname").and_return(true)
-      allow(@plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
+      allow(plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
 
       @release = StringIO.new("                             Oracle Solaris 11.1 X86\n")
       allow(File).to receive(:open).with("/etc/release").and_yield(@release)
-      @plugin.run
+      plugin.run
     end
 
     it "runs uname and set platform and build" do
-      expect(@plugin[:platform_build]).to eq("11.1")
+      expect(plugin[:platform_build]).to eq("11.1")
     end
 
     it "sets the platform" do
-      expect(@plugin[:platform]).to eq("solaris2")
+      expect(plugin[:platform]).to eq("solaris2")
     end
 
     it "sets the platform_version" do
-      expect(@plugin[:platform_version]).to eq("5.11")
+      expect(plugin[:platform_version]).to eq("5.11")
     end
 
   end
@@ -118,23 +119,23 @@ describe Ohai::System, "Solaris plugin platform" do
       UNAME_X
 
       allow(File).to receive(:exist?).with("/sbin/uname").and_return(true)
-      allow(@plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
+      allow(plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
 
       @release = StringIO.new("  OmniOS v11 r151026\n  Copyright 2017 OmniTI Computer Consulting, Inc. All rights reserved.\n  Copyright 2018 OmniOS Community Edition (OmniOSce) Association.\n  All rights reserved. Use is subject to licence terms.")
       allow(File).to receive(:open).with("/etc/release").and_yield(@release)
-      @plugin.run
+      plugin.run
     end
 
     it "runs uname and set platform and build" do
-      expect(@plugin[:platform_build]).to eq("omnios-r151026-673c59f55d")
+      expect(plugin[:platform_build]).to eq("omnios-r151026-673c59f55d")
     end
 
     it "sets the platform" do
-      expect(@plugin[:platform]).to eq("omnios")
+      expect(plugin[:platform]).to eq("omnios")
     end
 
     it "sets the platform_version" do
-      expect(@plugin[:platform_version]).to eq("151026")
+      expect(plugin[:platform_version]).to eq("151026")
     end
 
   end
@@ -156,23 +157,23 @@ describe Ohai::System, "Solaris plugin platform" do
       UNAME_X
 
       allow(File).to receive(:exist?).with("/sbin/uname").and_return(true)
-      allow(@plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
+      allow(plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
 
       @release = StringIO.new("             OpenIndiana Hipster 2020.04 (powered by illumos)\n        OpenIndiana Project, part of The Illumos Foundation (C) 2010-2020\n                        Use is subject to license terms.\n                           Assembled 03 May 2020")
       allow(File).to receive(:open).with("/etc/release").and_yield(@release)
-      @plugin.run
+      plugin.run
     end
 
     it "runs uname and set platform and build" do
-      expect(@plugin[:platform_build]).to eq("illumos-c3e16711de")
+      expect(plugin[:platform_build]).to eq("illumos-c3e16711de")
     end
 
     it "sets the platform" do
-      expect(@plugin[:platform]).to eq("openindiana")
+      expect(plugin[:platform]).to eq("openindiana")
     end
 
     it "sets the platform_version" do
-      expect(@plugin[:platform_version]).to eq("2020.04")
+      expect(plugin[:platform_version]).to eq("2020.04")
     end
 
   end
@@ -194,18 +195,18 @@ describe Ohai::System, "Solaris plugin platform" do
       UNAME_X
 
       allow(File).to receive(:exist?).with("/sbin/uname").and_return(true)
-      allow(@plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
+      allow(plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
       @release = StringIO.new("             OpenIndiana Development oi_151.1.8 (powered by illumos)\n        Copyright 2011 Oracle and/or its affiliates. All rights reserved\n                        Use is subject to license terms.\n                           Assembled 20 July 2013")
       allow(File).to receive(:open).with("/etc/release").and_yield(@release)
-      @plugin.run
+      plugin.run
     end
 
     it "sets the platform" do
-      expect(@plugin[:platform]).to eq("openindiana")
+      expect(plugin[:platform]).to eq("openindiana")
     end
 
     it "sets the platform_version" do
-      expect(@plugin[:platform_version]).to eq("151.1.8")
+      expect(plugin[:platform_version]).to eq("151.1.8")
     end
 
   end

--- a/spec/unit/plugins/solaris2/platform_spec.rb
+++ b/spec/unit/plugins/solaris2/platform_spec.rb
@@ -139,4 +139,75 @@ describe Ohai::System, "Solaris plugin platform" do
 
   end
 
+  describe "on OpenIndiana Hipster" do
+    before do
+      @uname_x = <<~UNAME_X
+        System = SunOS
+        Node = openindiana
+        Release = 5.11
+        KernelID = illumos-c3e16711de
+        Machine = i86pc
+        BusType = <unknown>
+        Serial = <unknown>
+        Users = <unknown>
+        OEM# = 0
+        Origin# = 1
+        NumCPU = 1
+      UNAME_X
+
+      allow(File).to receive(:exist?).with("/sbin/uname").and_return(true)
+      allow(@plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
+
+      @release = StringIO.new("             OpenIndiana Hipster 2020.04 (powered by illumos)\n        OpenIndiana Project, part of The Illumos Foundation (C) 2010-2020\n                        Use is subject to license terms.\n                           Assembled 03 May 2020")
+      allow(File).to receive(:open).with("/etc/release").and_yield(@release)
+      @plugin.run
+    end
+
+    it "runs uname and set platform and build" do
+      expect(@plugin[:platform_build]).to eq("illumos-c3e16711de")
+    end
+
+    it "sets the platform" do
+      expect(@plugin[:platform]).to eq("openindiana")
+    end
+
+    it "sets the platform_version" do
+      expect(@plugin[:platform_version]).to eq("2020.04")
+    end
+
+  end
+
+  describe "on OpenIndiana pre-Hipster" do
+    before do
+      @uname_x = <<~UNAME_X
+        System = SunOS
+        Node = openindiana
+        Release = 5.11
+        KernelID = illumos-cf2fa55
+        Machine = i86pc
+        BusType = <unknown>
+        Serial = <unknown>
+        Users = <unknown>
+        OEM# = 0
+        Origin# = 1
+        NumCPU = 2
+      UNAME_X
+
+      allow(File).to receive(:exist?).with("/sbin/uname").and_return(true)
+      allow(@plugin).to receive(:shell_out).with("/sbin/uname -X").and_return(mock_shell_out(0, @uname_x, ""))
+      @release = StringIO.new("             OpenIndiana Development oi_151.1.8 (powered by illumos)\n        Copyright 2011 Oracle and/or its affiliates. All rights reserved\n                        Use is subject to license terms.\n                           Assembled 20 July 2013")
+      allow(File).to receive(:open).with("/etc/release").and_yield(@release)
+      @plugin.run
+    end
+
+    it "sets the platform" do
+      expect(@plugin[:platform]).to eq("openindiana")
+    end
+
+    it "sets the platform_version" do
+      expect(@plugin[:platform_version]).to eq("151.1.8")
+    end
+
+  end
+
 end


### PR DESCRIPTION
1) Our regexes for the most part here were more complex than they needed to be
2) OpenIndiana's is now called OpenIndiana Hipster so the old regex was not working
3) Even the old regex only detected the major release instead of the full 3 point version

I doubt anyone is using the non-Hipster release at this point, but we detect it properly now and we have specs in place.

NOTE: Feel free to leave regex improvements here. I'm sure this could be better. I left the Solaris/Oracle Solaris one repetitive on purpose to make it easy to read what we were going for there. Realistically there we could probably squash that down to just "Oracle Linux" since that gets mid-Solaris 10 onwards.

Signed-off-by: Tim Smith <tsmith@chef.io>