### PR TITLE
Fix handling of remote targets for Ohai

### DIFF
--- a/lib/ohai/mixin/os.rb
+++ b/lib/ohai/mixin/os.rb
@@ -82,13 +82,13 @@ module Ohai
         else
           # now we have something like an IPMI console that isn't Unix-like or Windows, presumably cannot run ruby, and
           # so we just trust the train O/S information.
-          transport_connection.os
+          transport_connection.os.name
         end
       end
 
       # @api private
       def nonruby_target?
-        transport_connection && !transport_connection.os.unix? && !transport_connection.os.windows
+        transport_connection && !transport_connection.os.unix? && !transport_connection.os.windows?
       end
 
       # @api private

--- a/lib/ohai/plugins/os.rb
+++ b/lib/ohai/plugins/os.rb
@@ -40,6 +40,12 @@ Ohai.plugin(:OS) do
 
   collect_data(:target) do
     os collect_os
+    os_version "unknown"
+  end
+
+  collect_data(:api) do
+    os collect_os
+    os_version "unknown"
   end
 
   collect_data do


### PR DESCRIPTION
## Description

- Fix platform type `:target` to specify an `os_version` attribute.
  This allows including a related plugin inside a cookbook's `ohai` segment as opposed to installation in the system (Crash due to Chef trying to access a `nil` value)
- Add platform type `:api` to enable REST APIs as opposed to agent-less OS (e.g. Switches)
- Fix a return value of Object type as opposed to all other branches returning String for this
- Fix missing `?` on `nonruby_target?` check

## Related Issue

Bug fixes, somewhat Hackathon related... ;-)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
