### PR TITLE
Speedup the slowest spec by running fewer plugins

### DIFF
--- a/spec/unit/system_spec.rb
+++ b/spec/unit/system_spec.rb
@@ -407,6 +407,8 @@ describe "Ohai::System" do
       E
 
       it "runs all the plugins" do
+        # disable a few slow running plugins
+        Ohai.config[:disabled_plugins] = %i{Packages Virtualbox Ruby}
         ohai.run_additional_plugins(@plugins_directory)
         expect(ohai.data[:canteloupe][:english][:version]).to eq(2014)
         expect(ohai.data[:canteloupe][:french][:version]).to eq(2012)


### PR DESCRIPTION
This spec runs the entire Ohai suite, which can take a bit of time. let's disable the slowest stuff to speed it up a bit.

Signed-off-by: Tim Smith <tsmith@chef.io>