### PR TITLE
suppress constant redefinition warning

### DIFF
--- a/lib/ohai/plugins/eucalyptus.rb
+++ b/lib/ohai/plugins/eucalyptus.rb
@@ -29,7 +29,7 @@ Ohai.plugin(:Eucalyptus) do
   provides "eucalyptus"
   depends "network/interfaces"
 
-  MAC_MATCH = /^[dD]0:0[dD]:/.freeze
+  MAC_MATCH = /^[dD]0:0[dD]:/.freeze unless defined?(MAC_MATCH)
 
   # returns the mac address from the collection of all address types
   def get_mac_address(addresses)


### PR DESCRIPTION
Let's backport this for Chef 16 to minimize client output on nodes.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>
