### PR TITLE
Resolve new rubocop-performance warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development do
   gem "rspec-core", "~> 3.0"
   gem "rspec-expectations", "~> 3.0"
   gem "rspec-mocks", "~> 3.0"
-  gem "rubocop-performance", "1.9.0"
+  gem "rubocop-performance", "1.10.0"
   gem "rubocop-rspec"
 end
 

--- a/lib/ohai/plugins/network.rb
+++ b/lib/ohai/plugins/network.rb
@@ -82,7 +82,7 @@ Ohai.plugin(:NetworkAddresses) do
       elsif network[gw_attr] &&
           network["interfaces"][network[int_attr]] &&
           network["interfaces"][network[int_attr]]["addresses"]
-        if [ "0.0.0.0", "::", /^fe80:/ ].any? { |pat| pat === network[gw_attr] }
+        if [ "0.0.0.0", "::", /^fe80:/ ].any?(network[gw_attr])
           # link level default route
           logger.trace("Plugin Network: link level default #{family} route, picking ip from #{network[gw_attr]}")
           r = gw_if_ips.first


### PR DESCRIPTION
Looks like this comparison is 2x faster on average according to docs

Signed-off-by: Tim Smith <tsmith@chef.io>