### PR TITLE
Remove support for discontinued antergos distro

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -159,7 +159,7 @@ Ohai.plugin(:Platform) do
       "gentoo"
     when /slackware/
       "slackware"
-    when /arch/, /manjaro/, /antergos/
+    when /arch/, /manjaro/
       "arch"
     when /exherbo/
       "exherbo"

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -194,7 +194,7 @@ describe Ohai::System, "Linux plugin platform" do
       end
     end
 
-    %w{arch manjaro antergos}.each do |p|
+    %w{arch manjaro}.each do |p|
       it "returns arch for #{p} platform_family" do
         expect(plugin.platform_family_from_platform(p)).to eq("arch")
       end


### PR DESCRIPTION
This distro is now discontinued with the last release having shipped in
2019

Signed-off-by: Tim Smith <tsmith@chef.io>