### PR TITLE
suppress constant redefinition warning

### DIFF
--- a/lib/ohai/plugins/eucalyptus.rb
+++ b/lib/ohai/plugins/eucalyptus.rb
@@ -29,7 +29,7 @@ Ohai.plugin(:Eucalyptus) do
   provides "eucalyptus"
   depends "network/interfaces"
 
-  MAC_MATCH = /^[dD]0:0[dD]:/.freeze
+  MAC_MATCH = /^[dD]0:0[dD]:/.freeze unless defined?(MAC_MATCH)
 
   # returns the mac address from the collection of all address types
   def get_mac_address(addresses)


### PR DESCRIPTION
mostly just cleans up output in chef/chef rspec tests that reload ohai plugins