### PR TITLE
Adds chef_effortless collection to chef plugin

### DIFF
--- a/lib/ohai/plugins/chef.rb
+++ b/lib/ohai/plugins/chef.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Chef) do
     if Chef::CHEF_ROOT.include?("hab/pkgs/chef/chef")
       # Determine if client is running in zero mode which would show it is using the Effortless pattern.
       # Explicitly set response to true or nil, not false
-      ChefConfig::Config["chef_server_url"].include?("chefzero://") || nil
+      ChefConfig::Config["chef_server_url"].include?("chefzero://")
     end
   end
 

--- a/lib/ohai/plugins/chef.rb
+++ b/lib/ohai/plugins/chef.rb
@@ -20,9 +20,19 @@
 Ohai.plugin(:Chef) do
   provides "chef_packages/chef"
 
+  def chef_effortless?
+    # Determine if client is being run as a Habitat package.
+    if Chef::CHEF_ROOT.include?("hab/pkgs/chef/chef")
+      # Determine if client is running in zero mode which would show it is using the Effortless pattern.
+      # Explicitly set response to true or nil, not false
+      ChefConfig::Config["chef_server_url"].include?("chefzero://") || nil
+    end
+  end
+
   collect_data(:default, :target) do
     begin
       require "chef/version"
+      require "chef-config/config" unless defined?(ChefConfig::Config)
     rescue Gem::LoadError
       logger.trace("Plugin Chef: Unable to load the chef gem to determine the version")
       # this catches when you've done a major version bump of ohai, but
@@ -35,5 +45,6 @@ Ohai.plugin(:Chef) do
     chef_packages[:chef] = Mash.new
     chef_packages[:chef][:version] = Chef::VERSION
     chef_packages[:chef][:chef_root] = Chef::CHEF_ROOT
+    chef_packages[:chef][:chef_effortless] = chef_effortless?
   end
 end

--- a/spec/unit/plugins/chef_spec.rb
+++ b/spec/unit/plugins/chef_spec.rb
@@ -20,6 +20,8 @@
 
 begin
   require "spec_helper"
+  require "chef/version"
+  require "chef-config/config" unless defined?(ChefConfig::Config)
 
   describe Ohai::System, "plugin chef" do
     before do
@@ -29,6 +31,23 @@ begin
     it "sets [:chef_packages][:chef][:version] to the current chef version", if: defined?(Chef) do
       @plugin.run
       expect(@plugin[:chef_packages][:chef][:version]).to eq(Chef::VERSION)
+    end
+
+    it "sets [:chef_packages][:chef][:chef_root] to the current chef root directory", if: defined?(Chef) do
+      @plugin.run
+      expect(@plugin[:chef_packages][:chef][:chef_root]).to eq(Chef::CHEF_ROOT)
+    end
+
+    it "does not create [:chef_packages][:chef][:chef_effortless] by default", if: defined?(Chef) do
+      @plugin.run
+      expect(@plugin[:chef_packages][:chef][:chef_effortless]).to eq(nil)
+    end
+
+    it "sets [:chef_packages][:chef][:chef_effortless] to TRUE if executed from Habitat via CHEF_ROOT using Chef zero", if: defined?(Chef) do
+      stub_const("Chef::CHEF_ROOT", "/hab/pkgs/chef/chef-infra-client/X.X.X/XXXX/vendor/gems/chef-X.X.X/lib")
+      stub_const("ChefConfig::Config", { "chef_server_url" => "chefzero://localhost:1" })
+      @plugin.run
+      expect(@plugin[:chef_packages][:chef][:chef_effortless]).to eq(true)
     end
 
     pending "would set [:chef_packages][:chef][:version] if chef was available", unless: defined?(Chef)


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Adds check for Effortless pattern under `chef` plugin to populate if it is determined to be running as Effortless.  Will populate as `true` if found and `nil` if not matched.
`node['chef']['chef_effortless'] = true`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
