### PR TITLE
Refactor how we parse ifconfig in AIX

### DIFF
--- a/lib/ohai/plugins/aix/network.rb
+++ b/lib/ohai/plugins/aix/network.rb
@@ -38,7 +38,7 @@ Ohai.plugin(:Network) do
     # => state up/down (ifconfig/lsattr)
     # => arp (arp -an)
 
-    iface = Mash.new
+    ifaces = Mash.new
 
     network Mash.new unless network
 
@@ -56,20 +56,18 @@ Ohai.plugin(:Network) do
       network[:default_interface] = default_line[5]
     end
 
-    # Splits the ifconfig output to 1 line per interface
-    if_so = shell_out("ifconfig -a").stdout
-    if_so.gsub(/\n(\w+\d+)/, '___\1').split("___").each do |intraface|
-      splat = intraface.split(":")
-      interface = splat[0]
-      line = splat[1..-1][0]
-      iface[interface] = Mash.new
-      iface[interface][:state] = (line.include?("<UP,") ? "up" : "down")
+    # Splits the ifconfig output into arrays of interface strings
+    shell_out("ifconfig -a").stdout.split(/\n(?=\w)/).each do |int_lines|
+      int_name, int_data = int_lines.split(":", 2)
 
-      intraface.each_line do |lin|
+      ifaces[int_name] = Mash.new
+      ifaces[int_name][:state] = (int_data.include?("<UP,") ? "up" : "down")
+
+      int_data.each_line do |lin|
         case lin
         when /flags=\S+<(\S+)>/
-          iface[interface][:flags] = $1.split(",")
-          iface[interface][:metric] = $1 if lin =~ /metric\s(\S+)/
+          ifaces[int_name][:flags] = $1.split(",")
+          ifaces[int_name][:metric] = $1 if lin =~ /metric\s(\S+)/
         else
           # We have key value pairs.
           if lin =~ %r{inet (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(/(\d{1,2}))?}
@@ -84,34 +82,35 @@ Ohai.plugin(:Network) do
               netmask = IPAddr.new("255.255.255.255").mask(tmp_prefix.to_i).to_s
             end
 
-            iface[interface][:addresses] ||= Mash.new
-            iface[interface][:addresses][tmp_addr] = { "family" => "inet", "prefixlen" => tmp_prefix }
-            iface[interface][:addresses][tmp_addr][:netmask] = netmask
+            ifaces[int_name][:addresses] ||= Mash.new
+            ifaces[int_name][:addresses][tmp_addr] = { "family" => "inet", "prefixlen" => tmp_prefix }
+            ifaces[int_name][:addresses][tmp_addr][:netmask] = netmask
 
             if lin =~ /broadcast\s(\S+)\s/
-              iface[interface][:addresses][tmp_addr][:broadcast] = $1
+              ifaces[int_name][:addresses][tmp_addr][:broadcast] = $1
             end
           elsif lin =~ %r{inet6 ([a-f0-9\:]+)%?(\d*)/?(\d*)?}
             # TODO do we have more properties on inet6 in aix? broadcast
-            iface[interface][:addresses] ||= Mash.new
-            iface[interface][:addresses][$1] = { "family" => "inet6", "zone_index" => $2, "prefixlen" => $3 }
+            ifaces[int_name][:addresses] ||= Mash.new
+            ifaces[int_name][:addresses][$1] = { "family" => "inet6", "zone_index" => $2, "prefixlen" => $3 }
           else
-            # load all key-values, example "tcp_sendspace 131072 tcp_recvspace 131072 rfc1323 1"
+            # add all key value data into the interface mash
+            # for example "tcp_sendspace 131072 tcp_recvspace 131072 rfc1323 1"
+            # has keys tcp_sendspace, tcp_recvspace, and rfc1323
             properties = lin.split
-            n = properties.length / 2 - 1
-            (0..n).each do |i|
-              iface[interface][properties[i * 2]] = properties[(i * 2 + 1)]
+            (properties.size / 2).times do
+              ifaces[int_name][properties.shift] = properties.shift
             end
           end
         end
       end
 
       # Query macaddress
-      e_so = shell_out("entstat -d #{interface} | grep \"Hardware Address\"")
-      iface[interface][:addresses] ||= Mash.new
+      e_so = shell_out("entstat -d #{int_name} | grep \"Hardware Address\"")
+      ifaces[int_name][:addresses] ||= Mash.new
       e_so.stdout.each_line do |l|
         if l =~ /Hardware Address: (\S+)/
-          iface[interface][:addresses][$1.upcase] = { "family" => "lladdr" }
+          ifaces[int_name][:addresses][$1.upcase] = { "family" => "lladdr" }
           macaddress $1.upcase unless shell_out("uname -W").stdout.to_i > 0
         end
       end
@@ -123,8 +122,8 @@ Ohai.plugin(:Network) do
       so_n.stdout.each_line do |line|
         if line =~ /(\S+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(\d+)\s+(\S+)/
           interface = $6
-          iface[interface][:routes] = [] unless iface[interface][:routes]
-          iface[interface][:routes] << Mash.new( destination: $1, family: family,
+          ifaces[interface][:routes] = [] unless ifaces[interface][:routes]
+          ifaces[interface][:routes] << Mash.new( destination: $1, family: family,
                                                  via: $2, flags: $3)
         end
       end
@@ -143,6 +142,6 @@ Ohai.plugin(:Network) do
         count += 1
       end
     end
-    network["interfaces"] = iface
+    network["interfaces"] = ifaces
   end
 end

--- a/lib/ohai/plugins/aix/network.rb
+++ b/lib/ohai/plugins/aix/network.rb
@@ -22,7 +22,7 @@
 Ohai.plugin(:Network) do
   require_relative "../../mixin/network_helper"
 
-  provides "network", "counters/network", "macaddress"
+  provides "network", "network/interfaces", "counters/network", "macaddress"
 
   include Ohai::Mixin::NetworkHelper
 

--- a/lib/ohai/plugins/aix/network.rb
+++ b/lib/ohai/plugins/aix/network.rb
@@ -121,7 +121,7 @@ Ohai.plugin(:Network) do
       so_n.stdout.each_line do |line|
         if line =~ /(\S+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(\d+)\s+(\S+)/
           interface = $6
-          ifaces[interface][:routes] = [] unless ifaces[interface][:routes]
+          ifaces[interface][:routes] ||= []
           ifaces[interface][:routes] << Mash.new( destination: $1, family: family,
                                                  via: $2, flags: $3)
         end

--- a/lib/ohai/plugins/aix/network.rb
+++ b/lib/ohai/plugins/aix/network.rb
@@ -61,6 +61,7 @@ Ohai.plugin(:Network) do
       int_name, int_data = int_lines.split(":", 2)
 
       ifaces[int_name] = Mash.new
+      ifaces[int_name][:addresses] ||= Mash.new
       ifaces[int_name][:state] = (int_data.include?("<UP,") ? "up" : "down")
 
       int_data.each_line do |lin|
@@ -82,7 +83,6 @@ Ohai.plugin(:Network) do
               netmask = IPAddr.new("255.255.255.255").mask(tmp_prefix.to_i).to_s
             end
 
-            ifaces[int_name][:addresses] ||= Mash.new
             ifaces[int_name][:addresses][tmp_addr] = { "family" => "inet", "prefixlen" => tmp_prefix }
             ifaces[int_name][:addresses][tmp_addr][:netmask] = netmask
 
@@ -107,7 +107,6 @@ Ohai.plugin(:Network) do
 
       # Query macaddress
       e_so = shell_out("entstat -d #{int_name} | grep \"Hardware Address\"")
-      ifaces[int_name][:addresses] ||= Mash.new
       e_so.stdout.each_line do |l|
         if l =~ /Hardware Address: (\S+)/
           ifaces[int_name][:addresses][$1.upcase] = { "family" => "lladdr" }

--- a/lib/ohai/plugins/aix/network.rb
+++ b/lib/ohai/plugins/aix/network.rb
@@ -117,8 +117,7 @@ Ohai.plugin(:Network) do
 
     # Query routes information
     %w{inet inet6}.each do |family|
-      so_n = shell_out("netstat -nrf #{family}")
-      so_n.stdout.each_line do |line|
+      shell_out("netstat -nrf #{family}").stdout.each_line do |line|
         if line =~ /(\S+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(\d+)\s+(\S+)/
           interface = $6
           ifaces[interface][:routes] ||= []
@@ -129,9 +128,8 @@ Ohai.plugin(:Network) do
     end
 
     # List the arp entries in system.
-    so = shell_out("arp -an")
     count = 0
-    so.stdout.each_line do |line|
+    shell_out("arp -an").stdout.each_line do |line|
       network[:arp] ||= Mash.new
       if line =~ /\s*(\S+) \((\S+)\) at ([a-fA-F0-9\:]+) \[(\w+)\] stored in bucket/
         network[:arp][count] ||= Mash.new

--- a/lib/ohai/plugins/aix/network.rb
+++ b/lib/ohai/plugins/aix/network.rb
@@ -97,9 +97,8 @@ Ohai.plugin(:Network) do
             # add all key value data into the interface mash
             # for example "tcp_sendspace 131072 tcp_recvspace 131072 rfc1323 1"
             # has keys tcp_sendspace, tcp_recvspace, and rfc1323
-            properties = line.split
-            (properties.size / 2).times do
-              ifaces[int_name][properties.shift] = properties.shift
+            line.split.each_slice(2) do |key, value|
+              ifaces[int_name][key] = value
             end
           end
         end


### PR DESCRIPTION
There's a few different things going on here.

- more descriptive variable names. Variables like splat were not very useful and others like iface actually held more than 1 value
- replace a gsub and split with just a split on a regex from @phiggins
- avoid the whole weird splat thing and ranges and instead just split each interface into the name and all the data. This makes the variables more clear when we use them throughout
- avoid some positional math and just use shift to simply pop off the leading values to build the mash

Signed-off-by: Tim Smith <tsmith@chef.io>