### PR TITLE
Update Linode plugin to use domain / apt data to detect Linode 

### DIFF
--- a/lib/ohai/plugins/linode.rb
+++ b/lib/ohai/plugins/linode.rb
@@ -18,23 +18,31 @@
 Ohai.plugin(:Linode) do
   provides "linode"
 
-  depends "kernel"
+  depends "domain"
   depends "network/interfaces"
 
-  # Checks for matching linode kernel name
+  # Checks to see if the node is in the members.linode.com domain
   #
-  # Returns true or false
-  def has_linode_kernel?
-    if ( kernel_data = kernel )
-      kernel_data[:release].split("-").last.include?("linode")
-    end
+  # @return [Boolean]
+  #
+  def has_linode_domain?
+    domain&.include?("linode")
+  end
+
+  # Checks for linode mirrors in the apt sources.list file
+  #
+  # @return [Boolean]
+  #
+  def has_linode_apt_repos?
+    file_exist?("/etc/apt/sources.list") && file_read("/etc/apt/sources.list").include?("linode")
   end
 
   # Identifies the linode cloud by preferring the hint, then
   #
-  # Returns true or false
+  # @return [Boolean]
+  #
   def looks_like_linode?
-    hint?("linode") || has_linode_kernel?
+    hint?("linode") || has_linode_domain? || has_linode_apt_repos?
   end
 
   # Alters linode mash with new interface based on name parameter

--- a/lib/ohai/plugins/linode.rb
+++ b/lib/ohai/plugins/linode.rb
@@ -37,12 +37,11 @@ Ohai.plugin(:Linode) do
     hint?("linode") || has_linode_kernel?
   end
 
-  # Names linode ip address
-  #
-  # name - symbol of ohai name (e.g. :public_ip)
-  # eth - Interface name (e.g. :eth0)
-  #
   # Alters linode mash with new interface based on name parameter
+  #
+  # @param [Symbol] name Ohai name (e.g. :public_ip)
+  # @param [Symbol] eth Interface name (e.g. :eth0)
+  #
   def get_ip_address(name, eth)
     if ( eth_iface = network[:interfaces][eth] )
       eth_iface[:addresses].each do |key, info|


### PR DESCRIPTION
The current Linode plugin doesn't work at all. They no longer roll custom kernels so the kernel name detection doesn't ever fire. Instead we can look at the domain to see if it includes linode on RHEL boxes on check the apt sources on Debian/Ubuntu boxes.

Signed-off-by: Tim Smith <tsmith@chef.io>