### PR TITLE
OHAI16 - Change order of collect_programs_from_registry_key

### DIFF
--- a/lib/ohai/plugins/packages.rb
+++ b/lib/ohai/plugins/packages.rb
@@ -134,8 +134,9 @@ Ohai.plugin(:Packages) do
     require "win32/registry" unless defined?(Win32::Registry)
     packages Mash.new
     collect_programs_from_registry_key(Win32::Registry::HKEY_LOCAL_MACHINE, 'Software\Microsoft\Windows\CurrentVersion\Uninstall')
-    collect_programs_from_registry_key(Win32::Registry::HKEY_CURRENT_USER, 'Software\Microsoft\Windows\CurrentVersion\Uninstall')
+    # on 64 bit systems, 32 bit programs are stored here moved before HKEY_CURRENT_USER otherwise it is not collected (impacts both ohai 16 & 17)
     collect_programs_from_registry_key(Win32::Registry::HKEY_LOCAL_MACHINE, 'Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall')
+    collect_programs_from_registry_key(Win32::Registry::HKEY_CURRENT_USER, 'Software\Microsoft\Windows\CurrentVersion\Uninstall')
     # on 64 bit systems, 32 bit programs are stored here
   end
 


### PR DESCRIPTION
Change order of collect_programs_from_registry_key

move collection of Wos6432Node before HKEY_CURRENT_USER

When located last, ohai packages does not report Wow6432 software

Found when updating from Chef 15 to Chef 16

Signed-off-by: Wade Peacock <knightorc@xqqme.com>