### PR TITLE
Limit several of the Cloud/VM plugins to certain platforms

### DIFF
--- a/lib/ohai/plugins/digital_ocean.rb
+++ b/lib/ohai/plugins/digital_ocean.rb
@@ -49,7 +49,8 @@ Ohai.plugin(:DigitalOcean) do
     false
   end
 
-  collect_data do
+  # linux and freebsd is all digitalocean supports
+  collect_data(:linux, :freebsd) do
     if looks_like_digital_ocean?
       logger.trace("Plugin Digitalocean: looks_like_digital_ocean? == true")
       digital_ocean Mash.new

--- a/lib/ohai/plugins/libvirt.rb
+++ b/lib/ohai/plugins/libvirt.rb
@@ -89,7 +89,7 @@ Ohai.plugin(:Libvirt) do
     storage_data
   end
 
-  collect_data do
+  collect_data(:linux) do
     if virtualization[:role].eql?("host")
       load_libvirt
       begin

--- a/lib/ohai/plugins/linode.rb
+++ b/lib/ohai/plugins/linode.rb
@@ -51,7 +51,7 @@ Ohai.plugin(:Linode) do
     end
   end
 
-  collect_data do
+  collect_data(:linux) do
     # Setup linode mash if it is a linode system
     if looks_like_linode?
       logger.trace("Plugin Linode: looks_like_linode? == true")

--- a/lib/ohai/plugins/scaleway.rb
+++ b/lib/ohai/plugins/scaleway.rb
@@ -44,7 +44,7 @@ Ohai.plugin(:Scaleway) do
     false
   end
 
-  collect_data do
+  collect_data(:linux) do
     if looks_like_scaleway?
       logger.trace("Plugin Scaleway: looks_like_scaleway? == true")
       scaleway Mash.new

--- a/lib/ohai/plugins/virtualbox.rb
+++ b/lib/ohai/plugins/virtualbox.rb
@@ -128,7 +128,7 @@ Ohai.plugin(:Virtualbox) do
     logger.trace("Plugin VboxHost: Could not run '#{so_cmd}'. Skipping data")
   end
 
-  collect_data(:default) do
+  collect_data(:windows, :linux, :solaris2, :darwin) do
     case virtualization.dig("systems", "vbox")
     when "guest"
       logger.trace("Plugin Virtualbox: Node detected as vbox guest. Collecting guest data.")

--- a/spec/unit/plugins/digital_ocean_spec.rb
+++ b/spec/unit/plugins/digital_ocean_spec.rb
@@ -35,6 +35,7 @@ describe Ohai::System, "plugin digital_ocean" do
   end
 
   before do
+    allow(plugin).to receive(:collect_os).and_return(:linux)
     allow(plugin).to receive(:hint?).with("digital_ocean").and_return(false)
   end
 

--- a/spec/unit/plugins/linode_spec.rb
+++ b/spec/unit/plugins/linode_spec.rb
@@ -21,6 +21,7 @@ describe Ohai::System, "plugin linode" do
   let(:plugin) { get_plugin("linode") }
 
   before do
+    allow(plugin).to receive(:collect_os).and_return(:linux)
     plugin[:network] = {
       "interfaces" => {
         "eth0" => {

--- a/spec/unit/plugins/scaleway_spec.rb
+++ b/spec/unit/plugins/scaleway_spec.rb
@@ -21,6 +21,7 @@ describe Ohai::System, "plugin scaleway" do
   let(:plugin) { get_plugin("scaleway") }
 
   before do
+    allow(plugin).to receive(:collect_os).and_return(:linux)
     allow(plugin).to receive(:hint?).with("scaleway").and_return(false)
     allow(plugin).to receive(:file_exist?).with("/proc/cmdline").and_return(false)
   end


### PR DESCRIPTION
Running these on platforms these hypervisors / clouds don't support is pointless and in the case of scaleway it crashes on at least AIX. I went off the list of platforms these clouds / hypervisors support.

Signed-off-by: Tim Smith <tsmith@chef.io>