### PR TITLE
Do not attempt to reinitialize constants

### DIFF
--- a/lib/ohai/common/dmi.rb
+++ b/lib/ohai/common/dmi.rb
@@ -25,57 +25,59 @@ module Ohai
       # all-lowercase, all non-alphanumeric converted to '_'
       # 128-255 are 'oem_data_[id]'
       # Everything else is 'unknown'
-      ID_TO_DESCRIPTION = {
-        0 => "bios",
-        1 => "system",
-        2 => "base_board",
-        3 => "chassis",
-        4 => "processor",
-        5 => "memory_controller",
-        6 => "memory_module",
-        7 => "cache",
-        8 => "port_connector",
-        9 => "system_slots",
-        10 => "on_board_devices",
-        11 => "oem_strings",
-        12 => "system_configuration_options",
-        13 => "bios_language",
-        14 => "group_associations",
-        15 => "system_event_log",
-        16 => "physical_memory_array",
-        17 => "memory_device",
-        18 => "32_bit_memory_error",
-        19 => "memory_array_mapped_address",
-        20 => "memory_device_mapped_address",
-        21 => "built_in_pointing_device",
-        22 => "portable_battery",
-        23 => "system_reset",
-        24 => "hardware_security",
-        25 => "system_power_controls",
-        26 => "voltage_probe",
-        27 => "cooling_device",
-        28 => "temperature_probe",
-        29 => "electrical_current_probe",
-        30 => "out_of_band_remote_access",
-        31 => "boot_integrity_services",
-        32 => "system_boot",
-        33 => "64_bit_memory_error",
-        34 => "management_device",
-        35 => "management_device_component",
-        36 => "management_device_threshold_data",
-        37 => "memory_channel",
-        38 => "ipmi_device",
-        39 => "power_supply",
-        40 => "additional_information",
-        41 => "onboard_devices_extended_information",
-        42 => "management_controller_host_interfaces",
-        126 => "disabled_entries",
-        127 => "end_of_table_marker",
-      }.freeze
+      unless defined?(ID_TO_DESCRIPTION)
+        ID_TO_DESCRIPTION = {
+          0 => "bios",
+          1 => "system",
+          2 => "base_board",
+          3 => "chassis",
+          4 => "processor",
+          5 => "memory_controller",
+          6 => "memory_module",
+          7 => "cache",
+          8 => "port_connector",
+          9 => "system_slots",
+          10 => "on_board_devices",
+          11 => "oem_strings",
+          12 => "system_configuration_options",
+          13 => "bios_language",
+          14 => "group_associations",
+          15 => "system_event_log",
+          16 => "physical_memory_array",
+          17 => "memory_device",
+          18 => "32_bit_memory_error",
+          19 => "memory_array_mapped_address",
+          20 => "memory_device_mapped_address",
+          21 => "built_in_pointing_device",
+          22 => "portable_battery",
+          23 => "system_reset",
+          24 => "hardware_security",
+          25 => "system_power_controls",
+          26 => "voltage_probe",
+          27 => "cooling_device",
+          28 => "temperature_probe",
+          29 => "electrical_current_probe",
+          30 => "out_of_band_remote_access",
+          31 => "boot_integrity_services",
+          32 => "system_boot",
+          33 => "64_bit_memory_error",
+          34 => "management_device",
+          35 => "management_device_component",
+          36 => "management_device_threshold_data",
+          37 => "memory_channel",
+          38 => "ipmi_device",
+          39 => "power_supply",
+          40 => "additional_information",
+          41 => "onboard_devices_extended_information",
+          42 => "management_controller_host_interfaces",
+          126 => "disabled_entries",
+          127 => "end_of_table_marker",
+        }.freeze
+      end
 
       # list of IDs to collect from config or default to a sane list that prunes
       # away some of the less useful IDs
-      ID_TO_CAPTURE = [ 0, 1, 2, 3, 4, 6, 11 ].freeze
+      ID_TO_CAPTURE = [ 0, 1, 2, 3, 4, 6, 11 ].freeze unless defined?(ID_TO_CAPTURE)
 
       # the allowlisted DMI IDs. This is combination of the defaults + any additional
       # IDs defined in the :additional_dmi_ids config
@@ -116,14 +118,16 @@ module Ohai
         id
       end
 
-      SKIPPED_CONVENIENCE_KEYS = %w{
-        application_identifier
-        caption
-        creation_class_name
-        size
-        system_creation_class_name
-        record_id
-      }.freeze
+      unless defined?(SKIPPED_CONVENIENCE_KEYS)
+        SKIPPED_CONVENIENCE_KEYS = %w{
+          application_identifier
+          caption
+          creation_class_name
+          size
+          system_creation_class_name
+          record_id
+        }.freeze
+      end
 
       # create simplified convenience access keys for each record type
       # for single occurrences of one type, copy to top level all fields and values

--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -23,10 +23,12 @@ require "socket" unless defined?(Socket)
 module Ohai
   module Mixin
     module NetworkHelper
-      FAMILIES = {
-        "inet" => "default",
-        "inet6" => "default_inet6",
-      }.freeze
+      unless defined?(FAMILIES)
+        FAMILIES = {
+          "inet" => "default",
+          "inet6" => "default_inet6",
+        }.freeze
+      end
 
       def hex_to_dec_netmask(netmask)
         # example 'ffff0000' -> '255.255.0.0'

--- a/lib/ohai/plugins/rpm.rb
+++ b/lib/ohai/plugins/rpm.rb
@@ -22,16 +22,18 @@ Ohai.plugin(:Rpm) do
   provides "rpm"
   optional "true"
 
-  MACROS_MARKER = /========================/.freeze
+  MACROS_MARKER = /========================/.freeze unless defined?(MACROS_MARKER)
 
-  DO_NOT_SPLIT = %w{
-    build_arch
-    build_os
-    install_arch
-    install_os
-    archcolor
-    optflags
-  }.freeze
+  unless defined?(DO_NOT_SPLIT)
+    DO_NOT_SPLIT = %w{
+      build_arch
+      build_os
+      install_arch
+      install_os
+      archcolor
+      optflags
+    }.freeze
+  end
 
   collect_data(:aix, :darwin, :dragonflybsd, :freebsd, :linux, :netbsd, :openbsd, :solaris2) do
     rpm_path = which("rpm")

--- a/lib/ohai/util/ip_helper.rb
+++ b/lib/ohai/util/ip_helper.rb
@@ -21,8 +21,8 @@ module Ohai
       require "ipaddress" unless defined?(IPAddress)
 
       # Corresponding to RFC 4192 + RFC 4193
-      IPV6_LINK_LOCAL_UNICAST_BLOCK = IPAddress("fe80::/10")
-      IPV6_PRIVATE_ADDRESS_BLOCK = IPAddress("fc00::/7")
+      IPV6_LINK_LOCAL_UNICAST_BLOCK = IPAddress("fe80::/10") unless defined?(IPV6_LINK_LOCAL_UNICAST_BLOCK)
+      IPV6_PRIVATE_ADDRESS_BLOCK = IPAddress("fc00::/7") unless defined?(IPV6_PRIVATE_ADDRESS_BLOCK)
 
       def private_address?(addr)
         ip = IPAddress(addr)


### PR DESCRIPTION
## Description

ChefSpec invokes Ohai in its functionality. In situations where Ohai is already invoked before ChefSpec starts (for example, to detect the OS platform/version to configure Fauxhai), this will cause warnings about constants being already defined. This PR avoids those warnings by initializing constants only if they haven't been initialized earlier.

We did something similar in https://github.com/chef/ohai/pull/1628

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
