### PR TITLE
Removing the ruby deprecation warnings

### DIFF
--- a/lib/ohai/plugins/hostname.rb
+++ b/lib/ohai/plugins/hostname.rb
@@ -170,21 +170,9 @@ Ohai.plugin(:Hostname) do
     hostname host["dnshostname"].to_s
     machinename host["name"].to_s
 
-    info = Socket.gethostbyname(Socket.gethostname)
-    if info.first =~ /.+?\.(.*)/
-      fqdn info.first
-    else
-      # host is not in dns. optionally use:
-      # C:\WINDOWS\system32\drivers\etc\hosts
-      info[3..info.length].reverse_each do |addr|
-        hostent = Socket.gethostbyaddr(addr)
-        if hostent.first =~ /.+?\.(.*)/
-          fqdn hostent.first
-          break
-        end
-      end
-      fqdn info.first unless fqdn
-    end
+    info = Addrinfo.getaddrinfo(hostname, nil).first.getnameinfo
+    fqdn info.first unless fqdn
+
     domain collect_domain
   end
 end


### PR DESCRIPTION
Signed-off-by: Ashwin <avarma@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
- Here we are replacing Socket plugin with the Addrinfo plugin.
- According to the changes the specs are updated. 
- All Socket related specs are removed and updated accordingly.
 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
