### PR TITLE
Better format the elapsed plugin time

### DIFF
--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -66,7 +66,7 @@ module Ohai
           logger.trace("Plugin #{plugin.name} threw exception #{e.inspect} #{e.backtrace.join("\n")}")
         end
       end
-      logger.trace("Plugin #{plugin.name} took #{elapsed} seconds to run.")
+      logger.trace("Plugin #{plugin.name} took #{"%f" % elapsed.truncate(6)} seconds to run.")
     end
 
     # @param [Ohai::DSL::Plugin] plugin


### PR DESCRIPTION
Some of it was being printed in scientific notation depending on the elapsed time. Always print as a float and only show 6 digits. This makes it easier to sort and to reason with.

Signed-off-by: Tim Smith <tsmith@chef.io>