### PR TITLE
Chef 17: Set 'filesystem' to be new-style data on Windows

### DIFF
--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -98,14 +98,6 @@ Ohai.plugin(:Filesystem) do
     view
   end
 
-  def generate_deprecated_windows_view(fs)
-    view = generate_mountpoint_view(fs)
-    view.each do |mp, entry|
-      view[mp].delete("devices")
-    end
-    view
-  end
-
   def parse_common_df(out)
     fs = {}
     out.each_line do |line|
@@ -720,9 +712,10 @@ Ohai.plugin(:Filesystem) do
     fs_data["by_mountpoint"] = by_mountpoint
     fs_data["by_pair"] = by_pair
 
-    # Set the filesystem data - Windows didn't do the conversion when everyone
-    # else did, so 15 will have both be the new API and 16 will drop the old API
-    filesystem generate_deprecated_windows_view(fs)
+    # Chef 16 added 'filesystem2'
+    # In Chef 17 we made 'filesystem' and 'filesystem2' match (both new-style)
+    # In Chef 18 we will drop 'filesystem2'
+    filesystem fs_data
     filesystem2 fs_data
   end
 end

--- a/spec/unit/plugins/windows/filesystem_spec.rb
+++ b/spec/unit/plugins/windows/filesystem_spec.rb
@@ -89,8 +89,8 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "kb_used" => 9900,
           "percent_used" => 99,
         }.each do |k, v|
-          expect(plugin[:filesystem]["C:"][k]).to eq(v)
-          expect(plugin[:filesystem]["D:"][k]).to eq(v)
+          expect(plugin[:filesystem]["by_pair"][",C:"][k]).to eq(v)
+          expect(plugin[:filesystem]["by_pair"][",D:"][k]).to eq(v)
           expect(plugin[:filesystem2]["by_pair"][",C:"][k]).to eq(v)
           expect(plugin[:filesystem2]["by_pair"][",D:"][k]).to eq(v)
         end
@@ -105,7 +105,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "volume_name" => "",
           "encryption_status" => "FullyDecrypted",
         }.each do |k, v|
-          expect(plugin[:filesystem]["C:"][k]).to eq(v)
+          expect(plugin[:filesystem]["by_pair"][",C:"][k]).to eq(v)
           expect(plugin[:filesystem2]["by_pair"][",C:"][k]).to eq(v)
         end
 
@@ -117,7 +117,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "volume_name" => "",
           "encryption_status" => "EncryptionInProgress",
         }.each do |k, v|
-          expect(plugin[:filesystem]["D:"][k]).to eq(v)
+          expect(plugin[:filesystem]["by_pair"][",D:"][k]).to eq(v)
           expect(plugin[:filesystem2]["by_pair"][",D:"][k]).to eq(v)
         end
       end
@@ -139,8 +139,8 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "kb_used" => 9900,
           "percent_used" => 99,
         }.each do |k, v|
-          expect(plugin[:filesystem]["C:"][k]).to eq(v)
-          expect(plugin[:filesystem]["D:"][k]).to eq(v)
+          expect(plugin[:filesystem]["by_pair"]["volume 0,C:"][k]).to eq(v)
+          expect(plugin[:filesystem]["by_pair"]["volume 1,D:"][k]).to eq(v)
           expect(plugin[:filesystem2]["by_pair"]["volume 0,C:"][k]).to eq(v)
           expect(plugin[:filesystem2]["by_pair"]["volume 1,D:"][k]).to eq(v)
         end
@@ -155,7 +155,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "volume_name" => "Volume 0",
           "encryption_status" => "FullyDecrypted",
         }.each do |k, v|
-          expect(plugin[:filesystem]["C:"][k]).to eq(v)
+          expect(plugin[:filesystem]["by_pair"]["volume 0,C:"][k]).to eq(v)
           expect(plugin[:filesystem2]["by_pair"]["volume 0,C:"][k]).to eq(v)
         end
 
@@ -167,7 +167,7 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "volume_name" => "Volume 1",
           "encryption_status" => "EncryptionInProgress",
         }.each do |k, v|
-          expect(plugin[:filesystem]["D:"][k]).to eq(v)
+          expect(plugin[:filesystem]["by_pair"]["volume 1,D:"][k]).to eq(v)
           expect(plugin[:filesystem2]["by_pair"]["volume 1,D:"][k]).to eq(v)
         end
       end


### PR DESCRIPTION
For every platform we've had to go through these steps:
  * add fs2
  * make fs match fs2
  * remove fs2

We've completed this on all platforms except windows which was at step 1. This moves Windows to step 2.