### PR TITLE
Disable gem caching / rubygems updates in Buildkite

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -10,9 +10,7 @@ export LANG=C.UTF-8 LANGUAGE=C.UTF-8
 echo "--- bundle install"
 
 # we need the ruby 2.7 version of bundler, the 2.5/2.6 versions cannot pull our Gemfile correctly
-gem update --system
 gem install bundler
-bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec task"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,7 +1,5 @@
 ---
 expeditor:
-  cached_folders:
-    - vendor
   defaults:
     buildkite:
       retry:
@@ -45,9 +43,7 @@ steps:
 - label: run-specs-windows
   command:
     # we need the ruby 2.7 version of bundler, the 2.5/2.6 versions cannot pull our Gemfile correctly
-    - gem update --system
     - gem install bundler
-    - bundle config --local path vendor/bundle
     - bundle install --jobs=7 --retry=3 --without=profile
     - bundle exec rake spec
   expeditor:


### PR DESCRIPTION
Since we're pulling chef/chef from git now we're basically updating the
cache each and every time this runs, which is very slow. It's possibly
faster to just do it from scratch each time.

Signed-off-by: Tim Smith <tsmith@chef.io>