### PR TITLE
aix virtualization: Fix lpar name detection

### DIFF
--- a/lib/ohai/plugins/aix/virtualization.rb
+++ b/lib/ohai/plugins/aix/virtualization.rb
@@ -23,9 +23,7 @@ Ohai.plugin(:Virtualization) do
   collect_data(:aix) do
     virtualization Mash.new
 
-    uname_data = shell_out("uname -L").stdout.split
-    lpar_no = uname_data[0]
-    lpar_name = uname_data[1]
+    lpar_no, lpar_name = shell_out("uname -L").stdout.split(nil, 2)
 
     unless lpar_no.to_i == -1 || (lpar_no.to_i == 1 && lpar_name == "NULL")
       virtualization[:lpar_no] = lpar_no

--- a/spec/unit/plugins/aix/virtualization_spec.rb
+++ b/spec/unit/plugins/aix/virtualization_spec.rb
@@ -23,7 +23,7 @@ describe Ohai::System, "AIX virtualization plugin" do
     let(:plugin) do
       p = get_plugin("aix/virtualization")
       allow(p).to receive(:collect_os).and_return(:aix)
-      allow(p).to receive(:shell_out).with("uname -L").and_return(mock_shell_out(0, "29 l273pp027", nil))
+      allow(p).to receive(:shell_out).with("uname -L").and_return(mock_shell_out(0, "29 virtlpar03 - 7.1 testers", nil))
       allow(p).to receive(:shell_out).with("uname -W").and_return(mock_shell_out(0, "0", nil))
       allow(p).to receive(:shell_out).with("lswpar -L").and_return(mock_shell_out(0, @lswpar_l, nil))
       p
@@ -248,7 +248,7 @@ describe Ohai::System, "AIX virtualization plugin" do
     it "uname -L detects the LPAR number and name" do
       plugin.run
       expect(plugin[:virtualization][:lpar_no]).to eq("29")
-      expect(plugin[:virtualization][:lpar_name]).to eq("l273pp027")
+      expect(plugin[:virtualization][:lpar_name]).to eq("virtlpar03 - 7.1 testers")
     end
 
     context "when WPARs exist on the LPAR" do


### PR DESCRIPTION
LPAR partition names can have spaces in them, which is problematic with our previous split method which would throw away anything past the space. On our internal AIX cluster "virtlpar03 - 7.1 testers" became just "virtlpar03".

Signed-off-by: Tim Smith <tsmith@chef.io>