### PR TITLE
Fix FIPS mode detection

### DIFF
--- a/lib/ohai/plugins/fips.rb
+++ b/lib/ohai/plugins/fips.rb
@@ -30,6 +30,7 @@ Ohai.plugin(:Fips) do
     fips Mash.new
 
     require "openssl" unless defined?(OpenSSL)
-    fips["kernel"] = { "enabled" => OpenSSL::OPENSSL_FIPS }
+
+    fips["kernel"] = { "enabled" => defined?(OpenSSL.fips_mode) && OpenSSL.fips_mode }
   end
 end

--- a/spec/unit/plugins/fips_spec.rb
+++ b/spec/unit/plugins/fips_spec.rb
@@ -33,14 +33,14 @@ describe Ohai::System, "plugin fips" do
 
   context "when OpenSSL reports FIPS mode true" do
     it "sets fips enabled true" do
-      stub_const("OpenSSL::OPENSSL_FIPS", true)
+      allow(OpenSSL).to receive(:fips_mode).and_return(true)
       expect(subject).to be(true)
     end
   end
 
   context "when OpenSSL reports FIPS mode false" do
     it "sets fips enabled false" do
-      stub_const("OpenSSL::OPENSSL_FIPS", false)
+      allow(OpenSSL).to receive(:fips_mode).and_return(false)
       expect(subject).to be(false)
     end
   end


### PR DESCRIPTION
## Description

Previously FIPS detection relied on the `OpenSSL::OPENSSL_FIPS`
constant being defined. However, on RedHat operating systems, this
constant is always defined in
`/usr/include/openssl/opensslconf-x86_64.h`. As a result, on such
operating systems FIPS mode would erroneously be labeled as enabled.
This constant is a necessary but not sufficient condition to determine
whether FIPS is actually enabled.

OpenSSL has a runtime `fips_mode` check
(https://wiki.openssl.org/index.php/FIPS_mode()) that should be used
instead. Ruby will use this if the `OPENSSL_FIPS` compile-time
constant is available:
https://github.com/ruby/ruby/blob/685efac05983dee44ce2d96c24f2fcb96a0aebe2/ext/openssl/ossl.c#L413-L428

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
