### PR TITLE
Update mock logger to fix shellout specs.

### DIFF
--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -52,7 +52,7 @@ describe Ohai::Mixin::ShellOut, "shell_out" do
     }
   end
 
-  let(:logger) { instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil, trace?: false) }
+  let(:logger) { instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil, trace?: false, debug?: false) }
 
   class DummyPlugin
     include Ohai::Mixin::ShellOut


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Fix the busted specs. Example: https://buildkite.com/chef-oss/chef-ohai-master-verify/builds/757#_