### PR TITLE
Prevent docker plugin crashes on AIX

### DIFF
--- a/lib/ohai/plugins/docker.rb
+++ b/lib/ohai/plugins/docker.rb
@@ -48,7 +48,7 @@ Ohai.plugin(:Docker) do
     docker[:swarm] = shellout_data["Swarm"]
   end
 
-  collect_data do
+  collect_data(:linux, :windows, :darwin) do
     require "json" unless defined?(JSON)
 
     if virtualization[:systems][:docker]

--- a/spec/unit/plugins/docker_spec.rb
+++ b/spec/unit/plugins/docker_spec.rb
@@ -78,10 +78,14 @@ expected_output = {
 describe Ohai::System, "plugin docker" do
   let(:plugin) { get_plugin("docker") }
 
+  before do
+    plugin[:virtualization] = Mash.new
+    plugin[:virtualization][:systems] = Mash.new
+    allow(plugin).to receive(:collect_os).and_return(:linux)
+  end
+
   context "without docker installed" do
     it "does not create a docker attribute" do
-      plugin[:virtualization] = Mash.new
-      plugin[:virtualization][:systems] = Mash.new
       plugin.run
       expect(plugin).not_to have_key(:docker)
     end
@@ -89,8 +93,6 @@ describe Ohai::System, "plugin docker" do
 
   context "with docker installed" do
     it "creates a docker attribute with correct data" do
-      plugin[:virtualization] = Mash.new
-      plugin[:virtualization][:systems] = Mash.new
       plugin[:virtualization][:systems][:docker] = "host"
       allow(plugin).to receive(:shell_out).with("docker info --format '{{json .}}'").and_return(mock_shell_out(0, docker_output, ""))
       plugin.run


### PR DESCRIPTION
AIX lacks node['virtualization']['systems'] like every other OS so we
need to be a bit more defensive here. This doesn't impact the actual
run, but will make the verbose log output a bit nicer to read.

Signed-off-by: Tim Smith <tsmith@chef.io>