### PR TITLE
log plugin exception at warn level

### DIFF
--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -61,7 +61,7 @@ module Ohai
         rescue Ohai::Exceptions::Error, SystemExit # SystemExit: abort or exit from plug-in should exit Ohai with failure code
           raise
         rescue Exception => e
-          logger.trace("Plugin #{plugin.name} threw exception #{e.inspect} #{e.backtrace.join("\n")}")
+          logger.warn("Plugin #{plugin.name} threw exception #{e.inspect} #{e.backtrace.join("\n")}")
         end
       end
       logger.trace("Plugin #{plugin.name} took #{"%f" % elapsed.truncate(6)} seconds to run.")


### PR DESCRIPTION
## Description
This is a potential fix for https://github.com/chef/ohai/issues/1598

If a plugin throws an exception it should be logged at a higher level to boost visibility.

## Related Issue
https://github.com/chef/ohai/issues/1598

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have run the pre-merge tests locally and they pass.
- [ -] I have updated the documentation accordingly.
- [? ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
