### PR TITLE
Properly identify CentOS Stream as centos_stream for platform

### DIFF
--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -172,6 +172,24 @@ describe Ohai::System, "Linux plugin platform" do
         expect(plugin.platform_id_remap("centos")).to eq("nexus_centos")
       end
     end
+    context "when on centos stream" do
+      let(:os_release_content) do
+        <<~OS_RELEASE
+          NAME="CentOS Stream"
+          VERSION="8"
+          ID="centos"
+          ID_LIKE="rhel fedora"
+          VERSION_ID="8"
+          PRETTY_NAME="CentOS Stream 8"
+        OS_RELEASE
+      end
+
+      it "returns centos_stream for centos os-release id" do
+        expect(plugin).to receive(:file_exist?).at_least(:once).with("/etc/os-release").and_return(true)
+        expect(plugin).to receive(:file_read).with("/etc/os-release").and_return(os_release_content)
+        expect(plugin.platform_id_remap("centos")).to eq("centos_stream")
+      end
+    end
   end
 
   describe "#platform_family_from_platform" do


### PR DESCRIPTION
Currently ohai returns `centos` on CentOS Stream systems for platform which makes it difficult for users to know when they are on Stream or not. This properly identifies the system as `centos_stream` if it is indeed on Stream.

Changes include:

- Fix `read_os_release_info` to use `each_line` instead of split so that it includes the whole line, including spaces. This was causing issues when trying to parse the various fields. Also strip out newline characters which are included.
- Add `os_release_file_is_centos_stream?` method to detect `Stream` in `NAME` field
- Add `centos_stream` as rhel `platform_family`

Signed-off-by: Lance Albertson <lance@osuosl.org>
