### PR TITLE
Stop checking encoding names

### DIFF
--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -142,8 +142,8 @@ Ohai.plugin(:EC2) do
       ec2[:account_id] = fetch_dynamic_data["accountId"]
       ec2[:availability_zone] = fetch_dynamic_data["availabilityZone"]
       ec2[:region] = fetch_dynamic_data["region"]
-      # ASCII-8BIT is equivalent to BINARY in this case
-      if ec2[:userdata] && ec2[:userdata].encoding.to_s == "ASCII-8BIT"
+
+      if ec2[:userdata] && ec2[:userdata].encoding == Encoding::BINARY
         logger.trace("Plugin EC2: Binary UserData Found. Storing in base64")
         ec2[:userdata] = Base64.encode64(ec2[:userdata])
       end


### PR DESCRIPTION
Comparing the names is much less efficient than comparing the instance directly.
    
It may also change in the future: https://bugs.ruby-lang.org/issues/18576
