### PR TITLE
Gather zpool disks even if zpools uses disk labels/guids

### DIFF
--- a/lib/ohai/plugins/zpools.rb
+++ b/lib/ohai/plugins/zpools.rb
@@ -65,7 +65,9 @@ Ohai.plugin(:Zpools) do
       if platform_family == "solaris2"
         command = "su adm -c \"zpool status #{pool}\""
       else
-        command = "zpool status #{pool}"
+        # -L is used to give us real device names not label or uuid
+        # for example sda instead of ata-WDC_WD60EZAZ-00SF3B0_WD-WX32D203UXYK
+        command = "zpool status #{pool} -L"
       end
 
       so = shell_out(command)

--- a/spec/unit/plugins/zpools_spec.rb
+++ b/spec/unit/plugins/zpools_spec.rb
@@ -71,8 +71,8 @@ describe Ohai::System, "zpools plugin" do
       allow(plugin).to receive(:platform_family).and_return("rhel")
       allow(plugin).to receive(:collect_os).and_return(:linux)
       allow(plugin).to receive(:shell_out).with("zpool list -H -o name,size,alloc,free,cap,dedup,health,version").and_return(mock_shell_out(0, zpool_out, ""))
-      allow(plugin).to receive(:shell_out).with("zpool status rpool").and_return(mock_shell_out(0, zpool_status_rpool, ""))
-      allow(plugin).to receive(:shell_out).with("zpool status tank").and_return(mock_shell_out(0, zpool_status_tank, ""))
+      allow(plugin).to receive(:shell_out).with("zpool status rpool -L").and_return(mock_shell_out(0, zpool_status_rpool, ""))
+      allow(plugin).to receive(:shell_out).with("zpool status tank -L").and_return(mock_shell_out(0, zpool_status_tank, ""))
     end
 
     it "Has entries for both zpools" do


### PR DESCRIPTION
We were expecting the disk name for each device in the pool, but it's
actually better to add them by disk id or guid. That entirely breaks out
regex so use -L on linux to make sure we get the underlying disk.

Signed-off-by: Tim Smith <tsmith@chef.io>