### PR TITLE
Simplify aix platform / platform_family detection

### DIFF
--- a/lib/ohai/plugins/aix/platform.rb
+++ b/lib/ohai/plugins/aix/platform.rb
@@ -23,8 +23,8 @@ Ohai.plugin(:Platform) do
   depends "kernel"
 
   collect_data(:aix) do
-    platform kernel[:name]
+    platform "aix"
+    platform_family "aix"
     platform_version [kernel[:version], kernel[:release]].join(".")
-    platform_family platform
   end
 end

--- a/spec/unit/plugins/aix/platform_spec.rb
+++ b/spec/unit/plugins/aix/platform_spec.rb
@@ -18,12 +18,11 @@
 
 require "spec_helper"
 
-describe Ohai::System, "Aix plugin platform" do
+describe Ohai::System, "AIX plugin platform" do
   before do
     @plugin = get_plugin("aix/platform")
     allow(@plugin).to receive(:collect_os).and_return(:aix)
     kernel = Mash.new
-    kernel[:name] = "aix"
     kernel[:version] = "7"
     kernel[:release] = "1"
     allow(@plugin).to receive(:kernel).and_return(kernel)


### PR DESCRIPTION
If we're in a collect block for aix then we're on aix.

Signed-off-by: Tim Smith <tsmith@chef.io>