### PR TITLE
Fix parsing of hostnamectl to support values with colons

### DIFF
--- a/lib/ohai/plugins/linux/hostnamectl.rb
+++ b/lib/ohai/plugins/linux/hostnamectl.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Hostnamectl) do
     hostnamectl_path = which("hostnamectl")
     if hostnamectl_path
       shell_out(hostnamectl_path).stdout.split("\n").each do |line|
-        key, val = line.split(": ")
+        key, val = line.split(": ", 2)
         hostnamectl[key.chomp.lstrip.tr(" ", "_").downcase] = val.chomp
       end
     end

--- a/lib/ohai/plugins/linux/hostnamectl.rb
+++ b/lib/ohai/plugins/linux/hostnamectl.rb
@@ -27,7 +27,7 @@ Ohai.plugin(:Hostnamectl) do
     if hostnamectl_path
       shell_out(hostnamectl_path).stdout.split("\n").each do |line|
         key, val = line.split(": ", 2)
-        hostnamectl[key.chomp.lstrip.tr(" ", "_").downcase] = val.chomp
+        hostnamectl[key.chomp.lstrip.tr(" ", "_").downcase] = val
       end
     end
   end

--- a/lib/ohai/plugins/linux/hostnamectl.rb
+++ b/lib/ohai/plugins/linux/hostnamectl.rb
@@ -26,8 +26,8 @@ Ohai.plugin(:Hostnamectl) do
     hostnamectl_path = which("hostnamectl")
     if hostnamectl_path
       shell_out(hostnamectl_path).stdout.split("\n").each do |line|
-        key, val = line.split(":")
-        hostnamectl[key.chomp.lstrip.tr(" ", "_").downcase] = val.chomp.lstrip
+        key, val = line.split(": ")
+        hostnamectl[key.chomp.lstrip.tr(" ", "_").downcase] = val.chomp
       end
     end
   end

--- a/spec/unit/plugins/linux/hostnamectl_spec.rb
+++ b/spec/unit/plugins/linux/hostnamectl_spec.rb
@@ -34,6 +34,7 @@ describe Ohai::System, "Linux hostnamectl plugin" do
            Boot ID: e085ae9e65e245a8a7b62912adeebe97
   Operating System: Debian GNU/Linux 8 (jessie)
             Kernel: Linux 4.3.0-0.bpo.1-amd64
+       CPE OS Name: cpe:/o:foo:bar:8
       Architecture: x86-64
     HOSTNAMECTL_OUT
 
@@ -44,6 +45,7 @@ describe Ohai::System, "Linux hostnamectl plugin" do
       "static_hostname" => "foo",
       "icon_name" => "computer-laptop",
       "chassis" => "laptop",
+      "cpe_os_name" => "cpe:/o:foo:bar:8",
       "machine_id" => "6f702523e2fc7499eb1dc68e5314dacf",
       "boot_id" => "e085ae9e65e245a8a7b62912adeebe97",
       "operating_system" => "Debian GNU/Linux 8 (jessie)",


### PR DESCRIPTION
This is probably faster too since we don't have to lstrip each result.

Signed-off-by: Tim Smith <tsmith@chef.io>