### PR TITLE
Pin chef-utils and chef-config to chef 16.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 gemspec
 
 # pull these gems from master of chef/chef so that we're testing against what we will release
-gem "chef-config", git: "https://github.com/chef/chef", glob: "chef-config/chef-config.gemspec"
-gem "chef-utils", git: "https://github.com/chef/chef", glob: "chef-utils/chef-utils.gemspec"
+gem "chef-config", git: "https://github.com/chef/chef", branch: "chef-16", glob: "chef-config/chef-config.gemspec"
+gem "chef-utils", git: "https://github.com/chef/chef", branch: "chef-16", glob: "chef-utils/chef-utils.gemspec"
 
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do


### PR DESCRIPTION
Ohai 16 needs to pin to chef 16 and not master (17)

Signed-off-by: Tim Smith <tsmith@chef.io>