### PR TITLE
Fall back to /proc/cpuinfo if lscpu doesn't have CPU totals

### DIFF
--- a/lib/ohai/plugins/cpu.rb
+++ b/lib/ohai/plugins/cpu.rb
@@ -344,15 +344,23 @@ Ohai.plugin(:CPU) do
     cpuinfo
   end
 
+  # Check if the `lscpu` data looks reasonable
+  def valid_lscpu?(lscpu)
+    return false if lscpu.empty?
+    return false if %i{total real cores}.any? { |key| lscpu[key].to_i == 0 }
+
+    true
+  end
+
   collect_data(:linux) do
     cpuinfo = parse_cpuinfo
     lscpu = parse_lscpu(cpuinfo)
 
-    # If we don't have any data from lscpu then get it from /proc/cpuinfo
-    if lscpu.empty?
-      cpu cpuinfo
-    else
+    # If we don't have any sensible data from lscpu then get it from /proc/cpuinfo
+    if valid_lscpu?(lscpu)
       cpu lscpu
+    else
+      cpu cpuinfo
     end
   end
 


### PR DESCRIPTION
## Description

https://github.com/chef/ohai/pull/1454 made `lscpu` the primary way Ohai gathers CPU data, but the parser doesn't handle the output from a Raspberry Pi 4 Cortex-A72. For example, an ARM cluster has the output `Core(s) per cluster` instead of `Core(s) per socket`.

We should fall back to `/proc/cpuinfo` if we don't get reasonable data back. It's not enough just to have `lscpu` output.

## Related Issue

* https://github.com/chef/ohai/issues/1760
* https://github.com/chef/ohai/issues/1755

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
