### PR TITLE
Use strip instead of split($/) to cleanup shellout

### DIFF
--- a/lib/ohai/plugins/aix/virtualization.rb
+++ b/lib/ohai/plugins/aix/virtualization.rb
@@ -23,16 +23,16 @@ Ohai.plugin(:Virtualization) do
   collect_data(:aix) do
     virtualization Mash.new
 
-    so = shell_out("uname -L")
-    lpar_no = so.stdout.split($/)[0].split(/\s/)[0]
-    lpar_name = so.stdout.split($/)[0].split(/\s/)[1]
+    uname_data = shell_out("uname -L").stdout.split
+    lpar_no = uname_data[0]
+    lpar_name = uname_data[1]
 
     unless lpar_no.to_i == -1 || (lpar_no.to_i == 1 && lpar_name == "NULL")
       virtualization[:lpar_no] = lpar_no
       virtualization[:lpar_name] = lpar_name
     end
 
-    wpar_no = shell_out("uname -W").stdout.chomp
+    wpar_no = shell_out("uname -W").stdout.strip
     if wpar_no.to_i > 0
       virtualization[:wpar_no] = wpar_no
     else

--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -31,7 +31,7 @@ Ohai.plugin(:Virtualization) do
 
     # detect when in a jail or when a jail is actively running (not in stopped state)
     so = shell_out("sysctl -n security.jail.jailed")
-    if so.stdout.split($/)[0].to_i == 1
+    if so.stdout.strip.to_i == 1
       virtualization[:system] = "jail"
       virtualization[:role] = "guest"
       virtualization[:systems][:jail] = "guest"

--- a/lib/ohai/plugins/cpu.rb
+++ b/lib/ohai/plugins/cpu.rb
@@ -200,7 +200,7 @@ Ohai.plugin(:CPU) do
     end
 
     so = shell_out("sysctl -n hw.ncpu")
-    info[:total] = so.stdout.split($/)[0].to_i
+    info[:total] = so.stdout.strip.to_i
     cpu info
   end
 
@@ -220,7 +220,7 @@ Ohai.plugin(:CPU) do
 
     [["hw.model", :model_name], ["hw.ncpu", :total], ["hw.cpuspeed", :mhz]].each do |param, node|
       so = shell_out("sysctl -n #{param}")
-      cpuinfo[node] = so.stdout.split($/)[0]
+      cpuinfo[node] = so.stdout.strip
     end
 
     cpu cpuinfo

--- a/lib/ohai/plugins/dragonflybsd/memory.rb
+++ b/lib/ohai/plugins/dragonflybsd/memory.rb
@@ -26,22 +26,22 @@ Ohai.plugin(:Memory) do
 
     # /usr/src/sys/sys/vmmeter.h
     so = shell_out("sysctl -n vm.stats.vm.v_page_size")
-    memory[:page_size] = so.stdout.split($/)[0]
+    memory[:page_size] = so.stdout.strip
     so = shell_out("sysctl -n vm.stats.vm.v_page_count")
-    memory[:page_count] = so.stdout.split($/)[0]
+    memory[:page_count] = so.stdout.strip
     memory[:total] = memory[:page_size].to_i * memory[:page_count].to_i
     so = shell_out("sysctl -n vm.stats.vm.v_free_count")
-    memory[:free] = memory[:page_size].to_i * so.stdout.split($/)[0].to_i
+    memory[:free] = memory[:page_size].to_i * so.stdout.strip.to_i
     so = shell_out("sysctl -n vm.status.vm.v_active_count")
-    memory[:active] = memory[:page_size].to_i * so.stdout.split($/)[0].to_i
+    memory[:active] = memory[:page_size].to_i * so.stdout.strip.to_i
     so = shell_out("sysctl -n vm.status.vm.v_inactive_count")
-    memory[:inactive] = memory[:page_size].to_i * so.stdout.split($/)[0].to_i
+    memory[:inactive] = memory[:page_size].to_i * so.stdout.strip.to_i
     so = shell_out("sysctl -n vm.stats.vm.v_cache_count")
-    memory[:cache] = memory[:page_size].to_i * so.stdout.split($/)[0].to_i
+    memory[:cache] = memory[:page_size].to_i * so.stdout.strip.to_i
     so = shell_out("sysctl -n vm.stats.vm.v_wire_count")
-    memory[:wired] = memory[:page_size].to_i * so.stdout.split($/)[0].to_i
+    memory[:wired] = memory[:page_size].to_i * so.stdout.strip.to_i
     so = shell_out("sysctl -n vfs.bufspace")
-    memory[:buffers] = so.stdout.split($/)[0]
+    memory[:buffers] = so.stdout.strip
 
     so = shell_out("swapinfo")
     so.stdout.lines do |line|

--- a/lib/ohai/plugins/dragonflybsd/platform.rb
+++ b/lib/ohai/plugins/dragonflybsd/platform.rb
@@ -21,8 +21,8 @@ Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_family"
 
   collect_data(:dragonflybsd) do
-    platform shell_out("uname -s").stdout.split($/)[0].downcase
-    platform_version shell_out("uname -r").stdout.split($/)[0]
+    platform shell_out("uname -s").stdout.strip.downcase
+    platform_version shell_out("uname -r").stdout.strip
     platform_family "dragonflybsd"
   end
 end

--- a/lib/ohai/plugins/freebsd/memory.rb
+++ b/lib/ohai/plugins/freebsd/memory.rb
@@ -26,22 +26,22 @@ Ohai.plugin(:Memory) do
 
     # /usr/src/sys/sys/vmmeter.h
     so = shell_out("sysctl -n vm.stats.vm.v_page_size")
-    memory[:page_size] = so.stdout.split($/)[0]
+    memory[:page_size] = so.stdout.strip
     so = shell_out("sysctl -n vm.stats.vm.v_page_count")
-    memory[:page_count] = so.stdout.split($/)[0]
+    memory[:page_count] = so.stdout.strip
     memory[:total] = memory[:page_size].to_i * memory[:page_count].to_i
     so = shell_out("sysctl -n vm.stats.vm.v_free_count")
-    memory[:free] = memory[:page_size].to_i * so.stdout.split($/)[0].to_i
+    memory[:free] = memory[:page_size].to_i * so.stdout.strip.to_i
     so = shell_out("sysctl -n vm.status.vm.v_active_count")
-    memory[:active] = memory[:page_size].to_i * so.stdout.split($/)[0].to_i
+    memory[:active] = memory[:page_size].to_i * so.stdout.strip.to_i
     so = shell_out("sysctl -n vm.status.vm.v_inactive_count")
-    memory[:inactive] = memory[:page_size].to_i * so.stdout.split($/)[0].to_i
+    memory[:inactive] = memory[:page_size].to_i * so.stdout.strip.to_i
     so = shell_out("sysctl -n vm.stats.vm.v_cache_count")
-    memory[:cache] = memory[:page_size].to_i * so.stdout.split($/)[0].to_i
+    memory[:cache] = memory[:page_size].to_i * so.stdout.strip.to_i
     so = shell_out("sysctl -n vm.stats.vm.v_wire_count")
-    memory[:wired] = memory[:page_size].to_i * so.stdout.split($/)[0].to_i
+    memory[:wired] = memory[:page_size].to_i * so.stdout.strip.to_i
     so = shell_out("sysctl -n vfs.bufspace")
-    memory[:buffers] = so.stdout.split($/)[0]
+    memory[:buffers] = so.stdout.strip
 
     so = shell_out("swapinfo")
     so.stdout.lines do |line|

--- a/lib/ohai/plugins/freebsd/platform.rb
+++ b/lib/ohai/plugins/freebsd/platform.rb
@@ -21,8 +21,8 @@ Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_family"
 
   collect_data(:freebsd) do
-    platform shell_out("uname -s").stdout.split($/)[0].downcase
-    platform_version shell_out("uname -r").stdout.split($/)[0]
+    platform shell_out("uname -s").stdout.strip.downcase
+    platform_version shell_out("uname -r").stdout.strip
     platform_family "freebsd"
   end
 end

--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -38,8 +38,7 @@ Ohai.plugin(:Hostname) do
   # fqdn and domain may be broken if DNS is broken on the host
 
   def from_cmd(cmd)
-    so = shell_out(cmd)
-    so.stdout.split($/)[0]
+    shell_out(cmd).stdout.strip
   end
 
   # forward and reverse lookup to canonicalize FQDN (hostname -f equivalent)

--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Kernel) do
      ["uname -v", :version], ["uname -m", :machine],
      ["uname -p", :processor]].each do |cmd, property|
        so = shell_out(cmd)
-       kernel[property] = so.stdout.split($/)[0]
+       kernel[property] = so.stdout.strip
      end
     kernel
   end
@@ -170,7 +170,7 @@ Ohai.plugin(:Kernel) do
     kernel[:os] = kernel[:name]
 
     so = shell_out("sysctl -n hw.optional.x86_64")
-    if so.stdout.split($/)[0].to_i == 1
+    if so.stdout.strip.to_i == 1
       kernel[:machine] = "x86_64"
     end
 
@@ -190,7 +190,7 @@ Ohai.plugin(:Kernel) do
     kernel[:os] = kernel[:name]
 
     so = shell_out("uname -i")
-    kernel[:ident] = so.stdout.split($/)[0]
+    kernel[:ident] = so.stdout.strip
     so = shell_out("sysctl kern.securelevel")
     kernel[:securelevel] = so.stdout.split($/).select { |e| e =~ /kern.securelevel: (.+)$/ }
 
@@ -201,7 +201,7 @@ Ohai.plugin(:Kernel) do
     kernel init_kernel
 
     so = shell_out("uname -o")
-    kernel[:os] = so.stdout.split($/)[0]
+    kernel[:os] = so.stdout.strip
 
     modules = Mash.new
     so = shell_out("env lsmod")
@@ -233,7 +233,7 @@ Ohai.plugin(:Kernel) do
     kernel init_kernel
 
     so = shell_out("uname -s")
-    kernel[:os] = so.stdout.split($/)[0]
+    kernel[:os] = so.stdout.strip
 
     so = file_open("/etc/release", &:gets)
     md = /(?<update>\d.*\d)/.match(so)

--- a/lib/ohai/plugins/netbsd/platform.rb
+++ b/lib/ohai/plugins/netbsd/platform.rb
@@ -21,8 +21,8 @@ Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_family"
 
   collect_data(:netbsd) do
-    platform shell_out("uname -s").stdout.split($/)[0].downcase
-    platform_version shell_out("uname -r").stdout.split($/)[0]
+    platform shell_out("uname -s").stdout.strip.downcase
+    platform_version shell_out("uname -r").stdout.strip
     platform_family "netbsd"
   end
 end

--- a/lib/ohai/plugins/openbsd/platform.rb
+++ b/lib/ohai/plugins/openbsd/platform.rb
@@ -21,8 +21,8 @@ Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_family"
 
   collect_data(:openbsd) do
-    platform shell_out("uname -s").stdout.split($/)[0].downcase
-    platform_version shell_out("uname -r").stdout.split($/)[0]
+    platform shell_out("uname -s").stdout.strip.downcase
+    platform_version shell_out("uname -r").stdout.strip
     platform_family "openbsd"
   end
 end

--- a/lib/ohai/plugins/os.rb
+++ b/lib/ohai/plugins/os.rb
@@ -35,7 +35,7 @@ Ohai.plugin(:OS) do
 
     # This is __DragonFly_version / __FreeBSD_version. See sys/param.h or
     # http://www.freebsd.org/doc/en/books/porters-handbook/freebsd-versions.html.
-    os_version shell_out("sysctl -n kern.osreldate").stdout.split($/)[0]
+    os_version shell_out("sysctl -n kern.osreldate").stdout.strip
   end
 
   collect_data(:target) do

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -37,8 +37,7 @@ Ohai.plugin(:VMware) do
   depends "virtualization"
 
   def from_cmd(cmd)
-    so = shell_out(cmd)
-    so.stdout.strip
+    shell_out(cmd).stdout.strip
   end
 
   def get_vm_attributes(vmtools_path)

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -38,7 +38,7 @@ Ohai.plugin(:VMware) do
 
   def from_cmd(cmd)
     so = shell_out(cmd)
-    so.stdout.split($/)[0]
+    so.stdout.strip
   end
 
   def get_vm_attributes(vmtools_path)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ def it_should_check_from_mash(plugin, attribute, from, value)
 
   it "sets the #{plugin}[:#{attribute}] to the value from '#{from}'" do
     @plugin.run
-    expect(@plugin[plugin][attribute]).to eq(value[1].split($/)[0])
+    expect(@plugin[plugin][attribute]).to eq(value[1].strip)
   end
 end
 
@@ -67,7 +67,7 @@ def it_should_check_from_deep_mash(plugin, mash, attribute, from, value)
 
   it "sets the #{mash.inspect}[:#{attribute}] to the value from '#{from}'" do
     @plugin.run
-    value = value[1].split($/)[0]
+    value = value[1].strip
     if mash.is_a?(String)
       expect(@plugin[mash][attribute]).to eq(value)
     elsif mash.is_a?(Array)


### PR DESCRIPTION
```
irb(main):008:0> "something\n ".split($/)[0]
=> "something"
```

```
irb(main):009:0> "something\n ".strip
=> "something"
```

Calculating -------------------------------------
         split_stuff   120.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
         strip_stuff    80.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)

Comparison:
         strip_stuff:         80 allocated
         split_stuff:        120 allocated - 1.50x more
Warming up --------------------------------------
         split_stuff   328.234k i/100ms
         strip_stuff   604.612k i/100ms
Calculating -------------------------------------
         split_stuff      3.648M (± 3.2%) i/s -     18.381M in   5.044570s
         strip_stuff      5.993M (± 2.8%) i/s -     30.231M in   5.048664s

Comparison:
         strip_stuff:  5992617.3 i/s
         split_stuff:  3647589.6 i/s - 1.64x  (± 0.00) slower

Signed-off-by: Tim Smith <tsmith@chef.io>