### PR TITLE
Remove support for Pidora which is discontinued

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -149,7 +149,7 @@ Ohai.plugin(:Platform) do
       "amazon"
     when /suse/, /sles/, /opensuse/, /opensuseleap/, /sled/
       "suse"
-    when /fedora/, /pidora/, /arista_eos/
+    when /fedora/, /arista_eos/
       # In the broadest sense:  RPM-based, fedora-derived distributions which are not strictly re-compiled RHEL (if it uses RPMs, and smells more like redhat and less like
       # SuSE it probably goes here).
       "fedora"

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -182,7 +182,7 @@ describe Ohai::System, "Linux plugin platform" do
       end
     end
 
-    %w{fedora pidora arista_eos}.each do |p|
+    %w{fedora arista_eos}.each do |p|
       it "returns fedora for #{p} platform_family" do
         expect(plugin.platform_family_from_platform(p)).to eq("fedora")
       end


### PR DESCRIPTION
Pidora is Fedora 18 and hasn't been updated since 2014.

Signed-off-by: Tim Smith <tsmith@chef.io>