### PR TITLE
Remove the line anchor from the LSB plugin matches

### DIFF
--- a/lib/ohai/plugins/linux/lsb.rb
+++ b/lib/ohai/plugins/linux/lsb.rb
@@ -27,13 +27,13 @@ Ohai.plugin(:LSB) do
       # From package redhat-lsb on Fedora/Redhat, lsb-release on Debian/Ubuntu
       shell_out("lsb_release -a").stdout.lines do |line|
         case line
-        when /^Distributor ID:\s+(.+)$/
+        when /^Distributor ID:\s+(.+)/
           lsb[:id] = $1
-        when /^Description:\s+(.+)$/
+        when /^Description:\s+(.+)/
           lsb[:description] = $1
-        when /^Release:\s+(.+)$/
+        when /^Release:\s+(.+)/
           lsb[:release] = $1
-        when /^Codename:\s+(.+)$/
+        when /^Codename:\s+(.+)/
           lsb[:codename] = $1
         else
           lsb[:id] = line


### PR DESCRIPTION
These are 1 line at a time matches and we want everything until the end. There's no point in doing it this way.

Signed-off-by: Tim Smith <tsmith@chef.io>