### PR TITLE
Require Ruby 2.7 or later

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -24,14 +24,6 @@ steps:
       docker:
         image: ruby:2.7-buster
 
-- label: run-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh rspec
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6-buster
-
 - label: run-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rspec
@@ -40,13 +32,20 @@ steps:
       docker:
         image: ruby:2.7-buster
 
+- label: run-specs-ruby-3.0
+  command:
+    - .expeditor/run_linux_tests.sh rspec
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.0-buster
+
 - label: run-specs-windows
   command:
-    # we need the ruby 2.7 version of bundler, the 2.5/2.6 versions cannot pull our Gemfile correctly
-    - gem install bundler
     - bundle install --jobs=7 --retry=3 --without=profile
     - bundle exec rake spec
   expeditor:
     executor:
       docker:
         host_os: windows
+        image: rubydistros/windows-2019:2.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-performance
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   Exclude:
     - "spec/data/**/*"
     - "vendor/**/*"

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://github.com/chef/ohai/"
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.7"
 
   s.add_dependency "chef-config", ">= 12.8", "< 18"
   s.add_dependency "chef-utils", ">= 16.0", "< 18"
@@ -26,10 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency "plist", "~> 3.1"
   s.add_dependency "train-core"
   s.add_dependency "wmi-lite", "~> 1.0"
-  # Note for ohai developers: If chef-config causes you grief, try:
-  #     bundle install --with development
-  # this should work as long as chef is a development dependency in Gemfile.
-  #
 
   s.bindir = "bin"
   s.executables = %w{ohai}


### PR DESCRIPTION
We support N-1 and Ohai will support Ruby 3 and 2.7

Signed-off-by: Tim Smith <tsmith@chef.io>