### PR TITLE
Add support for VMware detection on Windows and details

### DIFF
--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -45,12 +45,14 @@ Ohai.plugin(:VMware) do
       logger.trace("Plugin VMware: #{vmtools_path} not found")
     else
       vmware Mash.new
+      vmware[:host] = Mash.new
+      vmware[:guest] = Mash.new
       begin
         # vmware-toolbox-cmd stat <param> commands
         # Iterate through each parameter supported by the "vwware-toolbox-cmd stat" command, assign value
         # to attribute "vmware[:<parameter>]"
         %w{hosttime speed sessionid balloon swap memlimit memres cpures cpulimit}.each do |param|
-          vmware[param] = from_cmd("#{vmtools_path} stat #{param}")
+          vmware[param] = from_cmd([vmtools_path, "stat", param])
           if /UpdateInfo failed/.match?(vmware[param])
             vmware[param] = nil
           end
@@ -59,8 +61,23 @@ Ohai.plugin(:VMware) do
         # Iterate through each parameter supported by the "vmware-toolbox-cmd status" command, assign value
         # to attribute "vmware[:<parameter>]"
         %w{upgrade timesync}.each do |param|
-          vmware[param] = from_cmd("#{vmtools_path} #{param} status")
+          vmware[param] = from_cmd([vmtools_path, param, "status"])
         end
+        # Distinguish hypervisors by presence of raw session data (vSphere only)
+        raw_session = from_cmd([vmtools_path, %w{stat raw json session}])
+        if raw_session.empty?
+          vmware[:host] = {
+            type: "vmware_desktop",
+          }
+        else
+          require "json" unless defined?(JSON)
+          session = JSON.parse(raw_session)
+          vmware[:host] = {
+            type: "vmware_vsphere",
+            version: session["version"],
+          }
+        end
+        vmware[:guest][:vmware_tools_version] = from_cmd([vmtools_path, "-v"]).split(" ").first
       rescue
         logger.trace("Plugin VMware: Error while collecting VMware guest attributes")
       end
@@ -71,4 +88,7 @@ Ohai.plugin(:VMware) do
     get_vm_attributes("/usr/bin/vmware-toolbox-cmd") if virtualization[:systems][:vmware]
   end
 
+  collect_data(:windows) do
+    get_vm_attributes("C:/Program Files/VMWare/VMware Tools/VMwareToolboxCmd.exe") if virtualization[:systems][:vmware]
+  end
 end

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -64,7 +64,7 @@ Ohai.plugin(:VMware) do
           vmware[param] = from_cmd([vmtools_path, param, "status"])
         end
         # Distinguish hypervisors by presence of raw session data (vSphere only)
-        raw_session = from_cmd([vmtools_path, %w{stat raw json session}])
+        raw_session = from_cmd([vmtools_path, "stat", "raw", "json", "session"])
         if raw_session.empty?
           vmware[:host] = {
             type: "vmware_desktop",

--- a/spec/unit/plugins/vmware_spec.rb
+++ b/spec/unit/plugins/vmware_spec.rb
@@ -28,17 +28,19 @@ describe Ohai::System, "plugin vmware" do
   context "when on vmware guest with toolbox installed" do
     before do
       allow(File).to receive(:exist?).with("/usr/bin/vmware-toolbox-cmd").and_return(true)
-      allow(plugin).to receive(:shell_out).with("#{path} stat speed").and_return(mock_shell_out(0, "2000 MHz", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat hosttime").and_return(mock_shell_out(0, "04 Jun 2015 19:21:16", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat sessionid").and_return(mock_shell_out(0, "0x0000000000000000", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat balloon").and_return(mock_shell_out(0, "0 MB", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat swap").and_return(mock_shell_out(0, "0 MB", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat memlimit").and_return(mock_shell_out(0, "4000000000 MB", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat memres").and_return(mock_shell_out(0, "0 MB", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat cpures").and_return(mock_shell_out(0, "0 MHz", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} stat cpulimit").and_return(mock_shell_out(0, "4000000000 MB", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} upgrade status").and_return(mock_shell_out(0, "VMware Tools are up-to-date.", nil))
-      allow(plugin).to receive(:shell_out).with("#{path} timesync status").and_return(mock_shell_out(0, "Disabled", nil))
+      allow(plugin).to receive(:shell_out).with([path, "stat", "speed"]).and_return(mock_shell_out(0, "2000 MHz", nil))
+      allow(plugin).to receive(:shell_out).with([path, "stat", "hosttime"]).and_return(mock_shell_out(0, "04 Jun 2015 19:21:16", nil))
+      allow(plugin).to receive(:shell_out).with([path, "stat", "sessionid"]).and_return(mock_shell_out(0, "0x0000000000000000", nil))
+      allow(plugin).to receive(:shell_out).with([path, "stat", "balloon"]).and_return(mock_shell_out(0, "0 MB", nil))
+      allow(plugin).to receive(:shell_out).with([path, "stat", "swap"]).and_return(mock_shell_out(0, "0 MB", nil))
+      allow(plugin).to receive(:shell_out).with([path, "stat", "memlimit"]).and_return(mock_shell_out(0, "4000000000 MB", nil))
+      allow(plugin).to receive(:shell_out).with([path, "stat", "memres"]).and_return(mock_shell_out(0, "0 MB", nil))
+      allow(plugin).to receive(:shell_out).with([path, "stat", "cpures"]).and_return(mock_shell_out(0, "0 MHz", nil))
+      allow(plugin).to receive(:shell_out).with([path, "stat", "cpulimit"]).and_return(mock_shell_out(0, "4000000000 MB", nil))
+      allow(plugin).to receive(:shell_out).with([path, "upgrade", "status"]).and_return(mock_shell_out(0, "VMware Tools are up-to-date.", nil))
+      allow(plugin).to receive(:shell_out).with([path, "timesync", "status"]).and_return(mock_shell_out(0, "Disabled", nil))
+      allow(plugin).to receive(:shell_out).with([path, "stat", "raw", "json", "session"]).and_return(mock_shell_out(0, '{ "version": "VMware ESX 7.0.0 build-15843807" }', nil))
+      allow(plugin).to receive(:shell_out).with([path, "-v"]).and_return(mock_shell_out(0, "10.3.0.5330", nil))
       plugin[:virtualization] = Mash.new
       plugin[:virtualization][:systems] = Mash.new
       plugin[:virtualization][:systems][:vmware] = Mash.new
@@ -55,6 +57,14 @@ describe Ohai::System, "plugin vmware" do
 
     it "gets tools update status" do
       expect(plugin[:vmware][:upgrade]).to eq("VMware Tools are up-to-date.")
+    end
+
+    it "gets tools version" do
+      expect(plugin[:vmware][:guest][:vmware_tools_version]).to eq("10.3.0.5330")
+    end
+
+    it "gets vSphere version" do
+      expect(plugin[:vmware][:host][:version]).to eq("VMware ESX 7.0.0 build-15843807")
     end
   end
 


### PR DESCRIPTION
## Description
Currently, `vmware` only collects data on Linux systems.

Extended this to work on Windows as well and added keys on distinguishing VMware Desktop platforms (Fusion/Player/Workstation) from server platforms (vSphere aka ESX). Includes VMware Tools version as well.

Contents of `vmware` on VMware Workstation and Windows 2019:

```json
{
  "host": {
    "type": "vmware_desktop"
  },
  "guest": {
    "vmware_tools_version": "11.2.6.28747"
  },
  "hosttime": "09 Dec 2021 10:57:20",
  "speed": "1992 MHz",
  "sessionid": "",
  "balloon": "",
  "swap": "",
  "memlimit": "",
  "memres": "",
  "cpures": "",
  "cpulimit": "",
  "upgrade": "VMware Tools are up-to-date.",
  "timesync": "Enabled"
}
```

Contents of `vmware` on VMware Workstation and Ubuntu 18.04:

```json
{
  "host": {
    "type": "vmware_desktop"
  },
  "guest": {
    "vmware_tools_version": "10.3.0.5330"
  },
  "hosttime": "09 Dec 2021 14:40:10",
  "speed": "1992 MHz",
  "sessionid": "",
  "balloon": "",
  "swap": "",
  "memlimit": "",
  "memres": "",
  "cpures": "",
  "cpulimit": "",
  "upgrade": "",
  "timesync": "Disabled"
}
```

Contents of `vmware` on VMware vSphere 7 and Windows 2019:

```json
{
  "host": {
    "type": "vmware_vsphere",
    "version": "VMware ESX 7.0.0 build-15843807"
  },
  "guest": {
    "vmware_tools_version": "11.0.5.17716"
  },
  "hosttime": "09 Dec 2021 12:16:55",
  "speed": "1992 MHz",
  "sessionid": "0x5ff24c6ec541d5ac",
  "balloon": "0 MB",
  "swap": "0 MB",
  "memlimit": "4294967295 MB",
  "memres": "0 MB",
  "cpures": "0 MHz",
  "cpulimit": "4294967295 MHz",
  "upgrade": "",
  "timesync": "Disabled"
}
```

## Related Issue

Interoperability :-)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
