### PR TITLE
Add plugin for linux livepatch

### DIFF
--- a/lib/ohai/plugins/linux/livepatch.rb
+++ b/lib/ohai/plugins/linux/livepatch.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+#
+# Author:: Song Liu <song@kernel.org>
+# Copyright:: Copyright (c) 2021 Facebook, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:Livepatch) do
+  provides "livepatch"
+
+  collect_data(:linux) do
+    if file_exist?("/sys/kernel/livepatch")
+      patches = Mash.new
+      dir_glob("/sys/kernel/livepatch/*").each do |livepatch_dir|
+        dir = File.basename(livepatch_dir)
+        patches[dir] = Mash.new
+        %w{enabled transition}.each do |check|
+          if file_exist?("/sys/kernel/livepatch/#{dir}/#{check}")
+            file_open("/sys/kernel/livepatch/#{dir}/#{check}") { |f| patches[dir][check] = f.read_nonblock(1024).strip }
+          end
+        end
+        livepatch patches
+      end
+    end
+  end
+end

--- a/spec/unit/plugins/linux/livepatch_spec.rb
+++ b/spec/unit/plugins/linux/livepatch_spec.rb
@@ -1,0 +1,62 @@
+#
+#  Author:: Song Liu <song@kernel.org>
+#  Copyright:: Copyright (c) 2021 Facebook, Inc.
+#  License:: Apache License, Version 2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+require "spec_helper"
+
+describe Ohai::System, "Linux Livepatch Plugin" do
+  PATCHES = {
+    "hotfix1" => {
+      "enabled" => "1",
+      "transition" => "0",
+    },
+    "hotfix2" => {
+      "enabled" => "0",
+      "transition" => "1",
+    },
+  }.freeze
+
+  def file_double(value)
+    tmp_double = double
+    expect(tmp_double).to receive(:read_nonblock).and_return(value)
+    tmp_double
+  end
+
+  before do
+    @plugin = get_plugin("linux/livepatch")
+    allow(@plugin).to receive(:collect_os).and_return(:linux)
+    allow(File).to receive(:exist?).with("/sys/kernel/livepatch").and_return(true)
+    allow(@plugin).to receive(:dir_glob).with("/sys/kernel/livepatch/*") do
+      PATCHES.collect { |patch, _files| "/sys/kernel/livepatch/#{patch}" }
+    end
+
+    PATCHES.each do |patch, checks|
+      allow(File).to receive(:exist?).with("/sys/kernel/livepatch/#{patch}").and_return(true)
+      checks.each do |check, value|
+        allow(File).to receive(:exist?).with("/sys/kernel/livepatch/#{patch}/#{check}").and_return(true)
+        allow(File).to receive(:open).with("/sys/kernel/livepatch/#{patch}/#{check}").and_yield(file_double(value))
+      end
+    end
+  end
+
+  it "collects all relevant data from livepatches" do
+    @plugin.run
+    PATCHES.each do |patch, checks|
+      expect(@plugin[:livepatch][patch.to_sym]).to include(checks)
+    end
+  end
+end


### PR DESCRIPTION
This plugin gets "enabled" and "transition" for each livepatch
in /sys/kernel/livepatch/*.

Signed-off-by: Song Liu <song@kernel.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
