### PR TITLE
Remove Linux LSB support for systems without lsb-release CLI

### DIFF
--- a/lib/ohai/plugins/linux/lsb.rb
+++ b/lib/ohai/plugins/linux/lsb.rb
@@ -39,22 +39,8 @@ Ohai.plugin(:LSB) do
           lsb[:id] = line
         end
       end
-    elsif file_exist?("/etc/lsb-release")
-      # Old, non-standard Debian support
-      file_open("/etc/lsb-release").each do |line|
-        case line
-        when /^DISTRIB_ID=["']?(.+?)["']?$/
-          lsb[:id] = $1
-        when /^DISTRIB_RELEASE=["']?(.+?)["']?$/
-          lsb[:release] = $1
-        when /^DISTRIB_CODENAME=["']?(.+?)["']?$/
-          lsb[:codename] = $1
-        when /^DISTRIB_DESCRIPTION=["']?(.+?)["']?$/
-          lsb[:description] = $1
-        end
-      end
     else
-      logger.trace("Plugin LSB: Skipping LSB, cannot find /etc/lsb-release or /usr/bin/lsb_release")
+      logger.trace("Plugin LSB: Skipping LSB, cannot find /usr/bin/lsb_release")
     end
   end
 end

--- a/spec/unit/plugins/linux/lsb_spec.rb
+++ b/spec/unit/plugins/linux/lsb_spec.rb
@@ -26,40 +26,6 @@ describe Ohai::System, "Linux lsb plugin" do
     allow(@plugin).to receive(:collect_os).and_return(:linux)
   end
 
-  describe "on systems with /etc/lsb-release" do
-    before do
-      @double_file = double("/etc/lsb-release")
-      allow(@double_file).to receive(:each)
-        .and_yield("DISTRIB_ID=Ubuntu")
-        .and_yield("DISTRIB_RELEASE=8.04")
-        .and_yield("DISTRIB_CODENAME=hardy")
-        .and_yield('DISTRIB_DESCRIPTION="Ubuntu 8.04"')
-      allow(File).to receive(:open).with("/etc/lsb-release").and_return(@double_file)
-      allow(File).to receive(:exist?).with("/usr/bin/lsb_release").and_return(false)
-      allow(File).to receive(:exist?).with("/etc/lsb-release").and_return(true)
-    end
-
-    it "sets lsb[:id]" do
-      @plugin.run
-      expect(@plugin[:lsb][:id]).to eq("Ubuntu")
-    end
-
-    it "sets lsb[:release]" do
-      @plugin.run
-      expect(@plugin[:lsb][:release]).to eq("8.04")
-    end
-
-    it "sets lsb[:codename]" do
-      @plugin.run
-      expect(@plugin[:lsb][:codename]).to eq("hardy")
-    end
-
-    it "sets lsb[:description]" do
-      @plugin.run
-      expect(@plugin[:lsb][:description]).to eq("Ubuntu 8.04")
-    end
-  end
-
   describe "on systems with /usr/bin/lsb_release" do
     before do
       allow(File).to receive(:exist?).with("/usr/bin/lsb_release").and_return(true)


### PR DESCRIPTION
This was something we did for legacy Debian < 7. Seems like we're good to nuke this at this point since we don't ship on anything less than 9 now.

Signed-off-by: Tim Smith <tsmith@chef.io>