### PR TITLE
Stick the common matched platforms first

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -134,10 +134,10 @@ Ohai.plugin(:Platform) do
   #
   def platform_family_from_platform(plat)
     case plat
-    when /debian/, /ubuntu/, /linuxmint/, /raspbian/, /cumulus/, /kali/, /pop/
+    when /ubuntu/, /debian/, /linuxmint/, /raspbian/, /cumulus/, /kali/, /pop/
       # apt-get+dpkg almost certainly goes here
       "debian"
-    when /oracle/, /centos/, /redhat/, /almalinux/, /scientific/, /enterpriseenterprise/, /xenserver/, /xcp-ng/, /cloudlinux/, /ibm_powerkvm/, /parallels/, /nexus_centos/, /clearos/, /bigip/, /alibabalinux/, /sangoma/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
+    when /centos/, /redhat/, /oracle/, /almalinux/, /scientific/, /enterpriseenterprise/, /xenserver/, /xcp-ng/, /cloudlinux/, /alibabalinux/, /sangoma/, /clearos/, /parallels/, /ibm_powerkvm/, /nexus_centos/, /bigip/ # Note that 'enterpriseenterprise' is oracle's LSB "distributor ID"
       # NOTE: "rhel" should be reserved exclusively for recompiled rhel versions that are nearly perfectly compatible down to the platform_version.
       # The operating systems that are "rhel" should all be as compatible as rhel7 = centos7 = oracle7 = scientific7 (98%-ish core RPM version compatibility
       # and the version numbers MUST track the upstream). The appropriate EPEL version repo should work nearly perfectly.  Some variation like the
@@ -149,7 +149,7 @@ Ohai.plugin(:Platform) do
       "rhel"
     when /amazon/
       "amazon"
-    when /suse/, /sles/, /opensuse/, /opensuseleap/, /sled/
+    when /suse/, /sles/, /opensuseleap/, /opensuse/, /sled/
       "suse"
     when /fedora/, /arista_eos/
       # In the broadest sense:  RPM-based, fedora-derived distributions which are not strictly re-compiled RHEL (if it uses RPMs, and smells more like redhat and less like
@@ -159,8 +159,6 @@ Ohai.plugin(:Platform) do
       "wrlinux"
     when /gentoo/
       "gentoo"
-    when /slackware/
-      "slackware"
     when /arch/, /manjaro/
       "arch"
     when /exherbo/
@@ -171,6 +169,8 @@ Ohai.plugin(:Platform) do
       "clearlinux"
     when /mangeia/
       "mandriva"
+    when /slackware/
+      "slackware"
     end
   end
 


### PR DESCRIPTION
Nothing super scientific here, but it's about 10% faster to match if the data is hit sooner. Stick the super obscure stuff last.

Signed-off-by: Tim Smith <tsmith@chef.io>