### PR TITLE
Simplify how we gather memory on AIX

### DIFF
--- a/lib/ohai/plugins/aix/memory.rb
+++ b/lib/ohai/plugins/aix/memory.rb
@@ -25,10 +25,10 @@ Ohai.plugin(:Memory) do
     memory Mash.new
     memory[:swap] = Mash.new
 
-    meminfo = shell_out("svmon -G -O unit=MB,summary=longreal | grep '[0-9]'").stdout
+    meminfo = shell_out("svmon -G -O unit=KB,summary=longreal | grep '[0-9]'").stdout
     total_in_mb, _u, free_in_mb = meminfo.split
-    memory[:total] = "#{total_in_mb.to_i * 1024}kB"
-    memory[:free] = "#{free_in_mb.to_i * 1024}kB"
+    memory[:total] = "#{total_in_mb.to_i}kB"
+    memory[:free] = "#{free_in_mb.to_i}kB"
 
     swap_info = shell_out("swap -s").stdout.split # returns swap info in 4K blocks
     memory[:swap]["total"] = "#{swap_info[2].to_i * 4}kB"

--- a/spec/unit/plugins/aix/memory_spec.rb
+++ b/spec/unit/plugins/aix/memory_spec.rb
@@ -22,28 +22,28 @@ describe Ohai::System, "AIX memory plugin" do
   before do
     @plugin = get_plugin("aix/memory")
     allow(@plugin).to receive(:collect_os).and_return(:aix)
-    allow(@plugin).to receive(:shell_out).with("svmon -G -O unit=MB,summary=longreal | grep '[0-9]'").and_return(mock_shell_out(0, " 513280.00 340034.17 173245.83   62535.17 230400.05 276950.14  70176.00\n", nil))
+    allow(@plugin).to receive(:shell_out).with("svmon -G -O unit=KB,summary=longreal | grep '[0-9]'").and_return(mock_shell_out(0, " 25165824   7255120  17910704    4507712   4913152  19409452   1572864\n", nil))
     @swap_s = "allocated  =    23887872 blocks    used  =   288912 blocks      free  =    23598960 blocks\n"
     allow(@plugin).to receive(:shell_out).with("swap -s").and_return(mock_shell_out(0, @swap_s, nil))
   end
 
   it "gets total memory" do
     @plugin.run
-    expect(@plugin["memory"]["total"]).to eql("#{513280 * 1024}kB")
+    expect(@plugin["memory"]["total"]).to eql("25165824kB")
   end
 
   it "gets free memory" do
     @plugin.run
-    expect(@plugin["memory"]["free"]).to eql("#{173245.83.to_i * 1024}kB")
+    expect(@plugin["memory"]["free"]).to eql("17910704kB")
   end
 
   it "gets total swap" do
     @plugin.run
-    expect(@plugin["memory"]["swap"]["total"]).to eql( "#{23887872 * 4}kB")
+    expect(@plugin["memory"]["swap"]["total"]).to eql( "95551488kB")
   end
 
   it "gets free swap" do
     @plugin.run
-    expect(@plugin["memory"]["swap"]["free"]).to eql( "#{23598960 * 4}kB")
+    expect(@plugin["memory"]["swap"]["free"]).to eql( "94395840kB")
   end
 end


### PR DESCRIPTION
The grep needs to get refactored away, but at least this way we avoid doing math on all the values we gather.

Signed-off-by: Tim Smith <tsmith@chef.io>