### PR TITLE
Darwin virtualization plugin: fix potential for false positive

### DIFF
--- a/lib/ohai/plugins/darwin/virtualization.rb
+++ b/lib/ohai/plugins/darwin/virtualization.rb
@@ -77,17 +77,15 @@ Ohai.plugin(:Virtualization) do
       virtualization[:systems][:vmware] = "guest"
     end
 
-    if prlctl_exists?
+    
+    if ioreg_exists? && /pci1ab8,4000/.match?(shell_out("ioreg -l").stdout)
+      virtualization[:system] = "parallels"
+      virtualization[:role] = "guest"
+      virtualization[:systems][:parallels] = "guest"
+    elsif prlctl_exists? 
       virtualization[:system] = "parallels"
       virtualization[:role] = "host"
       virtualization[:systems][:parallels] = "host"
-    elsif ioreg_exists?
-      so = shell_out("ioreg -l")
-      if /pci1ab8,4000/.match?(so.stdout)
-        virtualization[:system] = "parallels"
-        virtualization[:role] = "guest"
-        virtualization[:systems][:parallels] = "guest"
-      end
     end
   end
 end

--- a/lib/ohai/plugins/darwin/virtualization.rb
+++ b/lib/ohai/plugins/darwin/virtualization.rb
@@ -77,12 +77,11 @@ Ohai.plugin(:Virtualization) do
       virtualization[:systems][:vmware] = "guest"
     end
 
-    
     if ioreg_exists? && /pci1ab8,4000/.match?(shell_out("ioreg -l").stdout)
       virtualization[:system] = "parallels"
       virtualization[:role] = "guest"
       virtualization[:systems][:parallels] = "guest"
-    elsif prlctl_exists? 
+    elsif prlctl_exists?
       virtualization[:system] = "parallels"
       virtualization[:role] = "host"
       virtualization[:systems][:parallels] = "host"

--- a/spec/unit/plugins/darwin/virtualization_spec.rb
+++ b/spec/unit/plugins/darwin/virtualization_spec.rb
@@ -151,7 +151,7 @@ describe Ohai::System, "Darwin virtualization platform" do
       expect(plugin[:virtualization][:role]).to eq("guest")
       expect(plugin[:virtualization][:systems][:parallels]).to eq("guest")
     end
-    
+
     it "sets parallels host if /usr/local/bin/prlctl exists, /usr/sbin/ioreg exists, and ioreg's output does not contain pci1ab8,4000" do
       allow(plugin).to receive(:prlctl_exists?).and_return("/usr/local/bin/prlctl")
       allow(plugin).to receive(:ioreg_exists?).and_return(true)

--- a/spec/unit/plugins/darwin/virtualization_spec.rb
+++ b/spec/unit/plugins/darwin/virtualization_spec.rb
@@ -22,6 +22,55 @@ require "spec_helper"
 
 describe Ohai::System, "Darwin virtualization platform" do
   let(:plugin) { get_plugin("darwin/virtualization") }
+  let(:ioreg_vm) do
+    <<-IOREG
+      | |   +-o pci1ab8,4000@3  <class IOPCIDevice, id 0x1000001d1, registered, matched, active, busy 0 (40 ms), retain 9>
+      | |   | | {
+      | |   | |   "compatible" = <"pci1ab8,400","pci1ab8,4000","pciclass,ff0000">
+      | |   | |   "subsystem-vendor-id" = <b81a0000>
+      | |   | |   "IOName" = "pci1ab8,4000"
+      | |   | |   "reg" = <00180000000000000000000000000000000000001018000100000000000000000000000020000000>
+      | |   | |   "device-id" = <00400000>
+      | |   | |   "assigned-addresses" = <101800810000000040d200000000000020000000>
+      | |   | |   "IOPowerManagement" = {"MaxPowerState"=3,"ChildProxyPowerState"=2,"CurrentPowerState"=2}
+      | |   | |   "IOPCIResourced" = Yes
+      | |   | |   "IODeviceMemory" = ("IOSubMemoryDescriptor is not serializable")
+      | |   | |   "revision-id" = <00000000>
+      | |   | |   "IOInterruptControllers" = ("IOPCIMessagedInterruptController")
+      | |   | |   "vendor-id" = <b81a0000>
+      | |   | |   "pcidebug" = "0:3:0"
+      | |   | |   "class-code" = <0000ff00>
+      | |   | |   "IOInterruptSpecifiers" = (<0000000000000100>)
+      | |   | |   "IOPCIMSIMode" = Yes
+      | |   | |   "subsystem-id" = <00040000>
+      | |   | |   "name" = <"pci1ab8,4000">
+      | |   | | }
+    IOREG
+  end
+  let(:ioreg_not_vm) do
+    <<-IOREG
+      | |   +-o pci8086,2445@1F,4  <class IOPCIDevice, id 0x1000001d4, registered, matched, active, busy 0 (974 ms), retain 11>
+      | |     | {
+      | |     |   "compatible" = <"pci1ab8,400","pci8086,2445","pciclass,040100">
+      | |     |   "subsystem-vendor-id" = <b81a0000>
+      | |     |   "IOName" = "pci8086,2445"
+      | |     |   "reg" = <00fc00000000000000000000000000000000000010fc00010000000000000000000000000001000014fc000100000000000000000000000000010000>
+      | |     |   "device-id" = <45240000>
+      | |     |   "assigned-addresses" = <10fc00810000000000d10000000000000001000014fc00810000000000d000000000000000010000>
+      | |     |   "IOPowerManagement" = {"ChildrenPowerState"=2,"CurrentPowerState"=2,"ChildProxyPowerState"=2,"MaxPowerState"=3}
+      | |     |   "IOPCIResourced" = Yes
+      | |     |   "IODeviceMemory" = ("IOSubMemoryDescriptor is not serializable","IOSubMemoryDescriptor is not serializable")
+      | |     |   "revision-id" = <02000000>
+      | |     |   "IOInterruptControllers" = ("io-apic-0")
+      | |     |   "vendor-id" = <86800000>
+      | |     |   "pcidebug" = "0:31:4"
+      | |     |   "class-code" = <00010400>
+      | |     |   "IOInterruptSpecifiers" = (<1100000007000000>)
+      | |     |   "subsystem-id" = <00040000>
+      | |     |   "name" = <"pci8086,2445">
+      | |     | }
+    IOREG
+  end
 
   before do
     allow(plugin).to receive(:collect_os).and_return(:darwin)
@@ -80,41 +129,11 @@ describe Ohai::System, "Darwin virtualization platform" do
       expect(plugin[:virtualization][:systems][:vbox]).to eq("guest")
     end
 
-    it "sets parallels host if /usr/bin/prlctl exists" do
-      allow(plugin).to receive(:prlctl_exists?).and_return("/usr/bin/prlctl")
-      plugin.run
-      expect(plugin[:virtualization][:system]).to eq("parallels")
-      expect(plugin[:virtualization][:role]).to eq("host")
-      expect(plugin[:virtualization][:systems][:parallels]).to eq("host")
-    end
-
-    it "sets parallels guest if /usr/sbin/ioreg exists and its output contains pci1ab8,4000" do
+    it "sets parallels guest if /usr/local/bin/prlctl exists, /usr/sbin/ioreg exists, and ioreg's output contains pci1ab8,4000" do
+      allow(plugin).to receive(:prlctl_exists?).and_return("/usr/local/bin/prlctl")
       allow(plugin).to receive(:ioreg_exists?).and_return(true)
-      ioreg = <<-IOREG
-    | |   +-o pci1ab8,4000@3  <class IOPCIDevice, id 0x1000001d1, registered, matched, active, busy 0 (40 ms), retain 9>
-    | |   | | {
-    | |   | |   "compatible" = <"pci1ab8,400","pci1ab8,4000","pciclass,ff0000">
-    | |   | |   "subsystem-vendor-id" = <b81a0000>
-    | |   | |   "IOName" = "pci1ab8,4000"
-    | |   | |   "reg" = <00180000000000000000000000000000000000001018000100000000000000000000000020000000>
-    | |   | |   "device-id" = <00400000>
-    | |   | |   "assigned-addresses" = <101800810000000040d200000000000020000000>
-    | |   | |   "IOPowerManagement" = {"MaxPowerState"=3,"ChildProxyPowerState"=2,"CurrentPowerState"=2}
-    | |   | |   "IOPCIResourced" = Yes
-    | |   | |   "IODeviceMemory" = ("IOSubMemoryDescriptor is not serializable")
-    | |   | |   "revision-id" = <00000000>
-    | |   | |   "IOInterruptControllers" = ("IOPCIMessagedInterruptController")
-    | |   | |   "vendor-id" = <b81a0000>
-    | |   | |   "pcidebug" = "0:3:0"
-    | |   | |   "class-code" = <0000ff00>
-    | |   | |   "IOInterruptSpecifiers" = (<0000000000000100>)
-    | |   | |   "IOPCIMSIMode" = Yes
-    | |   | |   "subsystem-id" = <00040000>
-    | |   | |   "name" = <"pci1ab8,4000">
-    | |   | | }
-      IOREG
       shellout = double("shellout")
-      allow(shellout).to receive(:stdout).and_return(ioreg)
+      allow(shellout).to receive(:stdout).and_return(ioreg_vm)
       allow(plugin).to receive(:shell_out).with("ioreg -l").and_return(shellout)
       plugin.run
       expect(plugin[:virtualization][:system]).to eq("parallels")
@@ -122,32 +141,33 @@ describe Ohai::System, "Darwin virtualization platform" do
       expect(plugin[:virtualization][:systems][:parallels]).to eq("guest")
     end
 
-    it "does not set parallels guest if /usr/sbin/ioreg exists and its output not contain pci1ab8,4000" do
+    it "sets parallels guest if /usr/local/bin/prlctl does not exists, /usr/sbin/ioreg exists, and ioreg's output contains pci1ab8,4000" do
       allow(plugin).to receive(:ioreg_exists?).and_return(true)
-      ioreg = <<-IOREG
-    | |   +-o pci8086,2445@1F,4  <class IOPCIDevice, id 0x1000001d4, registered, matched, active, busy 0 (974 ms), retain 11>
-    | |     | {
-    | |     |   "compatible" = <"pci1ab8,400","pci8086,2445","pciclass,040100">
-    | |     |   "subsystem-vendor-id" = <b81a0000>
-    | |     |   "IOName" = "pci8086,2445"
-    | |     |   "reg" = <00fc00000000000000000000000000000000000010fc00010000000000000000000000000001000014fc000100000000000000000000000000010000>
-    | |     |   "device-id" = <45240000>
-    | |     |   "assigned-addresses" = <10fc00810000000000d10000000000000001000014fc00810000000000d000000000000000010000>
-    | |     |   "IOPowerManagement" = {"ChildrenPowerState"=2,"CurrentPowerState"=2,"ChildProxyPowerState"=2,"MaxPowerState"=3}
-    | |     |   "IOPCIResourced" = Yes
-    | |     |   "IODeviceMemory" = ("IOSubMemoryDescriptor is not serializable","IOSubMemoryDescriptor is not serializable")
-    | |     |   "revision-id" = <02000000>
-    | |     |   "IOInterruptControllers" = ("io-apic-0")
-    | |     |   "vendor-id" = <86800000>
-    | |     |   "pcidebug" = "0:31:4"
-    | |     |   "class-code" = <00010400>
-    | |     |   "IOInterruptSpecifiers" = (<1100000007000000>)
-    | |     |   "subsystem-id" = <00040000>
-    | |     |   "name" = <"pci8086,2445">
-    | |     | }
-      IOREG
       shellout = double("shellout")
-      allow(shellout).to receive(:stdout).and_return(ioreg)
+      allow(shellout).to receive(:stdout).and_return(ioreg_vm)
+      allow(plugin).to receive(:shell_out).with("ioreg -l").and_return(shellout)
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("parallels")
+      expect(plugin[:virtualization][:role]).to eq("guest")
+      expect(plugin[:virtualization][:systems][:parallels]).to eq("guest")
+    end
+    
+    it "sets parallels host if /usr/local/bin/prlctl exists, /usr/sbin/ioreg exists, and ioreg's output does not contain pci1ab8,4000" do
+      allow(plugin).to receive(:prlctl_exists?).and_return("/usr/local/bin/prlctl")
+      allow(plugin).to receive(:ioreg_exists?).and_return(true)
+      shellout = double("shellout")
+      allow(shellout).to receive(:stdout).and_return(ioreg_not_vm)
+      allow(plugin).to receive(:shell_out).with("ioreg -l").and_return(shellout)
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("parallels")
+      expect(plugin[:virtualization][:role]).to eq("host")
+      expect(plugin[:virtualization][:systems][:parallels]).to eq("host")
+    end
+
+    it "does not set parallels guest if /usr/local/bin/prlctl does not exist, /usr/sbin/ioreg exists, and ioreg's output does not contain pci1ab8,4000" do
+      allow(plugin).to receive(:ioreg_exists?).and_return(true)
+      shellout = double("shellout")
+      allow(shellout).to receive(:stdout).and_return(ioreg_not_vm)
       allow(plugin).to receive(:shell_out).with("ioreg -l").and_return(shellout)
       plugin.run
       expect(plugin[:virtualization]).to eq({ "systems" => {} })


### PR DESCRIPTION
## Description
Currently, a machine can be miscategorized as a physical machine. This can happen if a VM happens to have Parallels installed on it. This can be fixed by inverting the if-else statement, thereby checking if the machine is a VM before checking if the machine has Parallels installed on it.

## Related Issue
#1775 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin]
