### PR TITLE
Add plugin for btrfs

### DIFF
--- a/lib/ohai/plugins/linux/btrfs.rb
+++ b/lib/ohai/plugins/linux/btrfs.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+#
+# Author:: Boris Burkov <boris@bur.io>
+# Copyright:: Copyright (c) 2021 Facebook, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:Btrfs) do
+  provides "btrfs"
+  depends "filesystem"
+
+  collect_data(:linux) do
+    btrfs Mash.new
+    btrfs["by_mountpoint"] ||= Mash.new
+    btrfs["by_uuid"] ||= Mash.new
+    filesystem["by_mountpoint"].each do |mount, fs|
+      next unless fs["fs_type"] == "btrfs"
+
+      uuid = fs["uuid"]
+      logger.trace("Plugin Btrfs: found btrfs #{uuid} at #{mount}")
+      # don't read again if we already read this uuid
+      btrfs_data = btrfs["by_uuid"][uuid]
+      unless btrfs_data
+        btrfs_data = Mash.new
+        btrfs_data["uuid"] = uuid
+        alloc = "/sys/fs/btrfs/#{uuid}/allocation"
+        %w{data metadata system}.each do |bg_type|
+          dir = "#{alloc}/#{bg_type}"
+          %w{single dup}.each do |raid|
+            if file_exist?("#{dir}/#{raid}")
+              btrfs_data["raid"] = raid
+            end
+          end
+          logger.trace("Plugin Btrfs: reading allocation files at #{dir}")
+          btrfs_data["allocation"] ||= Mash.new
+          btrfs_data["allocation"][bg_type] ||= Mash.new
+          %w{total_bytes bytes_used}.each do |field|
+            bytes = file_read("#{dir}/#{field}").chomp.to_i
+            btrfs_data["allocation"][bg_type][field] = "#{bytes}"
+          end
+        end
+      end
+
+      btrfs["by_mountpoint"][mount] = btrfs_data
+      btrfs["by_uuid"][uuid] = btrfs_data
+    end
+  end
+end

--- a/spec/unit/plugins/linux/btrfs_spec.rb
+++ b/spec/unit/plugins/linux/btrfs_spec.rb
@@ -1,0 +1,70 @@
+#
+#  Author:: Boris Burkov <boris@bur.io>
+#  Copyright:: Copyright (c) 2021 Facebook, Inc.
+#  License:: Apache License, Version 2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+require "spec_helper"
+
+describe Ohai::System, "Linux Btrfs Plugin" do
+  ALLOC = {
+    "data" => {
+      "total_bytes" => "10000000000",
+      "bytes_used" => "7000000000",
+    },
+    "metadata" => {
+      "total_bytes" => "2000000000",
+      "bytes_used" => "200000000",
+    },
+    "system" => {
+      "total_bytes" => "100000000",
+      "bytes_used" => "10000",
+    },
+  }.freeze
+
+  before do
+    @plugin = get_plugin("linux/btrfs")
+    sysfs_base_path = "/sys/fs/btrfs/fake-uuid/allocation"
+    %w{data metadata system}.each do |bg_type|
+      allow(@plugin).to receive(:file_exists?).with("#{sysfs_base_path}/#{bg_type}/single").and_return(true)
+      allow(@plugin).to receive(:file_exists?).with("#{sysfs_base_path}/#{bg_type}/dup").and_return(false)
+      %w{total_bytes bytes_used}.each do |field|
+        allow(@plugin).to receive(:file_read).with("#{sysfs_base_path}/#{bg_type}/#{field}").and_return(ALLOC[bg_type][field])
+      end
+    end
+    @plugin[:filesystem] = {
+      by_mountpoint: {
+        "/": {
+          "fs_type": "btrfs",
+          "uuid": "fake-uuid",
+        },
+        "/mnt": {
+          "fs_type": "ext4",
+        },
+        "/mnt2": {
+          "fs_type": "btrfs",
+          "uuid": "fake-uuid",
+        },
+      },
+    }
+  end
+  it "collects btrfs usage information" do
+    @plugin.run
+    expect(@plugin[:btrfs]["by_mountpoint"]["/"]["allocation"]).to eq(ALLOC)
+    expect(@plugin[:btrfs]["by_mountpoint"]["/mnt"]).to eq(nil)
+    expect(@plugin[:btrfs]["by_mountpoint"]["/mnt2"]["allocation"]).to eq(ALLOC)
+    expect(@plugin[:btrfs]["by_uuid"]["fake-uuid"]["allocation"]).to eq(ALLOC)
+  end
+end


### PR DESCRIPTION
The plugin collects btrfs usage information by block_group type (data,
metadata, system) for every btrfs filesystem and mount.

N.B. it doesn't currently support any raid mode besides "dup"
correctly, since the main motivation is analyzing metadata usage.

Signed-off-by: Boris Burkov <boris@bur.io>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
