### PR TITLE
Remove stubbing mock methods onto the frozen `true` value

### DIFF
--- a/spec/unit/plugins/hostname_spec.rb
+++ b/spec/unit/plugins/hostname_spec.rb
@@ -95,7 +95,7 @@ describe Ohai::System, "hostname plugin" do
 end
 
 describe Ohai::System, "hostname plugin for windows", :windows_only do
-  let(:success) { true }
+  let(:success) { double }
 
   let(:host) do
     {

--- a/spec/unit/plugins/windows/filesystem_spec.rb
+++ b/spec/unit/plugins/windows/filesystem_spec.rb
@@ -1,6 +1,6 @@
 #
 #  Author:: Nimesh Pathi <nimesh.patni@msystechnologies.com>
-#  Copyright:: Copyright (c) 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 #  License:: Apache License, Version 2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ require "wmi-lite/wmi" unless defined?(WmiLite::Wmi)
 describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
   let(:plugin) { get_plugin("filesystem") }
 
-  let(:success) { true }
+  let(:success) { double }
 
   let(:logical_disks_instances) do
     [


### PR DESCRIPTION
Ideally we should track down the actual class of the object
being returned here and `instance_double()` it properly (but
there's a thousand other specs that need it more than this
does)
