### PR TITLE
Remove regex anchors in the Linux Memory plugin

### DIFF
--- a/lib/ohai/plugins/linux/memory.rb
+++ b/lib/ohai/plugins/linux/memory.rb
@@ -28,77 +28,77 @@ Ohai.plugin(:Memory) do
 
     file_open("/proc/meminfo").each do |line|
       case line
-      when /^MemTotal:\s+(\d+) (.+)$/
+      when /^MemTotal:\s+(\d+) (.+)/
         memory[:total] = "#{$1}#{$2}"
-      when /^MemFree:\s+(\d+) (.+)$/
+      when /^MemFree:\s+(\d+) (.+)/
         memory[:free] = "#{$1}#{$2}"
-      when /^MemAvailable:\s+(\d+) (.+)$/
+      when /^MemAvailable:\s+(\d+) (.+)/
         memory[:available] = "#{$1}#{$2}"
-      when /^Buffers:\s+(\d+) (.+)$/
+      when /^Buffers:\s+(\d+) (.+)/
         memory[:buffers] = "#{$1}#{$2}"
-      when /^Cached:\s+(\d+) (.+)$/
+      when /^Cached:\s+(\d+) (.+)/
         memory[:cached] = "#{$1}#{$2}"
-      when /^Active:\s+(\d+) (.+)$/
+      when /^Active:\s+(\d+) (.+)/
         memory[:active] = "#{$1}#{$2}"
-      when /^Inactive:\s+(\d+) (.+)$/
+      when /^Inactive:\s+(\d+) (.+)/
         memory[:inactive] = "#{$1}#{$2}"
-      when /^HighTotal:\s+(\d+) (.+)$/
+      when /^HighTotal:\s+(\d+) (.+)/
         memory[:high_total] = "#{$1}#{$2}"
-      when /^HighFree:\s+(\d+) (.+)$/
+      when /^HighFree:\s+(\d+) (.+)/
         memory[:high_free] = "#{$1}#{$2}"
-      when /^LowTotal:\s+(\d+) (.+)$/
+      when /^LowTotal:\s+(\d+) (.+)/
         memory[:low_total] = "#{$1}#{$2}"
-      when /^LowFree:\s+(\d+) (.+)$/
+      when /^LowFree:\s+(\d+) (.+)/
         memory[:low_free] = "#{$1}#{$2}"
-      when /^Dirty:\s+(\d+) (.+)$/
+      when /^Dirty:\s+(\d+) (.+)/
         memory[:dirty] = "#{$1}#{$2}"
-      when /^Writeback:\s+(\d+) (.+)$/
+      when /^Writeback:\s+(\d+) (.+)/
         memory[:writeback] = "#{$1}#{$2}"
-      when /^AnonPages:\s+(\d+) (.+)$/
+      when /^AnonPages:\s+(\d+) (.+)/
         memory[:anon_pages] = "#{$1}#{$2}"
-      when /^Mapped:\s+(\d+) (.+)$/
+      when /^Mapped:\s+(\d+) (.+)/
         memory[:mapped] = "#{$1}#{$2}"
-      when /^Slab:\s+(\d+) (.+)$/
+      when /^Slab:\s+(\d+) (.+)/
         memory[:slab] = "#{$1}#{$2}"
-      when /^SReclaimable:\s+(\d+) (.+)$/
+      when /^SReclaimable:\s+(\d+) (.+)/
         memory[:slab_reclaimable] = "#{$1}#{$2}"
-      when /^SUnreclaim:\s+(\d+) (.+)$/
+      when /^SUnreclaim:\s+(\d+) (.+)/
         memory[:slab_unreclaim] = "#{$1}#{$2}"
-      when /^PageTables:\s+(\d+) (.+)$/
+      when /^PageTables:\s+(\d+) (.+)/
         memory[:page_tables] = "#{$1}#{$2}"
-      when /^NFS_Unstable:\s+(\d+) (.+)$/
+      when /^NFS_Unstable:\s+(\d+) (.+)/
         memory[:nfs_unstable] = "#{$1}#{$2}"
-      when /^Bounce:\s+(\d+) (.+)$/
+      when /^Bounce:\s+(\d+) (.+)/
         memory[:bounce] = "#{$1}#{$2}"
-      when /^CommitLimit:\s+(\d+) (.+)$/
+      when /^CommitLimit:\s+(\d+) (.+)/
         memory[:commit_limit] = "#{$1}#{$2}"
-      when /^Committed_AS:\s+(\d+) (.+)$/
+      when /^Committed_AS:\s+(\d+) (.+)/
         memory[:committed_as] = "#{$1}#{$2}"
-      when /^VmallocTotal:\s+(\d+) (.+)$/
+      when /^VmallocTotal:\s+(\d+) (.+)/
         memory[:vmalloc_total] = "#{$1}#{$2}"
-      when /^VmallocUsed:\s+(\d+) (.+)$/
+      when /^VmallocUsed:\s+(\d+) (.+)/
         memory[:vmalloc_used] = "#{$1}#{$2}"
-      when /^VmallocChunk:\s+(\d+) (.+)$/
+      when /^VmallocChunk:\s+(\d+) (.+)/
         memory[:vmalloc_chunk] = "#{$1}#{$2}"
-      when /^SwapCached:\s+(\d+) (.+)$/
+      when /^SwapCached:\s+(\d+) (.+)/
         memory[:swap][:cached] = "#{$1}#{$2}"
-      when /^SwapTotal:\s+(\d+) (.+)$/
+      when /^SwapTotal:\s+(\d+) (.+)/
         memory[:swap][:total] = "#{$1}#{$2}"
-      when /^SwapFree:\s+(\d+) (.+)$/
+      when /^SwapFree:\s+(\d+) (.+)/
         memory[:swap][:free] = "#{$1}#{$2}"
-      when /^HugePages_Total:\s+(\d+)$/
+      when /^HugePages_Total:\s+(\d+)/
         memory[:hugepages][:total] = $1.to_s
-      when /^HugePages_Free:\s+(\d+)$/
+      when /^HugePages_Free:\s+(\d+)/
         memory[:hugepages][:free] = $1.to_s
-      when /^HugePages_Rsvd:\s+(\d+)$/
+      when /^HugePages_Rsvd:\s+(\d+)/
         memory[:hugepages][:reserved] = $1.to_s
-      when /^HugePages_Surp:\s+(\d+)$/
+      when /^HugePages_Surp:\s+(\d+)/
         memory[:hugepages][:surplus] = $1.to_s
-      when /^Hugepagesize:\s+(\d+) (.+)$/
+      when /^Hugepagesize:\s+(\d+) (.+)/
         memory[:hugepage_size] = "#{$1}#{$2}"
-      when /^Hugetlb:\s+(\d+) (.+)$/
+      when /^Hugetlb:\s+(\d+) (.+)/
         memory[:hugetlb] = "#{$1}#{$2}"
-      when /^DirectMap([0-9]+[a-zA-Z]):\s+(\d+) (.+)$/
+      when /^DirectMap([0-9]+[a-zA-Z]):\s+(\d+) (.+)/
         memory[:directmap][$1.to_sym] = "#{$2}#{$3}"
       end
     end


### PR DESCRIPTION
We're trying to match all everything here so we don't care about the end
of the line.

Signed-off-by: Tim Smith <tsmith@chef.io>