### PR TITLE
Properly detect NVME/XVD devices in ZFS zpools

### DIFF
--- a/lib/ohai/plugins/zpools.rb
+++ b/lib/ohai/plugins/zpools.rb
@@ -76,7 +76,7 @@ Ohai.plugin(:Zpools) do
         # linux: http://rubular.com/r/J3wQC6E2lH
         # solaris: http://rubular.com/r/FqOBzUQQ4p
         # freebsd: http://rubular.com/r/RYkMNlytXl
-        when /^\s+((sd|c|ad|da)[-_a-zA-Z0-9]+)\s+([-_a-zA-Z0-9]+)\s+(\d+)\s+(\d+)\s+(\d+)$/
+        when /^\s+((sd|c|ad|da|nvme)[-_a-zA-Z0-9]+)\s+([-_a-zA-Z0-9]+)\s+(\d+)\s+(\d+)\s+(\d+)$/
           logger.trace("Plugin Zpools: Parsing zpool status line: #{line.chomp}")
           pools[pool][:devices][$1] = Mash.new
           pools[pool][:devices][$1][:state] = $3

--- a/lib/ohai/plugins/zpools.rb
+++ b/lib/ohai/plugins/zpools.rb
@@ -76,7 +76,7 @@ Ohai.plugin(:Zpools) do
         # linux: http://rubular.com/r/J3wQC6E2lH
         # solaris: http://rubular.com/r/FqOBzUQQ4p
         # freebsd: http://rubular.com/r/RYkMNlytXl
-        when /^\s+((sd|c|ad|da|nvme)[-_a-zA-Z0-9]+)\s+([-_a-zA-Z0-9]+)\s+(\d+)\s+(\d+)\s+(\d+)$/
+        when /^\s+((sd|c|ad|da|nvme|xvd)[-_a-zA-Z0-9]+)\s+([-_a-zA-Z0-9]+)\s+(\d+)\s+(\d+)\s+(\d+)$/
           logger.trace("Plugin Zpools: Parsing zpool status line: #{line.chomp}")
           pools[pool][:devices][$1] = Mash.new
           pools[pool][:devices][$1][:state] = $3

--- a/spec/unit/plugins/zpools_spec.rb
+++ b/spec/unit/plugins/zpools_spec.rb
@@ -60,8 +60,8 @@ describe Ohai::System, "zpools plugin" do
     NAME          STATE     READ WRITE CKSUM
     rpool         ONLINE       0     0     0
       mirror-0    ONLINE       0     0     0
-        sda       ONLINE       0     0     0
-        sdb       ONLINE       0     0     0
+        xvda      ONLINE       0     0     0
+        xvdb      ONLINE       0     0     0
 
   errors: No known data errors
       EOSR
@@ -119,7 +119,7 @@ describe Ohai::System, "zpools plugin" do
 
     it "Has the correct devices per zpool" do
       plugin.run
-      expect(plugin[:zpools][:rpool][:devices].keys).to match(%w{sda sdb})
+      expect(plugin[:zpools][:rpool][:devices].keys).to match(%w{xvda xvdb})
       expect(plugin[:zpools][:tank][:devices].keys).to match(%w{sdc sdd sde sdf sdg sdh nvme0n1 nvme1n1 nvme2n1 nvme3n1 nvme4n1 nvme5n1})
     end
 

--- a/spec/unit/plugins/zpools_spec.rb
+++ b/spec/unit/plugins/zpools_spec.rb
@@ -36,12 +36,12 @@ describe Ohai::System, "zpools plugin" do
         sdg                    ONLINE       0     0     0
         sdh                    ONLINE       0     0     0
       raidz2-1                 ONLINE       0     0     0
-        sdi                    ONLINE       0     0     0
-        sdj                    ONLINE       0     0     0
-        sdk                    ONLINE       0     0     0
-        sdl                    ONLINE       0     0     0
-        sdm                    ONLINE       0     0     0
-        sdn                    ONLINE       0     0     0
+        nvme0n1                ONLINE       0     0     0
+        nvme1n1                ONLINE       0     0     0
+        nvme2n1                ONLINE       0     0     0
+        nvme3n1                ONLINE       0     0     0
+        nvme4n1                ONLINE       0     0     0
+        nvme5n1                ONLINE       0     0     0
       EOST
     end
     let(:zpool_out) do
@@ -117,10 +117,10 @@ describe Ohai::System, "zpools plugin" do
       expect(plugin[:zpools][:tank][:health]).to match("ONLINE")
     end
 
-    it "Has the correct number of devices" do
+    it "Has the correct devices per zpool" do
       plugin.run
-      expect(plugin[:zpools][:rpool][:devices].keys.size).to match(2)
-      expect(plugin[:zpools][:tank][:devices].keys.size).to match(12)
+      expect(plugin[:zpools][:rpool][:devices].keys).to match(%w{sda sdb})
+      expect(plugin[:zpools][:tank][:devices].keys).to match(%w{sdc sdd sde sdf sdg sdh nvme0n1 nvme1n1 nvme2n1 nvme3n1 nvme4n1 nvme5n1})
     end
 
     it "Won't have a version number" do


### PR DESCRIPTION
Add another match in the zpool status regex and then update the existing unit test to have some NVME/XVD devices in it.

Signed-off-by: Tim Smith <tsmith@chef.io>