### PR TITLE
Split on strings intead of regex for 3x speedup

### DIFF
--- a/lib/ohai/plugins/aix/uptime.rb
+++ b/lib/ohai/plugins/aix/uptime.rb
@@ -40,9 +40,9 @@ Ohai.plugin(:Uptime) do
     when /^\d+-\d/
       (d, h, m, s) = so.split(/[-:]/)
     when /^\d+:\d+:\d/
-      (h, m, s) = so.split(/:/)
+      (h, m, s) = so.split(":")
     else
-      (m, s) = so.split(/:/)
+      (m, s) = so.split(":")
     end
     elapsed_seconds = ((d.to_i * 86400) + (h.to_i * 3600) + (m.to_i * 60) + s.to_i)
 

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -55,7 +55,7 @@ Ohai.plugin(:Virtualization) do
     if File.executable?("/usr/sbin/zoneadm")
       zones = Mash.new
       shell_out("zoneadm list -pc").stdout.lines do |line|
-        info = line.chomp.split(/:/)
+        info = line.chomp.split(":")
         zones[info[1]] = {
           "id" => info[0],
           "state" => info[2],


### PR DESCRIPTION
This is just over 3x faster than using the regex.

Signed-off-by: Tim Smith <tsmith@chef.io>