### PR TITLE
grub2: add plugin to expose GRUB2 environment variables

### DIFF
--- a/lib/ohai/plugins/grub2.rb
+++ b/lib/ohai/plugins/grub2.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# Author:: Davide Cavalca <dcavalca@fb.com>
+# Copyright:: Copyright (c) 2020 Facebook
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:Grub2) do
+  provides "grub2/environment"
+  optional true
+
+  collect_data(:dragonflybsd, :freebsd, :linux, :netbsd) do
+    editenv_path = which("grub2-editenv")
+    if editenv_path
+      editenv_out = shell_out("#{editenv_path} list")
+
+      grub2 Mash.new unless grub2
+      grub2[:environment] ||= Mash.new
+
+      editenv_out.stdout.each_line do |line|
+        key, val = line.split("=", 2)
+        grub2[:environment][key] = val.strip
+      end
+    else
+      logger.trace("Plugin Grub2: Could not find grub2-editenv. Skipping plugin.")
+    end
+  end
+end

--- a/spec/unit/plugins/grub2_spec.rb
+++ b/spec/unit/plugins/grub2_spec.rb
@@ -1,0 +1,51 @@
+#
+# Author:: Davide Cavalca <dcavalca@fb.com>
+# Copyright:: Copyright (c) 2020 Facebook
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Ohai::System, "grub2 plugin" do
+  let(:plugin) { get_plugin("grub2") }
+
+  before do
+    allow(plugin).to receive(:collect_os).and_return(:linux)
+  end
+
+  it "populates grub2 if grub2-editenv is found" do
+    editenv_out = <<-EDITENV_OUT
+saved_entry=f4fd6be6243646e1a76a42d50f219818-5.2.9-229
+boot_success=1
+kernelopts=root=UUID=6db0ffcd-70ec-4333-86c3-873a9e2a0d77 ro
+    EDITENV_OUT
+    allow(plugin).to receive(:which).with("grub2-editenv").and_return("/bin/grub2-editenv")
+    allow(plugin).to receive(:shell_out).with("/bin/grub2-editenv list").and_return(mock_shell_out(0, editenv_out, ""))
+    plugin.run
+    expect(plugin[:grub2].to_hash).to eq({
+      "environment" => {
+        "saved_entry" => "f4fd6be6243646e1a76a42d50f219818-5.2.9-229",
+        "boot_success" => "1",
+        "kernelopts" => "root=UUID=6db0ffcd-70ec-4333-86c3-873a9e2a0d77 ro",
+      },
+    })
+  end
+
+  it "does not populate grub2 if grub2-editenv is not found" do
+    allow(plugin).to receive(:which).with("grub2-editenv").and_return(false)
+    plugin.run
+    expect(plugin[:grub2]).to be(nil)
+  end
+end


### PR DESCRIPTION
## Description
Add a basic plugin to expose GRUB2 environment variables. This is useful for example if one needs to manage the default kernel and/or its options on modern systems using EFI and BLS, but it will also work properly (and return useful data) on older systems.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
