### PR TITLE
Simplify the aix kernel plugin

### DIFF
--- a/lib/ohai/plugins/aix/kernel.rb
+++ b/lib/ohai/plugins/aix/kernel.rb
@@ -24,12 +24,12 @@ Ohai.plugin(:Kernel) do
   collect_data(:aix) do
     kernel Mash.new
 
-    uname_so = shell_out("uname -srvp").stdout.split
+    uname_so = shell_out("uname -rvp").stdout.split
 
-    kernel[:name] =    uname_so[0].downcase
-    kernel[:release] = uname_so[1]
-    kernel[:version] = uname_so[2]
-    kernel[:machine] = uname_so[3]
+    kernel[:name] =    "aix" # this is here for historical reasons, but it's always aix
+    kernel[:release] = uname_so[0]
+    kernel[:version] = uname_so[1]
+    kernel[:machine] = uname_so[2]
     kernel[:bits] =    shell_out("getconf KERNEL_BITMODE").stdout.strip
 
     modules = Mash.new

--- a/spec/unit/plugins/aix/kernel_spec.rb
+++ b/spec/unit/plugins/aix/kernel_spec.rb
@@ -22,7 +22,7 @@ describe Ohai::System, "AIX kernel plugin" do
   before do
     @plugin = get_plugin("aix/kernel")
     allow(@plugin).to receive(:collect_os).and_return(:aix)
-    allow(@plugin).to receive(:shell_out).with("uname -srvp").and_return(mock_shell_out(0, "AIX 2 7 powerpc", nil))
+    allow(@plugin).to receive(:shell_out).with("uname -rvp").and_return(mock_shell_out(0, "2 7 powerpc", nil))
     allow(@plugin).to receive(:shell_out).with("genkex -d").and_return(mock_shell_out(0, "    Text address     Size     Data address     Size File\nf1000000c0338000    77000 f1000000c0390000    1ec8c /usr/lib/drivers/cluster\n         6390000    20000          63a0000      ba8 /usr/lib/drivers/if_en", nil))
     allow(@plugin).to receive(:shell_out).with("getconf KERNEL_BITMODE").and_return(mock_shell_out(0, "64", nil))
     @plugin.run


### PR DESCRIPTION
There's no point in querying that we're on aix when we only execute this collect on aix. Just hard code it to aix for historic reasons.

Signed-off-by: Tim Smith <tsmith@chef.io>
