### PR TITLE
Fix node['fqdn'] for broken reverse record lookup

### DIFF
--- a/spec/unit/mixin/network_helper_spec.rb
+++ b/spec/unit/mixin/network_helper_spec.rb
@@ -27,4 +27,16 @@ describe Ohai::Mixin::NetworkHelper, "Network Helper Mixin" do
       expect(mixin.hex_to_dec_netmask("ffff0000")).to eq("255.255.0.0")
     end
   end
+
+  describe "canonicalize hostname" do
+    # this is a brittle test deliberately intended to discourage modifying this API
+    # (see the node in the code on the necessity of manual testing)
+    it "uses the correct ruby API" do
+      hostname = "broken.example.org"
+      addrinfo = instance_double(Addrinfo)
+      expect(Addrinfo).to receive(:getaddrinfo).with(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME).and_return([addrinfo])
+      expect(addrinfo).to receive(:canonname).and_return(hostname)
+      expect(mixin.canonicalize_hostname(hostname)).to eql(hostname)
+    end
+  end
 end


### PR DESCRIPTION
If broken.example.org has an A record to an IP address with no PTR
record (lets say to 10.20.30.40 which does not resolve in the configured
DNS servers):

```
[23] pry(main)> Addrinfo.getaddrinfo("broken.example.org", nil, nil, nil, nil, Socket::AI_CANONNAME).first.canonname
=> "broken.example.org"
```

vs:

```
> Addrinfo.getaddrinfo("broken.example.org", nil).first.getnameinfo.first
=> "10.20.30.40"
```

Effectively this change makes the ruby code behave like `hostname -f`
does which has the same behavior.
