### PR TITLE
Update chef gems need to refer chef-17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source "https://rubygems.org"
 
 gemspec
 
-# pull these gems from main of chef/chef so that we're testing against what we will release
-gem "chef-config", git: "https://github.com/chef/chef", branch: "main", glob: "chef-config/chef-config.gemspec"
-gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "chef-utils/chef-utils.gemspec"
+# pull these gems from chef-17 of chef/chef so that we're testing against what we will release
+gem "chef-config", git: "https://github.com/chef/chef", branch: "chef-17", glob: "chef-config/chef-config.gemspec"
+gem "chef-utils", git: "https://github.com/chef/chef", branch: "chef-17", glob: "chef-utils/chef-utils.gemspec"
 
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
Ohai 17.x should be in sync with Chef 17.x. The `chef-util` and `chef-config` gem dependencies should refer the `chef-17` branch of github.com/chef/chef

## Related Issue
Doesn't fix https://github.com/chef/ohai/issues/1771 but perhaps related.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
