### PR TITLE
lpar_no and wpar_no in AIX Virtualizatin plugin should be Integers

### DIFF
--- a/lib/ohai/plugins/aix/virtualization.rb
+++ b/lib/ohai/plugins/aix/virtualization.rb
@@ -24,14 +24,15 @@ Ohai.plugin(:Virtualization) do
     virtualization Mash.new
 
     lpar_no, lpar_name = shell_out("uname -L").stdout.split(nil, 2)
+    lpar_no = lpar_no.to_i
 
-    unless lpar_no.to_i == -1 || (lpar_no.to_i == 1 && lpar_name == "NULL")
+    unless lpar_no == -1 || (lpar_no == 1 && lpar_name == "NULL")
       virtualization[:lpar_no] = lpar_no
       virtualization[:lpar_name] = lpar_name
     end
 
-    wpar_no = shell_out("uname -W").stdout.strip
-    if wpar_no.to_i > 0
+    wpar_no = shell_out("uname -W").stdout.strip.to_i
+    if wpar_no > 0
       virtualization[:wpar_no] = wpar_no
     else
       # the below parses the output of lswpar in the long format

--- a/spec/unit/plugins/aix/virtualization_spec.rb
+++ b/spec/unit/plugins/aix/virtualization_spec.rb
@@ -247,7 +247,7 @@ describe Ohai::System, "AIX virtualization plugin" do
 
     it "uname -L detects the LPAR number and name" do
       plugin.run
-      expect(plugin[:virtualization][:lpar_no]).to eq("29")
+      expect(plugin[:virtualization][:lpar_no]).to eq(29)
       expect(plugin[:virtualization][:lpar_name]).to eq("virtlpar03 - 7.1 testers")
     end
 
@@ -314,7 +314,7 @@ describe Ohai::System, "AIX virtualization plugin" do
     end
 
     it "uname -W detects the WPAR number" do
-      expect(plugin[:virtualization][:wpar_no]).to eq("42")
+      expect(plugin[:virtualization][:wpar_no]).to eq(42)
     end
   end
 end


### PR DESCRIPTION
These don't make sense as strings. We should make them ints. This is a
breaking change.

Signed-off-by: Tim Smith <tsmith@chef.io>