### PR TITLE
tc qdisc plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,22 @@
 # Change Log
 
-<!-- latest_release 17.5.2 -->
-## [v17.5.2](https://github.com/chef/ohai/tree/v17.5.2) (2021-08-27)
-
-#### Merged Pull Requests
-- Update chefstyle requirement from 2.0.8 to 2.0.9 [#1692](https://github.com/chef/ohai/pull/1692) ([dependabot[bot]](https://github.com/dependabot[bot]))
+<!-- latest_release -->
 <!-- latest_release -->
 
-<!-- release_rollup since=17.3.1 -->
-### Changes not yet released to rubygems.org
-
-#### Merged Pull Requests
-- Update chefstyle requirement from 2.0.8 to 2.0.9 [#1692](https://github.com/chef/ohai/pull/1692) ([dependabot[bot]](https://github.com/dependabot[bot])) <!-- 17.5.2 -->
-- Update the list of EC2 metadata versions we support [#1690](https://github.com/chef/ohai/pull/1690) ([tas50](https://github.com/tas50)) <!-- 17.5.1 -->
-- Update tests and links for the branch rename [#1691](https://github.com/chef/ohai/pull/1691) ([tas50](https://github.com/tas50)) <!-- 17.5.0 -->
-- Update chefstyle requirement from 2.0.7 to 2.0.8 [#1686](https://github.com/chef/ohai/pull/1686) ([dependabot[bot]](https://github.com/dependabot[bot])) <!-- 17.4.0 -->
-- Update chefstyle requirement from 2.0.6 to 2.0.7 [#1683](https://github.com/chef/ohai/pull/1683) ([dependabot[bot]](https://github.com/dependabot[bot])) <!-- 17.3.2 -->
+<!-- release_rollup -->
 <!-- release_rollup -->
 
 <!-- latest_stable_release -->
+## [v17.5.2](https://github.com/chef/ohai/tree/v17.5.2) (2021-08-28)
+
+#### Merged Pull Requests
+- Update chefstyle requirement from 2.0.6 to 2.0.7 [#1683](https://github.com/chef/ohai/pull/1683) ([dependabot[bot]](https://github.com/dependabot[bot]))
+- Update chefstyle requirement from 2.0.7 to 2.0.8 [#1686](https://github.com/chef/ohai/pull/1686) ([dependabot[bot]](https://github.com/dependabot[bot]))
+- Update tests and links for the branch rename [#1691](https://github.com/chef/ohai/pull/1691) ([tas50](https://github.com/tas50))
+- Update the list of EC2 metadata versions we support [#1690](https://github.com/chef/ohai/pull/1690) ([tas50](https://github.com/tas50))
+- Update chefstyle requirement from 2.0.8 to 2.0.9 [#1692](https://github.com/chef/ohai/pull/1692) ([dependabot[bot]](https://github.com/dependabot[bot]))
+<!-- latest_stable_release -->
+
 ## [v17.3.1](https://github.com/chef/ohai/tree/v17.3.1) (2021-07-20)
 
 #### Merged Pull Requests
@@ -28,7 +26,6 @@
 - Add plugin for linux livepatch [#1672](https://github.com/chef/ohai/pull/1672) ([liu-song-6](https://github.com/liu-song-6))
 - Update rubocop-performance requirement from 1.11.3 to 1.11.4 [#1682](https://github.com/chef/ohai/pull/1682) ([dependabot[bot]](https://github.com/dependabot[bot]))
 - Update chefstyle requirement from 2.0.5 to 2.0.6 [#1681](https://github.com/chef/ohai/pull/1681) ([dependabot[bot]](https://github.com/dependabot[bot]))
-<!-- latest_stable_release -->
 
 ## [v17.1.0](https://github.com/chef/ohai/tree/v17.1.0) (2021-05-13)
 

--- a/lib/ohai/plugins/linux/tc.rb
+++ b/lib/ohai/plugins/linux/tc.rb
@@ -1,0 +1,61 @@
+#
+# Author:: Matthew Massey <matthewmassey@fb.com>
+# Copyright:: Copyright (c) 2021 Facebook
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:Tc) do
+  provides "tc"
+  optional true
+
+  collect_data(:linux) do
+    tc_path = which("tc")
+    if tc_path
+      cmd = "#{tc_path} qdisc show"
+      tc_output = shell_out(cmd)
+
+      tc_data = Mash.new
+      tc_data[:qdisc] = Mash.new
+
+      tc_output.stdout.split("\n").each do |line|
+        line = line.strip
+        if /dev (\w+)/ =~ line
+          dev = $1
+          tc_data[:qdisc][dev] ||= Mash.new
+        else
+          next
+        end
+        if /qdisc (\w+)/ =~ line
+          qdisc = $1
+          tc_data[:qdisc][dev][:qdiscs] ||= []
+          tc_data[:qdisc][dev][:qdiscs] << Mash.new
+          qdisc_idx = tc_data[:qdisc][dev][:qdiscs].length - 1
+          tc_data[:qdisc][dev][:qdiscs][qdisc_idx] ||= Mash.new
+          tc_data[:qdisc][dev][:qdiscs][qdisc_idx][:type] = qdisc
+          tc_data[:qdisc][dev][:qdiscs][qdisc_idx][:parms] ||= Mash.new
+        else
+          next
+        end
+        if qdisc == "fq" && /buckets (\d+)/ =~ line
+          buckets = $1.to_i
+          tc_data[:qdisc][dev][:qdiscs][qdisc_idx][:parms][:buckets] = buckets
+        end
+      end
+      tc tc_data
+    else
+      logger.trace("Plugin Tc: Could not find tc. Skipping plugin.")
+    end
+  end
+end

--- a/spec/unit/plugins/linux/tc_spec.rb
+++ b/spec/unit/plugins/linux/tc_spec.rb
@@ -1,0 +1,124 @@
+#
+# Author:: Matthew Massey <matthewmassey@fb.com>
+# Copyright:: Copyright (c) 2021 Facebook
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Ohai::System, "Linux tc plugin" do
+  let(:plugin) { get_plugin("linux/tc") }
+
+  before do
+    allow(plugin).to receive(:collect_os).and_return(:linux)
+  end
+
+  it "populates tc if tc is found" do
+    tc_out = <<-TC_OUT
+        qdisc noqueue 0: dev lo root refcnt 2
+        qdisc mq 1234: dev eth0 root
+        qdisc fq 8001: dev eth0 parent 1234:4 limit 10000p flow_limit 100p buckets 2048 orphan_mask 1023 quantum 3028b initial_quantum 15140b low_rate_threshold 550Kbit refill_delay 40.0ms
+        qdisc fq_codel 0: dev eth0 parent 1234:7 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn
+        qdisc fq_codel 0: dev eth0 parent 1234:5 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn
+        qdisc fq_codel 0: dev eth0 parent 1234:3 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn
+        qdisc fq_codel 0: dev eth0 parent 1234:1 limit 10240p flows 1024 quantum 1514 target 5.0ms interval 100.0ms memory_limit 32Mb ecn
+        qdisc fq 8003: dev eth0 parent 1234:6 limit 10000p flow_limit 100p buckets 8192 orphan_mask 1023 quantum 3028b initial_quantum 15140b low_rate_threshold 550Kbit refill_delay 40.0ms
+        qdisc fq 8002: dev eth0 parent 1234:2 limit 10000p flow_limit 100p buckets 4096 orphan_mask 1023 nopacing quantum 3028b initial_quantum 15140b low_rate_threshold 550Kbit refill_delay 40.0ms
+        qdisc pfifo_fast 8004: dev eth0 parent 1234:8 bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
+        qdisc clsact ffff: dev eth0 parent ffff:fff1
+        garbage line, this won't parse and should not break anything
+        dev eth99 garbage line but with a device name
+        qdisc fq 1234: dev eth0 fq but with no parms
+    TC_OUT
+    allow(plugin).to receive(:which).with("tc").and_return("/sbin/tc")
+    cmd = "/sbin/tc qdisc show"
+    allow(plugin).to receive(:shell_out).with(cmd).and_return(mock_shell_out(0, tc_out, ""))
+    plugin.run
+
+    expect(plugin[:tc].to_hash).to eq({
+      "qdisc" => {
+        "lo" => {
+          "qdiscs" => [
+            {
+              "type" =>  "noqueue",
+              "parms" => {},
+            },
+          ],
+        },
+        "eth0" =>  {
+          "qdiscs" => [
+            {
+              "type" => "mq",
+              "parms" => {},
+            },
+            {
+              "type" => "fq",
+              "parms" => {
+                "buckets" => 2048,
+              },
+            },
+            {
+              "type" => "fq_codel",
+              "parms" => {},
+            },
+            {
+              "type" => "fq_codel",
+              "parms" => {},
+            },
+            {
+              "type" => "fq_codel",
+              "parms" => {},
+            },
+            {
+              "type" => "fq_codel",
+              "parms" => {},
+            },
+            {
+              "type" => "fq",
+              "parms" => {
+                "buckets" => 8192,
+              },
+            },
+            {
+              "type" => "fq",
+              "parms" => {
+                "buckets" => 4096,
+              },
+            },
+            {
+              "type" => "pfifo_fast",
+              "parms" => {},
+            },
+            {
+              "type" => "clsact",
+              "parms" => {},
+            },
+            {
+              "type" => "fq",
+              "parms" => {},
+            },
+          ],
+        },
+        "eth99" => {},
+        },
+    })
+  end
+
+  it "does not populate tc if tc is not found" do
+    allow(plugin).to receive(:which).with("tc").and_return(false)
+    plugin.run
+    expect(plugin[:tc]).to be(nil)
+  end
+end


### PR DESCRIPTION
## Description
This plugin exposes the tc qdisc settings to chef.  For each interface a an array of qdiscs is created.
Each entry has the qdisc name, and a spot to places parameters for that particular qdisc.
The only parameter populated right now is the "buckets" values for fq discs.
 
Signed-off-by: Matthew Massey <matthewmassey@fb.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
