### PR TITLE
fix warning: already initialized constant MACROS_MARKER and warning: …

### DIFF
--- a/lib/ohai/plugins/rpm.rb
+++ b/lib/ohai/plugins/rpm.rb
@@ -22,9 +22,9 @@ Ohai.plugin(:Rpm) do
   provides "rpm"
   optional "true"
 
-  MACROS_MARKER = /========================/.freeze
+  MACROS_MARKER ||= /========================/.freeze
 
-  DO_NOT_SPLIT = %w{
+  DO_NOT_SPLIT ||= %w{
     build_arch
     build_os
     install_arch


### PR DESCRIPTION
…already initialized constant DO_NOT_SPLIT

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Fixes warning issues:

```
/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/ohai-17.9.0/lib/ohai/plugins/rpm.rb:25: warning: already initialized constant MACROS_MARKER
/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/ohai-17.9.0/lib/ohai/plugins/rpm.rb:25: warning: previous definition of MACROS_MARKER was here
/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/ohai-17.9.0/lib/ohai/plugins/rpm.rb:27: warning: already initialized constant DO_NOT_SPLIT
/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/ohai-17.9.0/lib/ohai/plugins/rpm.rb:27: warning: previous definition of DO_NOT_SPLIT was here
```
