### PR TITLE
[linux/platform] fix platform_version on Debian testing and unstable

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -287,6 +287,9 @@ Ohai.plugin(:Platform) do
     # centos only includes the major version in os-release for some reason
     if os_release_info["ID"] == "centos"
       get_redhatish_version(file_read("/etc/redhat-release").chomp)
+    # debian testing and unstable don't have VERSION_ID set
+    elsif os_release_info["ID"] == "debian"
+      os_release_info["VERSION_ID"] || file_read("/etc/debian_version").chomp
     else
       os_release_info["VERSION_ID"] || shell_out("/bin/uname -r").stdout.strip
     end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -312,6 +312,31 @@ describe Ohai::System, "Linux plugin platform" do
         expect(plugin[:platform_version]).to eq("7.5.1804")
       end
     end
+
+    context "when on debian and version data in os-release is missing" do
+      let(:os_data) do
+        <<~OS_DATA
+          PRETTY_NAME="Debian GNU/Linux bullseye/sid"
+          NAME="Debian GNU/Linux"
+          ID=debian
+          HOME_URL="https://www.debian.org/"
+          SUPPORT_URL="https://www.debian.org/support"
+          BUG_REPORT_URL="https://bugs.debian.org/"
+        OS_DATA
+      end
+
+      before do
+        expect(plugin).to receive(:file_read).with("/etc/os-release").and_return(os_data)
+        expect(plugin).to receive(:file_read).with("/etc/debian_version").and_return("bullseye/sid")
+      end
+
+      it "sets platform, platform_family from os-release and platform_version from debian_version" do
+        plugin.run
+        expect(plugin[:platform]).to eq("debian")
+        expect(plugin[:platform_family]).to eq("debian")
+        expect(plugin[:platform_version]).to eq("bullseye/sid")
+      end
+    end
   end
 
   context "when on system without /etc/os-release (legacy)" do


### PR DESCRIPTION
## Description

When this plugin is updated to use `/etc/os-release`, it introduces a regression
on Debian testing and unstable, where the `VERSION_ID` field is not set.

In the legacy code path, `platform_version` is set on Debian by reading
`/etc/debian_version`; this is still needed on Debian testing and unstable.

Add a special case for Debian, falling back to reading this file rather than
to using `uname -r`, and update the spec to cover this.

Signed-off-by: Michel Alexandre Salim <michel@fb.com>

## Related Issue
#1612 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chef/ohai/1614)
<!-- Reviewable:end -->
