### PR TITLE
Use a minimum of 1 thread per core for CPU total calculation

### DIFF
--- a/lib/ohai/plugins/cpu.rb
+++ b/lib/ohai/plugins/cpu.rb
@@ -193,7 +193,8 @@ Ohai.plugin(:CPU) do
           lscpu_real = lscpu_info[:sockets]
           lscpu_cores = lscpu_info[:sockets] * lscpu_info[:cores_per_socket]
         else
-          lscpu_total = lscpu_info[:sockets] * lscpu_info[:cores_per_socket] * lscpu_info[:threads_per_core]
+          threads_per_core = [lscpu_info[:threads_per_core], 1].max
+          lscpu_total = lscpu_info[:sockets] * lscpu_info[:cores_per_socket] * threads_per_core
           lscpu_real = lscpu_info[:sockets]
           lscpu_cores = lscpu_info[:sockets] * lscpu_info[:cores_per_socket]
         end

--- a/spec/data/plugins/cpuinfo-x86-guest-vtx.output
+++ b/spec/data/plugins/cpuinfo-x86-guest-vtx.output
@@ -1,0 +1,53 @@
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 26
+model name	: Intel(R) Xeon(R) CPU           X5570  @ 2.93GHz
+stepping	: 5
+microcode	: 0x1d
+cpu MHz		: 1703.430
+cache size	: 8192 KB
+physical id	: 1
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 21
+initial apicid	: 21
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 11
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm dca sse4_1 sse4_2 popcnt lahf_lm pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid dtherm ida flush_l1d
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 5851.81
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 40 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 26
+model name	: Intel(R) Xeon(R) CPU           X5570  @ 2.93GHz
+stepping	: 5
+microcode	: 0x1d
+cpu MHz		: 1749.755
+cache size	: 8192 KB
+physical id	: 0
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 5
+initial apicid	: 5
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 11
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm dca sse4_1 sse4_2 popcnt lahf_lm pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid dtherm ida flush_l1d
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 5851.58
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 40 bits physical, 48 bits virtual
+power management:

--- a/spec/data/plugins/lscpu-x86-guest-vtx-cores.output
+++ b/spec/data/plugins/lscpu-x86-guest-vtx-cores.output
@@ -1,0 +1,6 @@
+# The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting from zero.
+# CPU,Core,Socket
+12,4,0
+13,5,1

--- a/spec/data/plugins/lscpu-x86-guest-vtx.output
+++ b/spec/data/plugins/lscpu-x86-guest-vtx.output
@@ -1,0 +1,26 @@
+Architecture:         x86_64
+CPU op-mode(s):       32-bit, 64-bit
+Byte Order:           Little Endian
+Address sizes:        40 bits physical, 48 bits virtual
+CPU(s):               16
+On-line CPU(s) list:  0,2,5,9
+Off-line CPU(s) list: 1,3,4,6-8,10-15
+Thread(s) per core:   0
+Core(s) per socket:   4
+Socket(s):            2
+NUMA node(s):         2
+Vendor ID:            GenuineIntel
+CPU family:           6
+Model:                26
+Model name:           Intel(R) Xeon(R) CPU           X5570  @ 2.93GHz
+Stepping:             5
+CPU MHz:              1596.085
+BogoMIPS:             5852.18
+Virtualization:       VT-x
+L1d cache:            32K
+L1i cache:            32K
+L2 cache:             256K
+L3 cache:             8192K
+NUMA node0 CPU(s):    0,2,4,6,8,10,12,14
+NUMA node1 CPU(s):    1,3,5,7,9,11,13,15
+Flags:                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm dca sse4_1 sse4_2 popcnt lahf_lm pti tpr_shadow vnmi flexpriority ept vpid dtherm ida


### PR DESCRIPTION
## Description

In some LXD containers running with VT-x hardware virtualization, it appears that threads per core is 0, resulting in a total number of CPUs of 0. Add a test case and handle some quirks with the `lscpu` output.

This pull request also makes the default CPU configurable in the tests. Normally CPU 0 is the default, but on some virtualized hosts this is not the case.

## Related Issue

Closes https://github.com/chef/ohai/issues/1755

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
