### PR TITLE
Update ec2_metadata to use IMDSV2 (Continued from #1457)

### DIFF
--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -52,7 +52,7 @@ module Ohai
       def best_api_version
         @api_version ||= begin
           logger.trace("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}/ to determine the latest supported metadata release")
-          response = http_client.get("/", {:'X-aws-ec2-metadata-token' => v2_token})
+          response = http_client.get("/", { 'X-aws-ec2-metadata-token': v2_token })
           if response.code == "404"
             logger.trace("Mixin EC2: Received HTTP 404 from metadata server while determining API version, assuming 'latest'")
             return "latest"
@@ -86,8 +86,9 @@ module Ohai
       end
 
       def v2_token
-        http_client.put('/latest/api/token/', nil, {:'X-aws-ec2-metadata-token-ttl-seconds' => '60'})&.body
+        http_client.put("/latest/api/token/", nil, { 'X-aws-ec2-metadata-token-ttl-seconds': "60" })&.body
       end
+
       # Get metadata for a given path and API version
       #
       # Typically, a 200 response is expected for valid metadata.
@@ -97,7 +98,7 @@ module Ohai
       def metadata_get(id, api_version)
         path = "/#{api_version}/meta-data/#{id}"
         logger.trace("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}#{path}")
-        response = http_client.get(path, {:'X-aws-ec2-metadata-token' => v2_token})
+        response = http_client.get(path, { 'X-aws-ec2-metadata-token': v2_token })
         case response.code
         when "200"
           response.body
@@ -178,13 +179,13 @@ module Ohai
 
       def fetch_userdata
         logger.trace("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}/#{best_api_version}/user-data/")
-        response = http_client.get("/#{best_api_version}/user-data/", {:'X-aws-ec2-metadata-token' => v2_token})
+        response = http_client.get("/#{best_api_version}/user-data/", { 'X-aws-ec2-metadata-token': v2_token })
         response.code == "200" ? response.body : nil
       end
 
       def fetch_dynamic_data
         @fetch_dynamic_data ||= begin
-          response = http_client.get("/#{best_api_version}/dynamic/instance-identity/document/", {:'X-aws-ec2-metadata-token' => v2_token})
+          response = http_client.get("/#{best_api_version}/dynamic/instance-identity/document/", { 'X-aws-ec2-metadata-token': v2_token })
 
           if json?(response.body) && response.code == "200"
             FFI_Yajl::Parser.parse(response.body)

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -52,7 +52,7 @@ module Ohai
       def best_api_version
         @api_version ||= begin
           logger.trace("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}/ to determine the latest supported metadata release")
-          response = http_client.get("/")
+          response = http_client.get("/", {:'X-aws-ec2-metadata-token' => v2_token})
           if response.code == "404"
             logger.trace("Mixin EC2: Received HTTP 404 from metadata server while determining API version, assuming 'latest'")
             return "latest"
@@ -85,6 +85,9 @@ module Ohai
         end
       end
 
+      def v2_token
+        http_client.put('/latest/api/token/', nil, {:'X-aws-ec2-metadata-token-ttl-seconds' => '60'})&.body
+      end
       # Get metadata for a given path and API version
       #
       # Typically, a 200 response is expected for valid metadata.
@@ -94,7 +97,7 @@ module Ohai
       def metadata_get(id, api_version)
         path = "/#{api_version}/meta-data/#{id}"
         logger.trace("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}#{path}")
-        response = http_client.get(path)
+        response = http_client.get(path, {:'X-aws-ec2-metadata-token' => v2_token})
         case response.code
         when "200"
           response.body
@@ -175,13 +178,13 @@ module Ohai
 
       def fetch_userdata
         logger.trace("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}/#{best_api_version}/user-data/")
-        response = http_client.get("/#{best_api_version}/user-data/")
+        response = http_client.get("/#{best_api_version}/user-data/", {:'X-aws-ec2-metadata-token' => v2_token})
         response.code == "200" ? response.body : nil
       end
 
       def fetch_dynamic_data
         @fetch_dynamic_data ||= begin
-          response = http_client.get("/#{best_api_version}/dynamic/instance-identity/document/")
+          response = http_client.get("/#{best_api_version}/dynamic/instance-identity/document/", {:'X-aws-ec2-metadata-token' => v2_token})
 
           if json?(response.body) && response.code == "200"
             FFI_Yajl::Parser.parse(response.body)

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -86,7 +86,7 @@ module Ohai
       end
 
       def v2_token
-        @v2_token ||= http_client.put('/latest/api/token', nil, { 'X-aws-ec2-metadata-token-ttl-seconds': "60" })&.body
+        @v2_token ||= http_client.put("/latest/api/token", nil, { 'X-aws-ec2-metadata-token-ttl-seconds': "60" })&.body
       end
 
       # Get metadata for a given path and API version

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -85,8 +85,21 @@ module Ohai
         end
       end
 
+      #
+      # Fetch an API token for use querying AWS IMDSv2 or return nil if no token if found
+      # AWS like systems (think OpenStack) will not respond with a token here
+      #
+      # @return [NilClass, String] API token or nil
+      #
       def v2_token
-        @v2_token ||= http_client.put("/latest/api/token", nil, { 'X-aws-ec2-metadata-token-ttl-seconds': "60" })&.body
+        @v2_token ||= begin
+            request = http_client.put("/latest/api/token", nil, { 'X-aws-ec2-metadata-token-ttl-seconds': "60" })
+            if request.code == "404" # not on AWS
+              nil
+            else
+              request.body
+            end
+          end
       end
 
       # Get metadata for a given path and API version

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -49,6 +49,13 @@ module Ohai
       EC2_ARRAY_DIR    ||= %w{network/interfaces/macs}.freeze
       EC2_JSON_DIR     ||= %w{iam}.freeze
 
+      #
+      # The latest metadata version in EC2_SUPPORTED_VERSIONS that this instance supports
+      # in AWS supported metadata versions are determined at instance start so we need to be
+      # cautious here in case an instance has been running for a long time
+      #
+      # @return [String] the version
+      #
       def best_api_version
         @api_version ||= begin
           logger.trace("Mixin EC2: Fetching http://#{EC2_METADATA_ADDR}/ to determine the latest supported metadata release")

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -86,7 +86,7 @@ module Ohai
       end
 
       def v2_token
-        http_client.put("/latest/api/token/", nil, { 'X-aws-ec2-metadata-token-ttl-seconds': "60" })&.body
+        @v2_token ||= http_client.put('/latest/api/token', nil, { 'X-aws-ec2-metadata-token-ttl-seconds': "60" })&.body
       end
 
       # Get metadata for a given path and API version

--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -162,8 +162,8 @@ Ohai.plugin(:Rackspace) do
       unless rackspace[:public_ip].nil?
         rackspace[:public_hostname] = begin
           Resolv.getname(rackspace[:public_ip])
-        rescue Resolv::ResolvError, Resolv::ResolvTimeout
-          rackspace[:public_ip]
+                                      rescue Resolv::ResolvError, Resolv::ResolvTimeout
+                                        rackspace[:public_ip]
         end
       end
       rackspace[:local_ipv4] = rackspace[:private_ip]

--- a/spec/unit/mixin/ec2_metadata_spec.rb
+++ b/spec/unit/mixin/ec2_metadata_spec.rb
@@ -73,6 +73,13 @@ describe Ohai::Mixin::Ec2Metadata do
         expect { mixin.best_api_version }.to raise_error(RuntimeError)
       end
     end
+
+    context "when metadata service is disabled" do
+      let(:response) { double("Net::HTTP::PUT Response", body: "403 - Forbidden", code: "403") }
+      it "raises an error" do
+        expect { mixin.best_api_version }.to raise_error(RuntimeError)
+      end
+    end
   end
 
   describe "#metadata_get" do

--- a/spec/unit/mixin/ec2_metadata_spec.rb
+++ b/spec/unit/mixin/ec2_metadata_spec.rb
@@ -22,7 +22,7 @@ describe Ohai::Mixin::Ec2Metadata do
   let(:mixin) do
     metadata_object = Object.new.extend(described_class)
     http_client = double("Net::HTTP client")
-    allow(http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: "xxxxxxxxxxxxxxxxxxxxxxxx==", code: "200") }
+    allow(http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: "AQAEAE4UUd-3NE5EEeYYXKxicVfDOHsx0YSHFFSuCvo2GfCcxzJsvg==", code: "200") }
     allow(http_client).to receive(:get).and_return(response)
     allow(metadata_object).to receive(:http_client).and_return(http_client)
     metadata_object

--- a/spec/unit/mixin/ec2_metadata_spec.rb
+++ b/spec/unit/mixin/ec2_metadata_spec.rb
@@ -35,14 +35,14 @@ describe Ohai::Mixin::Ec2Metadata do
 
   describe "#best_api_version" do
     context "with a sorted list of metadata versions" do
-      let(:response) { double("Net::HTTP::GET Response", body: "1.0\n2011-05-01\n2012-01-12\nUnsupported", code: "200") }
+      let(:response) { double("Net::HTTP Response", body: "1.0\n2011-05-01\n2012-01-12\nUnsupported", code: "200") }
       it "returns the most recent version" do
         expect(mixin.best_api_version).to eq("2012-01-12")
       end
     end
 
     context "with an unsorted list of metadata versions" do
-      let(:response) { double("Net::HTTP::GET Response", body: "1.0\n2009-04-04\n2007-03-01\n2011-05-01\n2008-09-01\nUnsupported", code: "200") }
+      let(:response) { double("Net::HTTP Response", body: "1.0\n2009-04-04\n2007-03-01\n2011-05-01\n2008-09-01\nUnsupported", code: "200") }
 
       it "returns the most recent version (using string sort)" do
         expect(mixin.best_api_version).to eq("2011-05-01")
@@ -50,7 +50,7 @@ describe Ohai::Mixin::Ec2Metadata do
     end
 
     context "when no supported versions are found" do
-      let(:response) { double("Net::HTTP::GET Response", body: "2020-01-01\nUnsupported", code: "200") }
+      let(:response) { double("Net::HTTP Response", body: "2020-01-01\nUnsupported", code: "200") }
 
       it "raises an error" do
         expect { mixin.best_api_version }.to raise_error(RuntimeError)
@@ -59,7 +59,7 @@ describe Ohai::Mixin::Ec2Metadata do
 
     # Presume 'latest' when we get a 404 for Eucalyptus back-compat
     context "when the response code is 404" do
-      let(:response) { double("Net::HTTP::GET Response", code: "404") }
+      let(:response) { double("Net::HTTP Response", code: "404") }
 
       it "returns 'latest' as the version" do
         expect(mixin.best_api_version).to eq("latest")
@@ -67,7 +67,7 @@ describe Ohai::Mixin::Ec2Metadata do
     end
 
     context "when the response code is unexpected" do
-      let(:response) { double("Net::HTTP::GET Response", body: "1.0\n2011-05-01\n2012-01-12\nUnsupported", code: "418") }
+      let(:response) { double("Net::HTTP Response", body: "1.0\n2011-05-01\n2012-01-12\nUnsupported", code: "418") }
 
       it "raises an error" do
         expect { mixin.best_api_version }.to raise_error(RuntimeError)
@@ -84,7 +84,7 @@ describe Ohai::Mixin::Ec2Metadata do
 
   describe "#metadata_get" do
     context "when the response code is unexpected" do
-      let(:response) { double("Net::HTTP::GET Response", body: "", code: "418") }
+      let(:response) { double("Net::HTTP Response", body: "", code: "418") }
 
       it "raises an error" do
         expect { mixin.metadata_get("", "2012-01-12") }.to raise_error(RuntimeError)

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -46,9 +46,12 @@ describe Ohai::System, "plugin ec2" do
       t = double("connection")
       allow(t).to receive(:connect_nonblock).and_raise(Errno::EINPROGRESS)
       allow(Socket).to receive(:new).and_return(t)
+      @token = "xxxxxxxxxxxxxxxxxxxxxxxx=="
+      @get_token_header = {:'X-aws-ec2-metadata-token' => @token}
+      allow(@http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: @token, code: "200") }
       expect(@http_client).to receive(:get)
-        .with("/")
-        .and_return(double("Net::HTTP Response", body: "2012-01-12", code: "200"))
+        .with("/", @get_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "2012-01-12", code: "200"))
     end
 
     context "with common metadata paths" do
@@ -63,15 +66,15 @@ describe Ohai::System, "plugin ec2" do
       it "recursively fetches all the ec2 metadata" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
-            .with("/2012-01-12/#{name}")
-            .and_return(double("Net::HTTP Response", body: body, code: "200"))
+            .with("/2012-01-12/#{name}", @get_token_header)
+            .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/")
-          .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
+          .with("/2012-01-12/user-data/", @get_token_header)
+          .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/")
-          .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+          .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
 
@@ -84,14 +87,14 @@ describe Ohai::System, "plugin ec2" do
       it "fetches binary userdata opaquely" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
-            .with("/2012-01-12/#{name}")
+            .with("/2012-01-12/#{name}", @get_token_header)
             .and_return(double("Net::HTTP Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/")
+          .with("/2012-01-12/user-data/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/")
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
@@ -106,14 +109,14 @@ describe Ohai::System, "plugin ec2" do
       it "fetches AWS account id" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
-            .with("/2012-01-12/#{name}")
+            .with("/2012-01-12/#{name}", @get_token_header)
             .and_return(double("Net::HTTP Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/")
+          .with("/2012-01-12/user-data/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/")
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
@@ -128,14 +131,14 @@ describe Ohai::System, "plugin ec2" do
       it "fetches AWS region" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
-            .with("/2012-01-12/#{name}")
+            .with("/2012-01-12/#{name}", @get_token_header)
             .and_return(double("Net::HTTP Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/")
+          .with("/2012-01-12/user-data/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/")
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "{\"region\":\"us-east-1\"}", code: "200"))
 
         plugin.run
@@ -150,14 +153,14 @@ describe Ohai::System, "plugin ec2" do
       it "fetches AWS availability zone" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
-            .with("/2012-01-12/#{name}")
+            .with("/2012-01-12/#{name}", @get_token_header)
             .and_return(double("Net::HTTP Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/")
+          .with("/2012-01-12/user-data/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/")
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "{\"availabilityZone\":\"us-east-1d\"}", code: "200"))
 
         plugin.run
@@ -172,29 +175,29 @@ describe Ohai::System, "plugin ec2" do
 
     it "parses ec2 network/ directory as a multi-level hash" do
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/")
-        .and_return(double("Net::HTTP Response", body: "network/", code: "200"))
+        .with("/2012-01-12/meta-data/", @get_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "network/", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/network/")
-        .and_return(double("Net::HTTP Response", body: "interfaces/", code: "200"))
+        .with("/2012-01-12/meta-data/network/", @get_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "interfaces/", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/network/interfaces/")
-        .and_return(double("Net::HTTP Response", body: "macs/", code: "200"))
+        .with("/2012-01-12/meta-data/network/interfaces/", @get_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "macs/", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/network/interfaces/macs/")
-        .and_return(double("Net::HTTP Response", body: "12:34:56:78:9a:bc/", code: "200"))
+        .with("/2012-01-12/meta-data/network/interfaces/macs/", @get_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "12:34:56:78:9a:bc/", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/network/interfaces/macs/12:34:56:78:9a:bc/")
-        .and_return(double("Net::HTTP Response", body: "public_hostname", code: "200"))
+        .with("/2012-01-12/meta-data/network/interfaces/macs/12:34:56:78:9a:bc/", @get_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "public_hostname", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/network/interfaces/macs/12:34:56:78:9a:bc/public_hostname")
-        .and_return(double("Net::HTTP Response", body: "server17.opscode.com", code: "200"))
+        .with("/2012-01-12/meta-data/network/interfaces/macs/12:34:56:78:9a:bc/public_hostname", @get_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "server17.opscode.com", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/user-data/")
-        .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
+        .with("/2012-01-12/user-data/", @get_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/dynamic/instance-identity/document/")
-        .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+        .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run
 
@@ -209,22 +212,22 @@ describe Ohai::System, "plugin ec2" do
 
       it "parses ec2 iam/ directory and collect iam/security-credentials/" do
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/")
+          .with("/2012-01-12/meta-data/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "iam/", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/")
+          .with("/2012-01-12/meta-data/iam/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "security-credentials/", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/security-credentials/")
+          .with("/2012-01-12/meta-data/iam/security-credentials/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "MyRole", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/security-credentials/MyRole")
+          .with("/2012-01-12/meta-data/iam/security-credentials/MyRole", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/")
+          .with("/2012-01-12/user-data/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/")
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
@@ -242,25 +245,22 @@ describe Ohai::System, "plugin ec2" do
 
       it "parses ec2 iam/ directory and collect info and role_name and NOT collect iam/security-credentials/" do
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/")
+          .with("/2012-01-12/meta-data/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "iam/", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/")
-          .and_return(double("Net::HTTP Response", body: "info\nsecurity-credentials/", code: "200"))
+          .with("/2012-01-12/meta-data/iam/", @get_token_header)
+          .and_return(double("Net::HTTP Response", body: "security-credentials/", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/info")
-          .and_return(double("Net::HTTP Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2020-10-08T20:47:08Z\",\n  \"InstanceProfileArn\" : \"arn:aws:iam::111111111111:instance-profile/my_profile\",\n  \"InstanceProfileId\" : \"AAAAAAAAAAAAAAAAAAAAA\"\n}", code: "200"))
-        expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/security-credentials/")
+          .with("/2012-01-12/meta-data/iam/security-credentials/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "MyRole", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/security-credentials/MyRole")
+          .with("/2012-01-12/meta-data/iam/security-credentials/MyRole", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/")
+          .with("/2012-01-12/user-data/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/")
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
           .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
@@ -274,37 +274,36 @@ describe Ohai::System, "plugin ec2" do
 
     it "ignores \"./\" and \"../\" on ec2 metadata paths to avoid infinity loops" do
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/")
+        .with("/2012-01-12/meta-data/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: ".\n./\n..\n../\npath1/.\npath2/./\npath3/..\npath4/../", code: "200"))
+      expect(@http_client).not_to receive(:get)
+        .with("/2012-01-12/meta-data/.", @get_token_header)
+      expect(@http_client).not_to receive(:get)
+        .with("/2012-01-12/meta-data/./", @get_token_header)
+      expect(@http_client).not_to receive(:get)
+        .with("/2012-01-12/meta-data/..", @get_token_header)
+      expect(@http_client).not_to receive(:get)
+        .with("/2012-01-12/meta-data/../", @get_token_header)
+      expect(@http_client).not_to receive(:get)
+        .with("/2012-01-12/meta-data/path1/..", @get_token_header)
 
-      expect(@http_client).not_to receive(:get)
-        .with("/2012-01-12/meta-data/.")
-      expect(@http_client).not_to receive(:get)
-        .with("/2012-01-12/meta-data/./")
-      expect(@http_client).not_to receive(:get)
-        .with("/2012-01-12/meta-data/..")
-      expect(@http_client).not_to receive(:get)
-        .with("/2012-01-12/meta-data/../")
-      expect(@http_client).not_to receive(:get)
-        .with("/2012-01-12/meta-data/path1/..")
-
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/path1/")
+        .with("/2012-01-12/meta-data/path1/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/path2/")
+        .with("/2012-01-12/meta-data/path2/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/path3/")
+        .with("/2012-01-12/meta-data/path3/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/path4/")
+        .with("/2012-01-12/meta-data/path4/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/user-data/")
+        .with("/2012-01-12/user-data/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/dynamic/instance-identity/document/")
+        .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run
@@ -314,19 +313,19 @@ describe Ohai::System, "plugin ec2" do
 
     it "completes the run despite unavailable metadata" do
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/")
+        .with("/2012-01-12/meta-data/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "metrics/", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/metrics/")
+        .with("/2012-01-12/meta-data/metrics/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "vhostmd", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/metrics/vhostmd")
+        .with("/2012-01-12/meta-data/metrics/vhostmd", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "", code: "404"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/user-data/")
+        .with("/2012-01-12/user-data/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/dynamic/instance-identity/document/")
+        .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
         .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -51,7 +51,7 @@ describe Ohai::System, "plugin ec2" do
       allow(@http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: token, code: "200") }
       expect(@http_client).to receive(:get)
         .with("/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "2012-01-12", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "2012-01-12", code: "200"))
     end
 
     context "with common metadata paths" do
@@ -67,14 +67,14 @@ describe Ohai::System, "plugin ec2" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
             .with("/2012-01-12/#{name}", @get_req_token_header)
-            .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
+            .and_return(double("Net::HTTP Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
 
@@ -88,14 +88,14 @@ describe Ohai::System, "plugin ec2" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
             .with("/2012-01-12/#{name}", @get_req_token_header)
-            .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
+            .and_return(double("Net::HTTP Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
 
@@ -110,14 +110,14 @@ describe Ohai::System, "plugin ec2" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
             .with("/2012-01-12/#{name}", @get_req_token_header)
-            .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
+            .and_return(double("Net::HTTP Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
 
@@ -132,14 +132,14 @@ describe Ohai::System, "plugin ec2" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
             .with("/2012-01-12/#{name}", @get_req_token_header)
-            .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
+            .and_return(double("Net::HTTP Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "{\"region\":\"us-east-1\"}", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "{\"region\":\"us-east-1\"}", code: "200"))
 
         plugin.run
 
@@ -154,14 +154,14 @@ describe Ohai::System, "plugin ec2" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
             .with("/2012-01-12/#{name}", @get_req_token_header)
-            .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
+            .and_return(double("Net::HTTP Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "{\"availabilityZone\":\"us-east-1d\"}", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "{\"availabilityZone\":\"us-east-1d\"}", code: "200"))
 
         plugin.run
 
@@ -176,28 +176,28 @@ describe Ohai::System, "plugin ec2" do
     it "parses ec2 network/ directory as a multi-level hash" do
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "network/", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "network/", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/network/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "interfaces/", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "interfaces/", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/network/interfaces/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "macs/", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "macs/", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/network/interfaces/macs/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "12:34:56:78:9a:bc/", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "12:34:56:78:9a:bc/", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/network/interfaces/macs/12:34:56:78:9a:bc/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "public_hostname", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "public_hostname", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/network/interfaces/macs/12:34:56:78:9a:bc/public_hostname", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "server17.opscode.com", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "server17.opscode.com", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/user-data/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run
 
@@ -213,22 +213,22 @@ describe Ohai::System, "plugin ec2" do
       it "parses ec2 iam/ directory and collect iam/security-credentials/" do
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "iam/", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "iam/", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "security-credentials/", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "security-credentials/", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/security-credentials/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "MyRole", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "MyRole", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/security-credentials/MyRole", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
 
@@ -246,25 +246,27 @@ describe Ohai::System, "plugin ec2" do
       it "parses ec2 iam/ directory and collect info and role_name and NOT collect iam/security-credentials/" do
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "iam/", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "iam/", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "security-credentials/", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "info\nsecurity-credentials/", code: "200"))
+        expect(@http_client).to receive(:get)
+          .with("/2012-01-12/meta-data/iam/info", @get_req_token_header)
+          .and_return(double("Net::HTTP Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2020-10-08T20:47:08Z\",\n  \"InstanceProfileArn\" : \"arn:aws:iam::111111111111:instance-profile/my_profile\",\n  \"InstanceProfileId\" : \"AAAAAAAAAAAAAAAAAAAAA\"\n}", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/security-credentials/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "MyRole", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "MyRole", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/security-credentials/MyRole", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
-          .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+          .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
-
         expect(plugin[:ec2]).not_to be_nil
         expect(plugin[:ec2]["iam"]["info"]["InstanceProfileId"]).to eql "AAAAAAAAAAAAAAAAAAAAA"
         expect(plugin[:ec2]["iam"]["security-credentials"]).to be_nil
@@ -275,7 +277,7 @@ describe Ohai::System, "plugin ec2" do
     it "ignores \"./\" and \"../\" on ec2 metadata paths to avoid infinity loops" do
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: ".\n./\n..\n../\npath1/.\npath2/./\npath3/..\npath4/../", code: "200"))
+        .and_return(double("Net::HTTP Response", body: ".\n./\n..\n../\npath1/.\npath2/./\npath3/..\npath4/../", code: "200"))
       expect(@http_client).not_to receive(:get)
         .with("/2012-01-12/meta-data/.", @get_req_token_header)
       expect(@http_client).not_to receive(:get)
@@ -289,22 +291,22 @@ describe Ohai::System, "plugin ec2" do
 
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/path1/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/path2/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/path3/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/path4/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/user-data/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run
 
@@ -314,19 +316,19 @@ describe Ohai::System, "plugin ec2" do
     it "completes the run despite unavailable metadata" do
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "metrics/", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "metrics/", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/metrics/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "vhostmd", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "vhostmd", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/metrics/vhostmd", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "", code: "404"))
+        .and_return(double("Net::HTTP Response", body: "", code: "404"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/user-data/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run
 

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -46,7 +46,7 @@ describe Ohai::System, "plugin ec2" do
       t = double("connection")
       allow(t).to receive(:connect_nonblock).and_raise(Errno::EINPROGRESS)
       allow(Socket).to receive(:new).and_return(t)
-      @token = "xxxxxxxxxxxxxxxxxxxxxxxx=="
+      @token = "AQAEAE4UUd-3NE5EEeYYXKxicVfDOHsx0YSHFFSuCvo2GfCcxzJsvg=="
       @get_token_header = {:'X-aws-ec2-metadata-token' => @token}
       allow(@http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: @token, code: "200") }
       expect(@http_client).to receive(:get)
@@ -88,14 +88,14 @@ describe Ohai::System, "plugin ec2" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
             .with("/2012-01-12/#{name}", @get_token_header)
-            .and_return(double("Net::HTTP Response", body: body, code: "200"))
+            .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
 
@@ -110,14 +110,14 @@ describe Ohai::System, "plugin ec2" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
             .with("/2012-01-12/#{name}", @get_token_header)
-            .and_return(double("Net::HTTP Response", body: body, code: "200"))
+            .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
 
@@ -132,14 +132,14 @@ describe Ohai::System, "plugin ec2" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
             .with("/2012-01-12/#{name}", @get_token_header)
-            .and_return(double("Net::HTTP Response", body: body, code: "200"))
+            .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "{\"region\":\"us-east-1\"}", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "{\"region\":\"us-east-1\"}", code: "200"))
 
         plugin.run
 
@@ -154,14 +154,14 @@ describe Ohai::System, "plugin ec2" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
             .with("/2012-01-12/#{name}", @get_token_header)
-            .and_return(double("Net::HTTP Response", body: body, code: "200"))
+            .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "{\"availabilityZone\":\"us-east-1d\"}", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "{\"availabilityZone\":\"us-east-1d\"}", code: "200"))
 
         plugin.run
 
@@ -213,22 +213,22 @@ describe Ohai::System, "plugin ec2" do
       it "parses ec2 iam/ directory and collect iam/security-credentials/" do
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "iam/", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "iam/", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "security-credentials/", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "security-credentials/", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/security-credentials/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "MyRole", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "MyRole", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/security-credentials/MyRole", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
 
@@ -246,22 +246,22 @@ describe Ohai::System, "plugin ec2" do
       it "parses ec2 iam/ directory and collect info and role_name and NOT collect iam/security-credentials/" do
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "iam/", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "iam/", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "security-credentials/", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "security-credentials/", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/security-credentials/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "MyRole", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "MyRole", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/meta-data/iam/security-credentials/MyRole", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/user-data/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
           .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
-          .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+          .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
 
@@ -275,7 +275,7 @@ describe Ohai::System, "plugin ec2" do
     it "ignores \"./\" and \"../\" on ec2 metadata paths to avoid infinity loops" do
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: ".\n./\n..\n../\npath1/.\npath2/./\npath3/..\npath4/../", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: ".\n./\n..\n../\npath1/.\npath2/./\npath3/..\npath4/../", code: "200"))
       expect(@http_client).not_to receive(:get)
         .with("/2012-01-12/meta-data/.", @get_token_header)
       expect(@http_client).not_to receive(:get)
@@ -289,22 +289,22 @@ describe Ohai::System, "plugin ec2" do
 
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/path1/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/path2/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/path3/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/path4/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/user-data/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run
 
@@ -314,19 +314,19 @@ describe Ohai::System, "plugin ec2" do
     it "completes the run despite unavailable metadata" do
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "metrics/", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: "metrics/", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/metrics/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "vhostmd", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: "vhostmd", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/metrics/vhostmd", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "", code: "404"))
+        .and_return(double("Net::HTTP::GET Response", body: "", code: "404"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/user-data/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
-        .and_return(double("Net::HTTP Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
+        .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run
 

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -46,11 +46,11 @@ describe Ohai::System, "plugin ec2" do
       t = double("connection")
       allow(t).to receive(:connect_nonblock).and_raise(Errno::EINPROGRESS)
       allow(Socket).to receive(:new).and_return(t)
-      @token = "AQAEAE4UUd-3NE5EEeYYXKxicVfDOHsx0YSHFFSuCvo2GfCcxzJsvg=="
-      @get_token_header = {:'X-aws-ec2-metadata-token' => @token}
-      allow(@http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: @token, code: "200") }
+      token = "AQAEAE4UUd-3NE5EEeYYXKxicVfDOHsx0YSHFFSuCvo2GfCcxzJsvg=="
+      @get_req_token_header = {:'X-aws-ec2-metadata-token' => token}
+      allow(@http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: token, code: "200") }
       expect(@http_client).to receive(:get)
-        .with("/", @get_token_header)
+        .with("/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "2012-01-12", code: "200"))
     end
 
@@ -66,14 +66,14 @@ describe Ohai::System, "plugin ec2" do
       it "recursively fetches all the ec2 metadata" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
-            .with("/2012-01-12/#{name}", @get_token_header)
+            .with("/2012-01-12/#{name}", @get_req_token_header)
             .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/", @get_token_header)
+          .with("/2012-01-12/user-data/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
@@ -87,14 +87,14 @@ describe Ohai::System, "plugin ec2" do
       it "fetches binary userdata opaquely" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
-            .with("/2012-01-12/#{name}", @get_token_header)
+            .with("/2012-01-12/#{name}", @get_req_token_header)
             .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/", @get_token_header)
+          .with("/2012-01-12/user-data/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
@@ -109,14 +109,14 @@ describe Ohai::System, "plugin ec2" do
       it "fetches AWS account id" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
-            .with("/2012-01-12/#{name}", @get_token_header)
+            .with("/2012-01-12/#{name}", @get_req_token_header)
             .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/", @get_token_header)
+          .with("/2012-01-12/user-data/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
@@ -131,14 +131,14 @@ describe Ohai::System, "plugin ec2" do
       it "fetches AWS region" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
-            .with("/2012-01-12/#{name}", @get_token_header)
+            .with("/2012-01-12/#{name}", @get_req_token_header)
             .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/", @get_token_header)
+          .with("/2012-01-12/user-data/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "{\"region\":\"us-east-1\"}", code: "200"))
 
         plugin.run
@@ -153,14 +153,14 @@ describe Ohai::System, "plugin ec2" do
       it "fetches AWS availability zone" do
         paths.each do |name, body|
           expect(@http_client).to receive(:get)
-            .with("/2012-01-12/#{name}", @get_token_header)
+            .with("/2012-01-12/#{name}", @get_req_token_header)
             .and_return(double("Net::HTTP::GET Response", body: body, code: "200"))
         end
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/", @get_token_header)
+          .with("/2012-01-12/user-data/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "^_<8B>^H^H<C7>U^@^Csomething^@KT<C8><C9>,)<C9>IU(I-.I<CB><CC>I<E5>^B^@^Qz<BF><B0>^R^@^@^@", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "{\"availabilityZone\":\"us-east-1d\"}", code: "200"))
 
         plugin.run
@@ -175,28 +175,28 @@ describe Ohai::System, "plugin ec2" do
 
     it "parses ec2 network/ directory as a multi-level hash" do
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/", @get_token_header)
+        .with("/2012-01-12/meta-data/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "network/", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/network/", @get_token_header)
+        .with("/2012-01-12/meta-data/network/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "interfaces/", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/network/interfaces/", @get_token_header)
+        .with("/2012-01-12/meta-data/network/interfaces/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "macs/", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/network/interfaces/macs/", @get_token_header)
+        .with("/2012-01-12/meta-data/network/interfaces/macs/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "12:34:56:78:9a:bc/", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/network/interfaces/macs/12:34:56:78:9a:bc/", @get_token_header)
+        .with("/2012-01-12/meta-data/network/interfaces/macs/12:34:56:78:9a:bc/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "public_hostname", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/network/interfaces/macs/12:34:56:78:9a:bc/public_hostname", @get_token_header)
+        .with("/2012-01-12/meta-data/network/interfaces/macs/12:34:56:78:9a:bc/public_hostname", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "server17.opscode.com", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/user-data/", @get_token_header)
+        .with("/2012-01-12/user-data/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+        .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run
@@ -212,22 +212,22 @@ describe Ohai::System, "plugin ec2" do
 
       it "parses ec2 iam/ directory and collect iam/security-credentials/" do
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/", @get_token_header)
+          .with("/2012-01-12/meta-data/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "iam/", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/", @get_token_header)
+          .with("/2012-01-12/meta-data/iam/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "security-credentials/", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/security-credentials/", @get_token_header)
+          .with("/2012-01-12/meta-data/iam/security-credentials/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "MyRole", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/security-credentials/MyRole", @get_token_header)
+          .with("/2012-01-12/meta-data/iam/security-credentials/MyRole", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/", @get_token_header)
+          .with("/2012-01-12/user-data/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
@@ -245,22 +245,22 @@ describe Ohai::System, "plugin ec2" do
 
       it "parses ec2 iam/ directory and collect info and role_name and NOT collect iam/security-credentials/" do
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/", @get_token_header)
+          .with("/2012-01-12/meta-data/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "iam/", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/", @get_token_header)
+          .with("/2012-01-12/meta-data/iam/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "security-credentials/", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/security-credentials/", @get_token_header)
+          .with("/2012-01-12/meta-data/iam/security-credentials/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "MyRole", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/meta-data/iam/security-credentials/MyRole", @get_token_header)
+          .with("/2012-01-12/meta-data/iam/security-credentials/MyRole", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2012-08-22T07:47:22Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"AAAAAAAA\",\n  \"SecretAccessKey\" : \"SSSSSSSS\",\n  \"Token\" : \"12345678\",\n  \"Expiration\" : \"2012-08-22T11:25:52Z\"\n}", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/user-data/", @get_token_header)
+          .with("/2012-01-12/user-data/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
         expect(@http_client).to receive(:get)
-          .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+          .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
           .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
         plugin.run
@@ -274,36 +274,36 @@ describe Ohai::System, "plugin ec2" do
 
     it "ignores \"./\" and \"../\" on ec2 metadata paths to avoid infinity loops" do
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/", @get_token_header)
+        .with("/2012-01-12/meta-data/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: ".\n./\n..\n../\npath1/.\npath2/./\npath3/..\npath4/../", code: "200"))
       expect(@http_client).not_to receive(:get)
-        .with("/2012-01-12/meta-data/.", @get_token_header)
+        .with("/2012-01-12/meta-data/.", @get_req_token_header)
       expect(@http_client).not_to receive(:get)
-        .with("/2012-01-12/meta-data/./", @get_token_header)
+        .with("/2012-01-12/meta-data/./", @get_req_token_header)
       expect(@http_client).not_to receive(:get)
-        .with("/2012-01-12/meta-data/..", @get_token_header)
+        .with("/2012-01-12/meta-data/..", @get_req_token_header)
       expect(@http_client).not_to receive(:get)
-        .with("/2012-01-12/meta-data/../", @get_token_header)
+        .with("/2012-01-12/meta-data/../", @get_req_token_header)
       expect(@http_client).not_to receive(:get)
-        .with("/2012-01-12/meta-data/path1/..", @get_token_header)
+        .with("/2012-01-12/meta-data/path1/..", @get_req_token_header)
 
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/path1/", @get_token_header)
+        .with("/2012-01-12/meta-data/path1/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/path2/", @get_token_header)
+        .with("/2012-01-12/meta-data/path2/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/path3/", @get_token_header)
+        .with("/2012-01-12/meta-data/path3/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/path4/", @get_token_header)
+        .with("/2012-01-12/meta-data/path4/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/user-data/", @get_token_header)
+        .with("/2012-01-12/user-data/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+        .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run
@@ -313,19 +313,19 @@ describe Ohai::System, "plugin ec2" do
 
     it "completes the run despite unavailable metadata" do
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/", @get_token_header)
+        .with("/2012-01-12/meta-data/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "metrics/", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/metrics/", @get_token_header)
+        .with("/2012-01-12/meta-data/metrics/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "vhostmd", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/metrics/vhostmd", @get_token_header)
+        .with("/2012-01-12/meta-data/metrics/vhostmd", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "", code: "404"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/user-data/", @get_token_header)
+        .with("/2012-01-12/user-data/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/dynamic/instance-identity/document/", @get_token_header)
+        .with("/2012-01-12/dynamic/instance-identity/document/", @get_req_token_header)
         .and_return(double("Net::HTTP::GET Response", body: "{\"accountId\":\"4815162342\"}", code: "200"))
 
       plugin.run

--- a/spec/unit/plugins/ec2_spec.rb
+++ b/spec/unit/plugins/ec2_spec.rb
@@ -47,7 +47,7 @@ describe Ohai::System, "plugin ec2" do
       allow(t).to receive(:connect_nonblock).and_raise(Errno::EINPROGRESS)
       allow(Socket).to receive(:new).and_return(t)
       token = "AQAEAE4UUd-3NE5EEeYYXKxicVfDOHsx0YSHFFSuCvo2GfCcxzJsvg=="
-      @get_req_token_header = {:'X-aws-ec2-metadata-token' => token}
+      @get_req_token_header = { 'X-aws-ec2-metadata-token': token }
       allow(@http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: token, code: "200") }
       expect(@http_client).to receive(:get)
         .with("/", @get_req_token_header)

--- a/spec/unit/plugins/eucalyptus_spec.rb
+++ b/spec/unit/plugins/eucalyptus_spec.rb
@@ -34,7 +34,7 @@ describe Ohai::System, "plugin eucalyptus" do
     before do
       @http_client = double("Net::HTTP client")
       @token = "AQAEAE4UUd-3NE5EEeYYXKxicVfDOHsx0YSHFFSuCvo2GfCcxzJsvg=="
-      @get_req_token_header = {:'X-aws-ec2-metadata-token' => @token}
+      @get_req_token_header = { 'X-aws-ec2-metadata-token': @token }
       allow(plugin).to receive(:http_client).and_return(@http_client)
       allow(@http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: @token, code: "200") }
 

--- a/spec/unit/plugins/eucalyptus_spec.rb
+++ b/spec/unit/plugins/eucalyptus_spec.rb
@@ -33,26 +33,29 @@ describe Ohai::System, "plugin eucalyptus" do
   shared_examples_for "eucalyptus" do
     before do
       @http_client = double("Net::HTTP client")
+      @token = "AQAEAE4UUd-3NE5EEeYYXKxicVfDOHsx0YSHFFSuCvo2GfCcxzJsvg=="
+      @get_req_token_header = {:'X-aws-ec2-metadata-token' => @token}
       allow(plugin).to receive(:http_client).and_return(@http_client)
+      allow(@http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: @token, code: "200") }
 
       expect(@http_client).to receive(:get)
-        .with("/")
-        .and_return(double("Net::HTTP Response", body: "2012-01-12", code: "200"))
+        .with("/", @get_req_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "2012-01-12", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/")
-        .and_return(double("Net::HTTP Response", body: "instance_type\nami_id\nsecurity-groups", code: "200"))
+        .with("/2012-01-12/meta-data/", @get_req_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "instance_type\nami_id\nsecurity-groups", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/instance_type")
-        .and_return(double("Net::HTTP Response", body: "c1.medium", code: "200"))
+        .with("/2012-01-12/meta-data/instance_type", @get_req_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "c1.medium", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/ami_id")
-        .and_return(double("Net::HTTP Response", body: "ami-5d2dc934", code: "200"))
+        .with("/2012-01-12/meta-data/ami_id", @get_req_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "ami-5d2dc934", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/meta-data/security-groups")
-        .and_return(double("Net::HTTP Response", body: "group1\ngroup2", code: "200"))
+        .with("/2012-01-12/meta-data/security-groups", @get_req_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "group1\ngroup2", code: "200"))
       expect(@http_client).to receive(:get)
-        .with("/2012-01-12/user-data/")
-        .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
+        .with("/2012-01-12/user-data/", @get_req_token_header)
+        .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
     end
 
     it "recursively fetches all the eucalyptus metadata" do

--- a/spec/unit/plugins/eucalyptus_spec.rb
+++ b/spec/unit/plugins/eucalyptus_spec.rb
@@ -40,22 +40,22 @@ describe Ohai::System, "plugin eucalyptus" do
 
       expect(@http_client).to receive(:get)
         .with("/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "2012-01-12", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "2012-01-12", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "instance_type\nami_id\nsecurity-groups", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "instance_type\nami_id\nsecurity-groups", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/instance_type", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "c1.medium", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "c1.medium", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/ami_id", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "ami-5d2dc934", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "ami-5d2dc934", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/meta-data/security-groups", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "group1\ngroup2", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "group1\ngroup2", code: "200"))
       expect(@http_client).to receive(:get)
         .with("/2012-01-12/user-data/", @get_req_token_header)
-        .and_return(double("Net::HTTP::GET Response", body: "By the pricking of my thumb...", code: "200"))
+        .and_return(double("Net::HTTP Response", body: "By the pricking of my thumb...", code: "200"))
     end
 
     it "recursively fetches all the eucalyptus metadata" do

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -187,12 +187,16 @@ describe Ohai::System, "plugin openstack" do
       let(:http_client) { double("Net::HTTP", { :read_timeout= => nil, :keep_alive_timeout= => nil } ) }
 
       def allow_get(url, response_body)
+        token = "AQAEAE4UUd-3NE5EEeYYXKxicVfDOHsx0YSHFFSuCvo2GfCcxzJsvg=="
+        allow(http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: token, code: "200") }
         allow(http_client).to receive(:get)
-          .with(url)
+          .with(url, {:'X-aws-ec2-metadata-token' =>token})
           .and_return(double("HTTP Response", code: "200", body: response_body))
       end
 
       def allow_get_response(url, response_body)
+        token = "AQAEAE4UUd-3NE5EEeYYXKxicVfDOHsx0YSHFFSuCvo2GfCcxzJsvg=="
+        allow(http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: token, code: "200") }
         allow(http_client).to receive(:get_response)
           .with(url, nil, nil)
           .and_return(double("HTTP Response", code: "200", body: response_body))

--- a/spec/unit/plugins/openstack_spec.rb
+++ b/spec/unit/plugins/openstack_spec.rb
@@ -190,7 +190,7 @@ describe Ohai::System, "plugin openstack" do
         token = "AQAEAE4UUd-3NE5EEeYYXKxicVfDOHsx0YSHFFSuCvo2GfCcxzJsvg=="
         allow(http_client).to receive(:put) { double("Net::HTTP::PUT Response", body: token, code: "200") }
         allow(http_client).to receive(:get)
-          .with(url, {:'X-aws-ec2-metadata-token' =>token})
+          .with(url, { 'X-aws-ec2-metadata-token': token })
           .and_return(double("HTTP Response", code: "200", body: response_body))
       end
 


### PR DESCRIPTION
Reflected the comments on the pull request in #1457.

I have confirmed that this works with an EC2 instance with IMDSv2 only enabled.

Here's a quote from the original PR by @wilkosz

## Agenda

> Update all service calls to EC2 metadata to use IMDSV2 spec:
> https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
>
> EC2 metadata service IMDSV1 introduced quite a few vulnerabilities: https://hackerone.com/reports/508459

## Fix

> Add v2 token generation for each NET::HTTP::Get request.
> Closes issue #1411

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue

- https://github.com/chef/ohai/pull/1457
- https://github.com/chef/ohai/issues/1411

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).



This also backports https://github.com/chef/ohai/pull/1599 which fixes this to not break openstack/euca
