### PR TITLE
ohai/plugins/packages.rb - order change - present in both ohai 16 and 17 - impact chef 16/17

### DIFF
--- a/lib/ohai/plugins/packages.rb
+++ b/lib/ohai/plugins/packages.rb
@@ -134,9 +134,9 @@ Ohai.plugin(:Packages) do
     require "win32/registry" unless defined?(Win32::Registry)
     packages Mash.new
     collect_programs_from_registry_key(Win32::Registry::HKEY_LOCAL_MACHINE, 'Software\Microsoft\Windows\CurrentVersion\Uninstall')
-    collect_programs_from_registry_key(Win32::Registry::HKEY_CURRENT_USER, 'Software\Microsoft\Windows\CurrentVersion\Uninstall')
+    # on 64 bit systems, 32 bit programs are stored here moved before HKEY_CURRENT_USER otherwise it is not collected (impacts both ohai 16 & 17)
     collect_programs_from_registry_key(Win32::Registry::HKEY_LOCAL_MACHINE, 'Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall')
-    # on 64 bit systems, 32 bit programs are stored here
+    collect_programs_from_registry_key(Win32::Registry::HKEY_CURRENT_USER, 'Software\Microsoft\Windows\CurrentVersion\Uninstall')
   end
 
   collect_data(:aix) do


### PR DESCRIPTION
Change order of collect_programs_from_registry_key
move collection of Wos6432Node before HKEY_CURRENT_USER

## Description
When located last, ohai packages does not report Wow6432 software

## Related Issue
Found when updating from Chef 15 to Chef 16

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Wade Peacock <knightorc@xqqme.com>