### PR TITLE
Don't track sensitive new ec2 metadata

### DIFF
--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -121,6 +121,9 @@ Ohai.plugin(:EC2) do
       logger.trace("Plugin EC2: looks_like_ec2? == true")
       ec2 Mash.new
       fetch_metadata.each do |k, v|
+        # this includes sensitive data we don't want to store on the node
+        next if k == "identity_credentials_ec2_security_credentials_ec2_instance"
+
         # fetch_metadata returns IAM security credentials, including the IAM user's
         # secret access key. We'd rather not have ohai send this information
         # to the server. If the instance is associated with an IAM role we grab


### PR DESCRIPTION
When I bumped the aws metadata versions we support it brought in some
new sensitive data we don't want on nodes. This skips accesskeyid /
secretaccesskey storage.

Signed-off-by: Tim Smith <tsmith@chef.io>