### PR TITLE
Add cloud provider oci

### DIFF
--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -6,7 +6,7 @@ name: exec
   push:
     branches:
       - main
-      - 1=7-stable
+      - 17-stable
       - 16-stable
 
 permissions:

--- a/lib/ohai/mixin/oci_metadata.rb
+++ b/lib/ohai/mixin/oci_metadata.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #
 # Author:: Renato Covarrubias (<rnt@rnt.cl>)
 # License:: Apache License, Version 2.0
@@ -15,15 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "net/http" unless defined?(Net::HTTP)
+require 'net/http' unless defined?(Net::HTTP)
 
 module Ohai
   module Mixin
     module OCIMetadata
-
-      # Trailing dot to host is added to avoid DNS search path
-      OCI_METADATA_ADDR ||= "169.254.169.254"
-      OCI_METADATA_URL ||= "/opc/v2"
+      OCI_METADATA_ADDR = '169.254.169.254'
+      OCI_METADATA_URL = '/opc/v2'
 
       # fetch the meta content with a timeout and the required header
       def http_get(uri)
@@ -33,14 +32,14 @@ module Ohai
           uri,
           {
             'Authorization' => 'Bearer Oracle',
-            "User-Agent" => "chef-ohai/#{Ohai::VERSION}",
+            'User-Agent' => "chef-ohai/#{Ohai::VERSION}"
           }
         )
       end
 
-      def fetch_metadata(metadata = "instance")
+      def fetch_metadata(metadata = 'instance')
         response = http_get("#{OCI_METADATA_URL}/#{metadata}")
-        return nil unless response.code == "200"
+        return nil unless response.code == '200'
 
         if json?(response.body)
           data = String(response.body)

--- a/lib/ohai/mixin/oci_metadata.rb
+++ b/lib/ohai/mixin/oci_metadata.rb
@@ -38,31 +38,18 @@ module Ohai
         )
       end
 
+      # Fetch metadata from api
       def fetch_metadata(metadata = "instance")
         response = http_get("#{OCI_METADATA_URL}/#{metadata}")
         return nil unless response.code == "200"
 
-        if json?(response.body)
-          data = String(response.body)
-          parser = FFI_Yajl::Parser.new
-          parser.parse(data)
-        else
-          response.body
-        end
-      end
-
-      # @param [String] data that might be JSON
-      #
-      # @return [Boolean] is the data JSON or not?
-      def json?(data)
-        data = String(data)
-        parser = FFI_Yajl::Parser.new
         begin
-          parser.parse(data)
-          true
+          data = String(response.body)
+          metadata = parser.parse(data)
         rescue FFI_Yajl::ParseError
-          false
+          metadata = response.body
         end
+        metadata
       end
     end
   end

--- a/lib/ohai/mixin/oci_metadata.rb
+++ b/lib/ohai/mixin/oci_metadata.rb
@@ -16,13 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'net/http' unless defined?(Net::HTTP)
+require "net/http" unless defined?(Net::HTTP)
 
 module Ohai
   module Mixin
     module OCIMetadata
-      OCI_METADATA_ADDR = '169.254.169.254'
-      OCI_METADATA_URL = '/opc/v2'
+      OCI_METADATA_ADDR = "169.254.169.254"
+      OCI_METADATA_URL = "/opc/v2"
 
       # fetch the meta content with a timeout and the required header
       def http_get(uri)
@@ -31,15 +31,15 @@ module Ohai
         conn.get(
           uri,
           {
-            'Authorization' => 'Bearer Oracle',
-            'User-Agent' => "chef-ohai/#{Ohai::VERSION}"
+            "Authorization" => "Bearer Oracle",
+            "User-Agent" => "chef-ohai/#{Ohai::VERSION}",
           }
         )
       end
 
-      def fetch_metadata(metadata = 'instance')
+      def fetch_metadata(metadata = "instance")
         response = http_get("#{OCI_METADATA_URL}/#{metadata}")
-        return nil unless response.code == '200'
+        return nil unless response.code == "200"
 
         if json?(response.body)
           data = String(response.body)

--- a/lib/ohai/mixin/oci_metadata.rb
+++ b/lib/ohai/mixin/oci_metadata.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+#
+# Author:: Renato Covarrubias (<rnt@rnt.cl>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "net/http" unless defined?(Net::HTTP)
+
+module Ohai
+  module Mixin
+    module OCIMetadata
+
+      # Trailing dot to host is added to avoid DNS search path
+      OCI_METADATA_ADDR ||= "169.254.169.254"
+      OCI_METADATA_URL ||= "/opc/v2"
+
+      # fetch the meta content with a timeout and the required header
+      def http_get(uri)
+        conn = Net::HTTP.start(OCI_METADATA_ADDR)
+        conn.read_timeout = 6
+        conn.get(
+          uri,
+          {
+            'Authorization' => 'Bearer Oracle',
+            "User-Agent" => "chef-ohai/#{Ohai::VERSION}",
+          }
+        )
+      end
+
+      def fetch_metadata(metadata = "instance")
+        response = http_get("#{OCI_METADATA_URL}/#{metadata}")
+        return nil unless response.code == "200"
+
+        if json?(response.body)
+          data = String(response.body)
+          parser = FFI_Yajl::Parser.new
+          parser.parse(data)
+        else
+          response.body
+        end
+      end
+
+      # @param [String] data that might be JSON
+      #
+      # @return [Boolean] is the data JSON or not?
+      def json?(data)
+        data = String(data)
+        parser = FFI_Yajl::Parser.new
+        begin
+          parser.parse(data)
+          true
+        rescue FFI_Yajl::ParseError
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/ohai/mixin/oci_metadata.rb
+++ b/lib/ohai/mixin/oci_metadata.rb
@@ -23,6 +23,7 @@ module Ohai
     module OCIMetadata
       OCI_METADATA_ADDR = "169.254.169.254"
       OCI_METADATA_URL = "/opc/v2"
+      CHASSIS_ASSET_TAG_FILE = "/sys/devices/virtual/dmi/id/chassis_asset_tag"
 
       # fetch the meta content with a timeout and the required header
       def http_get(uri)

--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -341,7 +341,7 @@ Ohai.plugin(:Cloud) do
   # OCI
   # ----------------------------------------
 
-  # Is current Oracle Cloud Infraestructure?
+  # Is current Oracle Cloud Infrastructure?
   #
   # === Return
   # true:: If oci Hash is defined

--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -351,10 +351,10 @@ Ohai.plugin(:Cloud) do
   end
 
   # Fill cloud hash with OCI values
-  def get_oci_values
-    oci["metadata"]["network"].each { |vnic| @cloud_attr_obj.add_ipv4_addr(vnic['privateIp'], :private) }
-    @cloud_attr_obj.local_hostname = oci["metadata"]['compute']['hostname']
-    @cloud_attr_obj.provider = "oci"
+  def oci_values
+    oci['metadata']['network']['interface'].each { |vnic| @cloud_attr_obj.add_ipv4_addr(vnic['privateIp'], :private) }
+    @cloud_attr_obj.local_hostname = oci['metadata']['compute']['hostname']
+    @cloud_attr_obj.provider = 'oci'
   end
 
   collect_data do
@@ -372,7 +372,7 @@ Ohai.plugin(:Cloud) do
     get_digital_ocean_values if on_digital_ocean?
     get_softlayer_values if on_softlayer?
     get_alibaba_values if on_alibaba?
-    get_oci_values if on_oci?
+    oci_values if on_oci?
 
     cloud @cloud_attr_obj.cloud_mash
   end

--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -28,6 +28,7 @@ Ohai.plugin(:Cloud) do
   depends "azure"
   depends "digital_ocean"
   depends "softlayer"
+  depends "oci"
 
   # Class to help enforce the interface exposed to node[:cloud] (OHAI-542)
   #
@@ -336,6 +337,26 @@ Ohai.plugin(:Cloud) do
     @cloud_attr_obj.provider = "softlayer"
   end
 
+  # ----------------------------------------
+  # OCI
+  # ----------------------------------------
+
+  # Is current Oracle Cloud Infraestructure?
+  #
+  # === Return
+  # true:: If oci Hash is defined
+  # false:: Otherwise
+  def on_oci?
+    oci != nil
+  end
+
+  # Fill cloud hash with OCI values
+  def get_oci_values
+    oci["metadata"]["network"].each { |vnic| @cloud_attr_obj.add_ipv4_addr(vnic['privateIp'], :private) }
+    @cloud_attr_obj.local_hostname = oci["metadata"]['compute']['hostname']
+    @cloud_attr_obj.provider = "oci"
+  end
+
   collect_data do
     require "ipaddr" unless defined?(IPAddr)
 
@@ -351,6 +372,7 @@ Ohai.plugin(:Cloud) do
     get_digital_ocean_values if on_digital_ocean?
     get_softlayer_values if on_softlayer?
     get_alibaba_values if on_alibaba?
+    get_oci_values if on_oci?
 
     cloud @cloud_attr_obj.cloud_mash
   end

--- a/lib/ohai/plugins/cloud.rb
+++ b/lib/ohai/plugins/cloud.rb
@@ -352,9 +352,9 @@ Ohai.plugin(:Cloud) do
 
   # Fill cloud hash with OCI values
   def oci_values
-    oci['metadata']['network']['interface'].each { |vnic| @cloud_attr_obj.add_ipv4_addr(vnic['privateIp'], :private) }
-    @cloud_attr_obj.local_hostname = oci['metadata']['compute']['hostname']
-    @cloud_attr_obj.provider = 'oci'
+    oci["metadata"]["network"]["interface"].each { |vnic| @cloud_attr_obj.add_ipv4_addr(vnic["privateIp"], :private) }
+    @cloud_attr_obj.local_hostname = oci["metadata"]["compute"]["hostname"]
+    @cloud_attr_obj.provider = "oci"
   end
 
   collect_data do

--- a/lib/ohai/plugins/oci.rb
+++ b/lib/ohai/plugins/oci.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+#
+# Author:: Renato Covarrubias (<rnt@rnt.cl>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Ohai.plugin(:Oci) do
+  require_relative "../mixin/oci_metadata"
+  require_relative "../mixin/http_helper"
+
+  include Ohai::Mixin::OCIMetadata
+  include Ohai::Mixin::HttpHelper
+
+  provides "oci"
+
+  collect_data do
+    oci_metadata_from_hints = hint?("oci")
+    if oci_metadata_from_hints
+      logger.trace("Plugin OCI: oci hint is present. Parsing any hint data.")
+      oci Mash.new
+      oci_metadata_from_hints.each { |k, v| oci[k] = v }
+      oci["metadata"] = parse_metadata
+    elsif oci_chassis_asset_tag?
+      logger.trace("Plugin oci: No hints present, but system appears to be on oci.")
+      oci Mash.new
+      oci["metadata"] = parse_metadata
+    else
+      logger.trace("Plugin oci: No hints present and doesn't appear to be on oci.")
+      false
+    end
+  end
+ 
+  def oci_chassis_asset_tag?
+    has_oci_chassis_asset_tag = false
+    if file_exist?("/sys/devices/virtual/dmi/id/chassis_asset_tag")
+      file_open("/sys/devices/virtual/dmi/id/chassis_asset_tag").each do |line|
+        if /OracleCloud.com/.match?(line)
+          logger.trace("Plugin oci: Found OracleCloud.com chassis_asset_tag used by oci.")
+          has_oci_chassis_asset_tag = true
+          break
+        end
+      end
+    end
+    has_oci_chassis_asset_tag
+  end
+
+  def parse_metadata
+    return nil unless can_socket_connect?(Ohai::Mixin::OCIMetadata::OCI_METADATA_ADDR, 80)
+
+    instance_data = fetch_metadata('instance')
+    return nil if instance_data.nil?
+
+    metadata = Mash.new
+    metadata["compute"] = Mash.new
+
+    instance_data.each do |k, v|
+      metadata["compute"][k] = v
+    end
+
+    vnics_data = fetch_metadata('vnics')
+    
+    unless vnics_data.nil?
+      metadata["network"] = Mash.new
+      vnics_data.each do |k, v|
+        metadata["network"][k] = v
+      end
+    end
+
+    volume_attachments_data = fetch_metadata('volumeAttachments')
+
+    unless volume_attachments_data.nil?
+      metadata["volumes"] = Mash.new
+      volume_attachments_data.each do |k, v|
+        metadata["volumes"][k] = v
+      end
+    end
+
+    metadata
+  end
+end

--- a/lib/ohai/plugins/oci.rb
+++ b/lib/ohai/plugins/oci.rb
@@ -18,25 +18,25 @@
 #
 
 Ohai.plugin(:Oci) do
-  require_relative '../mixin/oci_metadata'
-  require_relative '../mixin/http_helper'
+  require_relative "../mixin/oci_metadata"
+  require_relative "../mixin/http_helper"
 
   include Ohai::Mixin::OCIMetadata
   include Ohai::Mixin::HttpHelper
 
-  provides 'oci'
+  provides "oci"
 
   collect_data do
-    oci_metadata_from_hints = hint?('oci')
+    oci_metadata_from_hints = hint?("oci")
     if oci_metadata_from_hints
-      logger.trace('Plugin OCI: oci hint is present. Parsing any hint data.')
+      logger.trace("Plugin OCI: oci hint is present. Parsing any hint data.")
       oci Mash.new
       oci_metadata_from_hints.each { |k, v| oci[k] = v }
-      oci['metadata'] = parse_metadata
+      oci["metadata"] = parse_metadata
     elsif oci_chassis_asset_tag?
-      logger.trace('Plugin oci: No hints present, but system appears to be on oci.')
+      logger.trace("Plugin oci: No hints present, but system appears to be on oci.")
       oci Mash.new
-      oci['metadata'] = parse_metadata
+      oci["metadata"] = parse_metadata
     else
       logger.trace("Plugin oci: No hints present and doesn't appear to be on oci.")
       false
@@ -45,11 +45,11 @@ Ohai.plugin(:Oci) do
 
   def oci_chassis_asset_tag?
     has_oci_chassis_asset_tag = false
-    if file_exist?('/sys/devices/virtual/dmi/id/chassis_asset_tag')
-      file_open('/sys/devices/virtual/dmi/id/chassis_asset_tag').each do |line|
+    if file_exist?("/sys/devices/virtual/dmi/id/chassis_asset_tag")
+      file_open("/sys/devices/virtual/dmi/id/chassis_asset_tag").each do |line|
         next unless /OracleCloud.com/.match?(line)
 
-        logger.trace('Plugin oci: Found OracleCloud.com chassis_asset_tag used by oci.')
+        logger.trace("Plugin oci: Found OracleCloud.com chassis_asset_tag used by oci.")
         has_oci_chassis_asset_tag = true
         break
       end
@@ -60,32 +60,32 @@ Ohai.plugin(:Oci) do
   def parse_metadata
     return nil unless can_socket_connect?(Ohai::Mixin::OCIMetadata::OCI_METADATA_ADDR, 80)
 
-    instance_data = fetch_metadata('instance')
+    instance_data = fetch_metadata("instance")
     return nil if instance_data.nil?
 
     metadata = Mash.new
-    metadata['compute'] = Mash.new
+    metadata["compute"] = Mash.new
 
     instance_data.each do |k, v|
-      metadata['compute'][k] = v
+      metadata["compute"][k] = v
     end
 
-    vnics_data = fetch_metadata('vnics')
+    vnics_data = fetch_metadata("vnics")
 
     unless vnics_data.nil?
-      metadata['network'] = Mash.new
-      metadata['network']['interface'] = []
+      metadata["network"] = Mash.new
+      metadata["network"]["interface"] = []
       vnics_data.each do |v|
-        metadata['network']['interface'].append(v)
+        metadata["network"]["interface"].append(v)
       end
     end
 
-    volume_attachments_data = fetch_metadata('volumeAttachments')
+    volume_attachments_data = fetch_metadata("volumeAttachments")
 
     unless volume_attachments_data.nil?
-      metadata['volumes'] = Mash.new
+      metadata["volumes"] = Mash.new
       volume_attachments_data.each do |k, v|
-        metadata['volumes'][k] = v
+        metadata["volumes"][k] = v
       end
     end
 

--- a/lib/ohai/plugins/oci.rb
+++ b/lib/ohai/plugins/oci.rb
@@ -74,9 +74,9 @@ Ohai.plugin(:Oci) do
 
     unless vnics_data.nil?
       metadata['network'] = Mash.new
-      metadata['network']['interfaces'] = []
+      metadata['network']['interface'] = []
       vnics_data.each do |v|
-        metadata['network']['interfaces'].append(v)
+        metadata['network']['interface'].append(v)
       end
     end
 

--- a/lib/ohai/plugins/oci.rb
+++ b/lib/ohai/plugins/oci.rb
@@ -45,8 +45,8 @@ Ohai.plugin(:Oci) do
 
   def oci_chassis_asset_tag?
     has_oci_chassis_asset_tag = false
-    if file_exist?("/sys/devices/virtual/dmi/id/chassis_asset_tag")
-      file_open("/sys/devices/virtual/dmi/id/chassis_asset_tag").each do |line|
+    if file_exist?(Ohai::Mixin::OCIMetadata::CHASSIS_ASSET_TAG_FILE)
+      file_open(Ohai::Mixin::OCIMetadata::CHASSIS_ASSET_TAG_FILE).each do |line|
         next unless /OracleCloud.com/.match?(line)
 
         logger.trace("Plugin oci: Found OracleCloud.com chassis_asset_tag used by oci.")

--- a/spec/unit/mixin/oci_metadata_spec.rb
+++ b/spec/unit/mixin/oci_metadata_spec.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
-require 'ohai/mixin/oci_metadata'
+require "spec_helper"
+require "ohai/mixin/oci_metadata"
 
 describe Ohai::Mixin::OCIMetadata do
   let(:mixin) do
@@ -27,26 +27,26 @@ describe Ohai::Mixin::OCIMetadata do
   end
 
   before do
-    logger = instance_double('Mixlib::Log::Child', trace: nil, debug: nil, warn: nil)
+    logger = instance_double("Mixlib::Log::Child", trace: nil, debug: nil, warn: nil)
     allow(mixin).to receive(:logger).and_return(logger)
   end
 
-  describe '#http_get' do
-    it 'gets the passed URI' do
-      http_mock = double('http')
+  describe "#http_get" do
+    it "gets the passed URI" do
+      http_mock = double("http")
       allow(http_mock).to receive(:read_timeout=)
-      allow(Net::HTTP).to receive(:start).with('169.254.169.254').and_return(http_mock)
+      allow(Net::HTTP).to receive(:start).with("169.254.169.254").and_return(http_mock)
 
-      expect(http_mock).to receive(:get).with('169.254.169.254',
-                                              { 'Authorization' => 'Bearer Oracle',
-                                                'User-Agent' => "chef-ohai/#{Ohai::VERSION}" })
-      mixin.http_get('169.254.169.254')
+      expect(http_mock).to receive(:get).with("169.254.169.254",
+                                              { "Authorization" => "Bearer Oracle",
+                                                "User-Agent" => "chef-ohai/#{Ohai::VERSION}" })
+      mixin.http_get("169.254.169.254")
     end
   end
 
-  describe '#fetch_metadata' do
-    it 'returns an empty hash given a non-200 response' do
-      http_mock = double('http', { code: '404' })
+  describe "#fetch_metadata" do
+    it "returns an empty hash given a non-200 response" do
+      http_mock = double("http", { code: "404" })
       allow(mixin).to receive(:http_get).and_return(http_mock)
 
       expect(mixin.logger).not_to receive(:warn)
@@ -54,13 +54,13 @@ describe Ohai::Mixin::OCIMetadata do
       expect(vals).to eq(nil)
     end
 
-    it 'returns a populated hash given valid JSON response' do
-      http_mock = double('http', { code: '200', body: '{ "foo": "bar"}' })
+    it "returns a populated hash given valid JSON response" do
+      http_mock = double("http", { code: "200", body: '{ "foo": "bar"}' })
       allow(mixin).to receive(:http_get).and_return(http_mock)
 
       expect(mixin.logger).not_to receive(:warn)
       vals = mixin.fetch_metadata
-      expect(vals).to eq({ 'foo' => 'bar' })
+      expect(vals).to eq({ "foo" => "bar" })
     end
   end
 end

--- a/spec/unit/mixin/oci_metadata_spec.rb
+++ b/spec/unit/mixin/oci_metadata_spec.rb
@@ -35,12 +35,12 @@ describe Ohai::Mixin::OCIMetadata do
     it "gets the passed URI" do
       http_mock = double("http")
       allow(http_mock).to receive(:read_timeout=)
-      allow(Net::HTTP).to receive(:start).with("169.254.169.254").and_return(http_mock)
+      allow(Net::HTTP).to receive(:start).with(Ohai::Mixin::OCIMetadata::OCI_METADATA_ADDR).and_return(http_mock)
 
-      expect(http_mock).to receive(:get).with("169.254.169.254",
+      expect(http_mock).to receive(:get).with(Ohai::Mixin::OCIMetadata::OCI_METADATA_ADDR,
                                               { "Authorization" => "Bearer Oracle",
                                                 "User-Agent" => "chef-ohai/#{Ohai::VERSION}" })
-      mixin.http_get("169.254.169.254")
+      mixin.http_get(Ohai::Mixin::OCIMetadata::OCI_METADATA_ADDR)
     end
   end
 

--- a/spec/unit/mixin/oci_metadata_spec.rb
+++ b/spec/unit/mixin/oci_metadata_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#
+# Author:: Renato Covarrubias <rnt@rnt.cl>
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDIT"Net::HTTP Response"NS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'ohai/mixin/oci_metadata'
+
+describe Ohai::Mixin::OCIMetadata do
+  let(:mixin) do
+    mixin = Object.new.extend(Ohai::Mixin::OCIMetadata)
+    mixin
+  end
+
+  before do
+    logger = instance_double('Mixlib::Log::Child', trace: nil, debug: nil, warn: nil)
+    allow(mixin).to receive(:logger).and_return(logger)
+  end
+
+  describe '#http_get' do
+    it 'gets the passed URI' do
+      http_mock = double('http')
+      allow(http_mock).to receive(:read_timeout=)
+      allow(Net::HTTP).to receive(:start).with('169.254.169.254').and_return(http_mock)
+
+      expect(http_mock).to receive(:get).with('169.254.169.254',
+                                              { 'Authorization' => 'Bearer Oracle',
+                                                'User-Agent' => "chef-ohai/#{Ohai::VERSION}" })
+      mixin.http_get('169.254.169.254')
+    end
+  end
+
+  describe '#fetch_metadata' do
+    it 'returns an empty hash given a non-200 response' do
+      http_mock = double('http', { code: '404' })
+      allow(mixin).to receive(:http_get).and_return(http_mock)
+
+      expect(mixin.logger).not_to receive(:warn)
+      vals = mixin.fetch_metadata
+      expect(vals).to eq(nil)
+    end
+
+    it 'returns a populated hash given valid JSON response' do
+      http_mock = double('http', { code: '200', body: '{ "foo": "bar"}' })
+      allow(mixin).to receive(:http_get).and_return(http_mock)
+
+      expect(mixin.logger).not_to receive(:warn)
+      vals = mixin.fetch_metadata
+      expect(vals).to eq({ 'foo' => 'bar' })
+    end
+  end
+end

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -517,55 +517,12 @@ describe Ohai::System, "plugin cloud" do
       @plugin[:oci] = Mash.new
       @plugin[:oci][:metadata] = {
         'compute' => {
-          'availabilityDomain' => 'EMIr:PHX-AD-1',
-          'faultDomain' => 'FAULT-DOMAIN-3',
-          'compartmentId' => 'ocid1.tenancy.oc1..exampleuniqueID',
-          'displayName' => 'my-example-instance',
-          'hostname' => 'my-hostname',
-          'id' => 'ocid1.instance.oc1.phx.exampleuniqueID',
-          'image' => 'ocid1.image.oc1.phx.exampleuniqueID',
-          'metadata' => {
-            'ssh_authorized_keys' => 'example-ssh-key'
-          },
-          'region' => 'phx',
-          'canonicalRegionName' => 'us-phoenix-1',
-          'ociAdName' => 'phx-ad-1',
-          'regionInfo' => {
-            'realmKey' => 'oc1',
-            'realmDomainComponent' => 'oraclecloud.com',
-            'regionKey' => 'PHX',
-            'regionIdentifier' => 'us-phoenix-1'
-          },
-          'shape' => 'VM.Standard.E3.Flex',
-          'state' => 'Running',
-          'timeCreated' => 1_600_381_928_581,
-          'agentConfig' => {
-            'monitoringDisabled' => false,
-            'managementDisabled' => false,
-            'allPluginsDisabled' => false,
-            'pluginsConfig' => [
-              { 'name' => 'OS Management Service Agent', 'desiredState' => 'ENABLED' },
-              { 'name' => 'Custom Logs Monitoring', 'desiredState' => 'ENABLED' },
-              { 'name' => 'Compute Instance Run Command', 'desiredState' => 'ENABLED' },
-              { 'name' => 'Compute Instance Monitoring', 'desiredState' => 'ENABLED' }
-            ]
-          },
-          'freeformTags' => {
-            'Department' => 'Finance'
-          },
-          'definedTags' => {
-            'Operations' => {
-              'CostCenter' => '42'
-            }
-          }
+          'hostname' => 'my-hostname'
         },
         'network' => {
           'interface' => [
             { 'vnicId' => 'ocid1.vnic.oc1.phx.exampleuniqueID', 'privateIp' => '10.0.3.6', 'vlanTag' => 11,
               'macAddr' => '00:00:00:00:00:01', 'virtualRouterIp' => '10.0.3.1', 'subnetCidrBlock' => '10.0.3.0/24',
-              'nicIndex' => 0 },
-            { 'vnicId' => 'ocid1.vnic.oc1.phx.exampleuniqueID', 'privateIp' => '10.0.4.3', 'vlanTag' => 12,
-              'macAddr' => '00:00:00:00:00:02', 'virtualRouterIp' => '10.0.4.1', 'subnetCidrBlock' => '10.0.4.0/24',
               'nicIndex' => 0 }
           ]
         }

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -512,41 +512,41 @@ describe Ohai::System, "plugin cloud" do
     end
   end
 
-  describe 'with OCI mash' do
+  describe "with OCI mash" do
     before do
       @plugin[:oci] = Mash.new
       @plugin[:oci][:metadata] = {
-        'compute' => {
-          'hostname' => 'my-hostname'
+        "compute" => {
+          "hostname" => "my-hostname",
         },
-        'network' => {
-          'interface' => [
-            { 'vnicId' => 'ocid1.vnic.oc1.phx.exampleuniqueID', 'privateIp' => '10.0.3.6', 'vlanTag' => 11,
-              'macAddr' => '00:00:00:00:00:01', 'virtualRouterIp' => '10.0.3.1', 'subnetCidrBlock' => '10.0.3.0/24',
-              'nicIndex' => 0 }
-          ]
-        }
+        "network" => {
+          "interface" => [
+            { "vnicId" => "ocid1.vnic.oc1.phx.exampleuniqueID", "privateIp" => "10.0.3.6", "vlanTag" => 11,
+              "macAddr" => "00:00:00:00:00:01", "virtualRouterIp" => "10.0.3.1", "subnetCidrBlock" => "10.0.3.0/24",
+              "nicIndex" => 0 },
+          ],
+        },
       }
     end
 
     it "doesn't populates cloud vm_name" do
       @plugin.run
-      expect(@plugin[:cloud][:vm_name]).not_to eq('testtest')
+      expect(@plugin[:cloud][:vm_name]).not_to eq("testtest")
     end
 
-    it 'populates cloud local_hostname' do
+    it "populates cloud local_hostname" do
       @plugin.run
-      expect(@plugin[:cloud][:local_hostname]).to eq('my-hostname')
+      expect(@plugin[:cloud][:local_hostname]).to eq("my-hostname")
     end
 
-    it 'populates cloud private ip' do
+    it "populates cloud private ip" do
       @plugin.run
-      expect(@plugin[:cloud][:local_ipv4]).to eq(@plugin[:oci][:metadata][:network][:interface][0]['privateIp'])
+      expect(@plugin[:cloud][:local_ipv4]).to eq(@plugin[:oci][:metadata][:network][:interface][0]["privateIp"])
     end
 
-    it 'populates cloud provider' do
+    it "populates cloud provider" do
       @plugin.run
-      expect(@plugin[:cloud][:provider]).to eq('oci')
+      expect(@plugin[:cloud][:provider]).to eq("oci")
     end
   end
 end

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -535,9 +535,13 @@ describe Ohai::System, "plugin cloud" do
     end
 
     it 'populates cloud local_hostname' do
-      @plugin[:oci]['metadata']['compute']['hostname'] = 'my-hostname'
       @plugin.run
       expect(@plugin[:cloud][:local_hostname]).to eq('my-hostname')
+    end
+
+    it 'populates cloud private ip' do
+      @plugin.run
+      expect(@plugin[:cloud][:local_ipv4]).to eq(@plugin[:oci][:metadata][:network][:interface][0]['privateIp'])
     end
 
     it 'populates cloud provider' do

--- a/spec/unit/plugins/oci_spec.rb
+++ b/spec/unit/plugins/oci_spec.rb
@@ -18,77 +18,77 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+require "spec_helper"
 begin
-  require 'win32/registry' unless defined?(Win32::Registry)
+  require "win32/registry" unless defined?(Win32::Registry)
 rescue LoadError => e
   puts "Skipping missing rake dep: #{e}"
 end
 
-describe Ohai::System, 'plugin oci' do
-  let(:plugin) { get_plugin('oci') }
+describe Ohai::System, "plugin oci" do
+  let(:plugin) { get_plugin("oci") }
   let(:hint) do
     {
-      'local_hostname' => 'test-vm',
-      'provider' => 'oci'
+      "local_hostname" => "test-vm",
+      "provider" => "oci",
     }
   end
 
   let(:response_data) do
     {
-      'compute' => {
-        'availabilityDomain' => 'EMIr:PHX-AD-1',
-        'faultDomain' => 'FAULT-DOMAIN-3',
-        'compartmentId' => 'ocid1.tenancy.oc1..exampleuniqueID',
-        'displayName' => 'my-example-instance',
-        'hostname' => 'my-hostname',
-        'id' => 'ocid1.instance.oc1.phx.exampleuniqueID',
-        'image' => 'ocid1.image.oc1.phx.exampleuniqueID',
-        'metadata' => {
-          'ssh_authorized_keys' => 'example-ssh-key'
+      "compute" => {
+        "availabilityDomain" => "EMIr:PHX-AD-1",
+        "faultDomain" => "FAULT-DOMAIN-3",
+        "compartmentId" => "ocid1.tenancy.oc1..exampleuniqueID",
+        "displayName" => "my-example-instance",
+        "hostname" => "my-hostname",
+        "id" => "ocid1.instance.oc1.phx.exampleuniqueID",
+        "image" => "ocid1.image.oc1.phx.exampleuniqueID",
+        "metadata" => {
+          "ssh_authorized_keys" => "example-ssh-key",
         },
-        'region' => 'phx',
-        'canonicalRegionName' => 'us-phoenix-1',
-        'ociAdName' => 'phx-ad-1',
-        'regionInfo' => {
-          'realmKey' => 'oc1',
-          'realmDomainComponent' => 'oraclecloud.com',
-          'regionKey' => 'PHX',
-          'regionIdentifier' => 'us-phoenix-1'
+        "region" => "phx",
+        "canonicalRegionName" => "us-phoenix-1",
+        "ociAdName" => "phx-ad-1",
+        "regionInfo" => {
+          "realmKey" => "oc1",
+          "realmDomainComponent" => "oraclecloud.com",
+          "regionKey" => "PHX",
+          "regionIdentifier" => "us-phoenix-1",
         },
-        'shape' => 'VM.Standard.E3.Flex',
-        'state' => 'Running',
-        'timeCreated' => 1_600_381_928_581,
-        'agentConfig' => {
-          'monitoringDisabled' => false,
-          'managementDisabled' => false,
-          'allPluginsDisabled' => false,
-          'pluginsConfig' => [
-            { 'name' => 'OS Management Service Agent', 'desiredState' => 'ENABLED' },
-            { 'name' => 'Custom Logs Monitoring', 'desiredState' => 'ENABLED' },
-            { 'name' => 'Compute Instance Run Command', 'desiredState' => 'ENABLED' },
-            { 'name' => 'Compute Instance Monitoring', 'desiredState' => 'ENABLED' }
-          ]
+        "shape" => "VM.Standard.E3.Flex",
+        "state" => "Running",
+        "timeCreated" => 1_600_381_928_581,
+        "agentConfig" => {
+          "monitoringDisabled" => false,
+          "managementDisabled" => false,
+          "allPluginsDisabled" => false,
+          "pluginsConfig" => [
+            { "name" => "OS Management Service Agent", "desiredState" => "ENABLED" },
+            { "name" => "Custom Logs Monitoring", "desiredState" => "ENABLED" },
+            { "name" => "Compute Instance Run Command", "desiredState" => "ENABLED" },
+            { "name" => "Compute Instance Monitoring", "desiredState" => "ENABLED" },
+          ],
         },
-        'freeformTags' => {
-          'Department' => 'Finance'
+        "freeformTags" => {
+          "Department" => "Finance",
         },
-        'definedTags' => {
-          'Operations' => {
-            'CostCenter' => '42'
-          }
-        }
+        "definedTags" => {
+          "Operations" => {
+            "CostCenter" => "42",
+          },
+        },
       },
-      'network' => {
-        'interface' => [
-          { 'vnicId' => 'ocid1.vnic.oc1.phx.exampleuniqueID', 'privateIp' => '10.0.3.6', 'vlanTag' => 11,
-            'macAddr' => '00:00:00:00:00:01', 'virtualRouterIp' => '10.0.3.1', 'subnetCidrBlock' => '10.0.3.0/24',
-            'nicIndex' => 0 },
-          { 'vnicId' => 'ocid1.vnic.oc1.phx.exampleuniqueID', 'privateIp' => '10.0.4.3', 'vlanTag' => 12,
-            'macAddr' => '00:00:00:00:00:02', 'virtualRouterIp' => '10.0.4.1', 'subnetCidrBlock' => '10.0.4.0/24',
-            'nicIndex' => 0 }
-        ]
-      }
+      "network" => {
+        "interface" => [
+          { "vnicId" => "ocid1.vnic.oc1.phx.exampleuniqueID", "privateIp" => "10.0.3.6", "vlanTag" => 11,
+            "macAddr" => "00:00:00:00:00:01", "virtualRouterIp" => "10.0.3.1", "subnetCidrBlock" => "10.0.3.0/24",
+            "nicIndex" => 0 },
+          { "vnicId" => "ocid1.vnic.oc1.phx.exampleuniqueID", "privateIp" => "10.0.4.3", "vlanTag" => 12,
+            "macAddr" => "00:00:00:00:00:02", "virtualRouterIp" => "10.0.4.1", "subnetCidrBlock" => "10.0.4.0/24",
+            "nicIndex" => 0 },
+        ],
+      },
     }
   end
 
@@ -99,65 +99,65 @@ describe Ohai::System, 'plugin oci' do
       .and_return(false)
   end
 
-  shared_examples_for '!oci' do
-    it 'does not set the oci attribute' do
+  shared_examples_for "!oci" do
+    it "does not set the oci attribute" do
       plugin.run
       expect(plugin[:oci]).to be_nil
     end
   end
 
-  shared_examples_for 'oci' do
-    it 'sets the oci attribute' do
+  shared_examples_for "oci" do
+    it "sets the oci attribute" do
       plugin.run
       expect(plugin[:oci]).to be_truthy
       expect(plugin[:oci]).to have_key(:metadata)
     end
   end
 
-  describe 'with oci hint file' do
+  describe "with oci hint file" do
     before do
-      allow(plugin).to receive(:hint?).with('oci').and_return(hint)
+      allow(plugin).to receive(:hint?).with("oci").and_return(hint)
     end
 
-    it 'sets the oci cloud attributes' do
+    it "sets the oci cloud attributes" do
       plugin.run
-      expect(plugin[:oci]['provider']).to eq('oci')
-      expect(plugin[:oci]['local_hostname']).to eq('test-vm')
+      expect(plugin[:oci]["provider"]).to eq("oci")
+      expect(plugin[:oci]["local_hostname"]).to eq("test-vm")
     end
   end
 
-  describe 'without oci hint file not in OCI' do
+  describe "without oci hint file not in OCI" do
     before do
-      allow(plugin).to receive(:hint?).with('oci').and_return(false)
-      allow(plugin).to receive(:file_exist?).with('/sys/devices/virtual/dmi/id/chassis_asset_tag').and_return(true)
-      @double_file = double('/sys/devices/virtual/dmi/id/chassis_asset_tag')
+      allow(plugin).to receive(:hint?).with("oci").and_return(false)
+      allow(plugin).to receive(:file_exist?).with("/sys/devices/virtual/dmi/id/chassis_asset_tag").and_return(true)
+      @double_file = double("/sys/devices/virtual/dmi/id/chassis_asset_tag")
       allow(@double_file).to receive(:each)
-        .and_yield('')
-      allow(plugin).to receive(:file_open).with('/sys/devices/virtual/dmi/id/chassis_asset_tag').and_return(@double_file)
+        .and_yield("")
+      allow(plugin).to receive(:file_open).with("/sys/devices/virtual/dmi/id/chassis_asset_tag").and_return(@double_file)
     end
 
-    it_behaves_like '!oci'
+    it_behaves_like "!oci"
   end
 
-  describe 'without oci hint file in OCI' do
+  describe "without oci hint file in OCI" do
     before do
-      allow(plugin).to receive(:hint?).with('oci').and_return(false)
-      allow(plugin).to receive(:file_exist?).with('/sys/devices/virtual/dmi/id/chassis_asset_tag').and_return(true)
-      @double_file = double('/sys/devices/virtual/dmi/id/chassis_asset_tag')
+      allow(plugin).to receive(:hint?).with("oci").and_return(false)
+      allow(plugin).to receive(:file_exist?).with("/sys/devices/virtual/dmi/id/chassis_asset_tag").and_return(true)
+      @double_file = double("/sys/devices/virtual/dmi/id/chassis_asset_tag")
       allow(@double_file).to receive(:each)
-        .and_yield('OracleCloud.com')
-      allow(plugin).to receive(:file_open).with('/sys/devices/virtual/dmi/id/chassis_asset_tag').and_return(@double_file)
+        .and_yield("OracleCloud.com")
+      allow(plugin).to receive(:file_open).with("/sys/devices/virtual/dmi/id/chassis_asset_tag").and_return(@double_file)
     end
 
-    it_behaves_like 'oci'
+    it_behaves_like "oci"
   end
 
-  describe 'with non-responsive metadata endpoint' do
+  describe "with non-responsive metadata endpoint" do
     before do
-      allow(plugin).to receive(:hint?).with('oci').and_return({})
+      allow(plugin).to receive(:hint?).with("oci").and_return({})
     end
 
-    it 'does not return metadata information' do
+    it "does not return metadata information" do
       allow(plugin).to receive(:can_socket_connect?)
         .with(Ohai::Mixin::OCIMetadata::OCI_METADATA_ADDR, 80)
         .and_return(true)
@@ -169,9 +169,9 @@ describe Ohai::System, 'plugin oci' do
     end
   end
 
-  describe 'with responsive metadata endpoint' do
+  describe "with responsive metadata endpoint" do
     before do
-      allow(plugin).to receive(:hint?).with('oci').and_return({})
+      allow(plugin).to receive(:hint?).with("oci").and_return({})
       allow(plugin).to receive(:can_socket_connect?)
         .with(Ohai::Mixin::OCIMetadata::OCI_METADATA_ADDR, 80)
         .and_return(true)
@@ -179,20 +179,20 @@ describe Ohai::System, 'plugin oci' do
       plugin.run
     end
 
-    it 'returns metadata compute information' do
-      expect(plugin[:oci][:metadata][:compute][:availabilityDomain]).to eq('EMIr:PHX-AD-1')
-      expect(plugin[:oci][:metadata][:compute][:compartmentId]).to eq('ocid1.tenancy.oc1..exampleuniqueID')
-      expect(plugin[:oci][:metadata][:compute][:faultDomain]).to eq('FAULT-DOMAIN-3')
-      expect(plugin[:oci][:metadata][:compute][:hostname]).to eq('my-hostname')
-      expect(plugin[:oci][:metadata][:compute][:image]).to eq('ocid1.image.oc1.phx.exampleuniqueID')
-      expect(plugin[:oci][:metadata][:compute][:region]).to eq('phx')
-      expect(plugin[:oci][:metadata][:compute][:shape]).to eq('VM.Standard.E3.Flex')
-      expect(plugin[:oci][:metadata][:compute][:state]).to eq('Running')
+    it "returns metadata compute information" do
+      expect(plugin[:oci][:metadata][:compute][:availabilityDomain]).to eq("EMIr:PHX-AD-1")
+      expect(plugin[:oci][:metadata][:compute][:compartmentId]).to eq("ocid1.tenancy.oc1..exampleuniqueID")
+      expect(plugin[:oci][:metadata][:compute][:faultDomain]).to eq("FAULT-DOMAIN-3")
+      expect(plugin[:oci][:metadata][:compute][:hostname]).to eq("my-hostname")
+      expect(plugin[:oci][:metadata][:compute][:image]).to eq("ocid1.image.oc1.phx.exampleuniqueID")
+      expect(plugin[:oci][:metadata][:compute][:region]).to eq("phx")
+      expect(plugin[:oci][:metadata][:compute][:shape]).to eq("VM.Standard.E3.Flex")
+      expect(plugin[:oci][:metadata][:compute][:state]).to eq("Running")
     end
 
-    it 'returns metadata network information' do
-      expect(plugin[:oci][:metadata][:network][:interface][0][:macAddr]).to eq('00:00:00:00:00:01')
-      expect(plugin[:oci][:metadata][:network][:interface][0][:privateIp]).to eq('10.0.3.6')
+    it "returns metadata network information" do
+      expect(plugin[:oci][:metadata][:network][:interface][0][:macAddr]).to eq("00:00:00:00:00:01")
+      expect(plugin[:oci][:metadata][:network][:interface][0][:privateIp]).to eq("10.0.3.6")
     end
   end
 end

--- a/spec/unit/plugins/oci_spec.rb
+++ b/spec/unit/plugins/oci_spec.rb
@@ -129,11 +129,11 @@ describe Ohai::System, "plugin oci" do
   describe "without oci hint file not in OCI" do
     before do
       allow(plugin).to receive(:hint?).with("oci").and_return(false)
-      allow(plugin).to receive(:file_exist?).with("/sys/devices/virtual/dmi/id/chassis_asset_tag").and_return(true)
-      @double_file = double("/sys/devices/virtual/dmi/id/chassis_asset_tag")
+      allow(plugin).to receive(:file_exist?).with(Ohai::Mixin::OCIMetadata::CHASSIS_ASSET_TAG_FILE).and_return(true)
+      @double_file = double(Ohai::Mixin::OCIMetadata::CHASSIS_ASSET_TAG_FILE)
       allow(@double_file).to receive(:each)
         .and_yield("")
-      allow(plugin).to receive(:file_open).with("/sys/devices/virtual/dmi/id/chassis_asset_tag").and_return(@double_file)
+      allow(plugin).to receive(:file_open).with(Ohai::Mixin::OCIMetadata::CHASSIS_ASSET_TAG_FILE).and_return(@double_file)
     end
 
     it_behaves_like "!oci"
@@ -142,11 +142,11 @@ describe Ohai::System, "plugin oci" do
   describe "without oci hint file in OCI" do
     before do
       allow(plugin).to receive(:hint?).with("oci").and_return(false)
-      allow(plugin).to receive(:file_exist?).with("/sys/devices/virtual/dmi/id/chassis_asset_tag").and_return(true)
-      @double_file = double("/sys/devices/virtual/dmi/id/chassis_asset_tag")
+      allow(plugin).to receive(:file_exist?).with(Ohai::Mixin::OCIMetadata::CHASSIS_ASSET_TAG_FILE).and_return(true)
+      @double_file = double(Ohai::Mixin::OCIMetadata::CHASSIS_ASSET_TAG_FILE)
       allow(@double_file).to receive(:each)
         .and_yield("OracleCloud.com")
-      allow(plugin).to receive(:file_open).with("/sys/devices/virtual/dmi/id/chassis_asset_tag").and_return(@double_file)
+      allow(plugin).to receive(:file_open).with(Ohai::Mixin::OCIMetadata::CHASSIS_ASSET_TAG_FILE).and_return(@double_file)
     end
 
     it_behaves_like "oci"

--- a/spec/unit/plugins/oci_spec.rb
+++ b/spec/unit/plugins/oci_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+#
+# Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+begin
+  require 'win32/registry' unless defined?(Win32::Registry)
+rescue LoadError => e
+  puts "Skipping missing rake dep: #{e}"
+end
+
+describe Ohai::System, 'plugin oci' do
+  let(:plugin) { get_plugin('oci') }
+  let(:hint) do
+    {
+      'local_hostname' => 'test-vm',
+      'provider' => 'oci'
+    }
+  end
+
+  let(:response_data) do
+    {
+      'compute' => {
+        'availabilityDomain' => 'EMIr:PHX-AD-1',
+        'faultDomain' => 'FAULT-DOMAIN-3',
+        'compartmentId' => 'ocid1.tenancy.oc1..exampleuniqueID',
+        'displayName' => 'my-example-instance',
+        'hostname' => 'my-hostname',
+        'id' => 'ocid1.instance.oc1.phx.exampleuniqueID',
+        'image' => 'ocid1.image.oc1.phx.exampleuniqueID',
+        'metadata' => {
+          'ssh_authorized_keys' => 'example-ssh-key'
+        },
+        'region' => 'phx',
+        'canonicalRegionName' => 'us-phoenix-1',
+        'ociAdName' => 'phx-ad-1',
+        'regionInfo' => {
+          'realmKey' => 'oc1',
+          'realmDomainComponent' => 'oraclecloud.com',
+          'regionKey' => 'PHX',
+          'regionIdentifier' => 'us-phoenix-1'
+        },
+        'shape' => 'VM.Standard.E3.Flex',
+        'state' => 'Running',
+        'timeCreated' => 1_600_381_928_581,
+        'agentConfig' => {
+          'monitoringDisabled' => false,
+          'managementDisabled' => false,
+          'allPluginsDisabled' => false,
+          'pluginsConfig' => [
+            { 'name' => 'OS Management Service Agent', 'desiredState' => 'ENABLED' },
+            { 'name' => 'Custom Logs Monitoring', 'desiredState' => 'ENABLED' },
+            { 'name' => 'Compute Instance Run Command', 'desiredState' => 'ENABLED' },
+            { 'name' => 'Compute Instance Monitoring', 'desiredState' => 'ENABLED' }
+          ]
+        },
+        'freeformTags' => {
+          'Department' => 'Finance'
+        },
+        'definedTags' => {
+          'Operations' => {
+            'CostCenter' => '42'
+          }
+        }
+      },
+      'network' => {
+        'interface' => [
+          { 'vnicId' => 'ocid1.vnic.oc1.phx.exampleuniqueID', 'privateIp' => '10.0.3.6', 'vlanTag' => 11,
+            'macAddr' => '00:00:00:00:00:01', 'virtualRouterIp' => '10.0.3.1', 'subnetCidrBlock' => '10.0.3.0/24',
+            'nicIndex' => 0 },
+          { 'vnicId' => 'ocid1.vnic.oc1.phx.exampleuniqueID', 'privateIp' => '10.0.4.3', 'vlanTag' => 12,
+            'macAddr' => '00:00:00:00:00:02', 'virtualRouterIp' => '10.0.4.1', 'subnetCidrBlock' => '10.0.4.0/24',
+            'nicIndex' => 0 }
+        ]
+      }
+    }
+  end
+
+  before do
+    # skips all the metadata logic unless we want to test it
+    allow(plugin).to receive(:can_socket_connect?)
+      .with(Ohai::Mixin::OCIMetadata::OCI_METADATA_ADDR, 80)
+      .and_return(false)
+  end
+
+  shared_examples_for '!oci' do
+    it 'does not set the oci attribute' do
+      plugin.run
+      expect(plugin[:oci]).to be_nil
+    end
+  end
+
+  shared_examples_for 'oci' do
+    it 'sets the oci attribute' do
+      plugin.run
+      expect(plugin[:oci]).to be_truthy
+      expect(plugin[:oci]).to have_key(:metadata)
+    end
+  end
+
+  describe 'with oci hint file' do
+    before do
+      allow(plugin).to receive(:hint?).with('oci').and_return(hint)
+    end
+
+    it 'sets the oci cloud attributes' do
+      plugin.run
+      expect(plugin[:oci]['provider']).to eq('oci')
+      expect(plugin[:oci]['local_hostname']).to eq('test-vm')
+    end
+  end
+
+  describe 'without oci hint file not in OCI' do
+    before do
+      allow(plugin).to receive(:hint?).with('oci').and_return(false)
+      allow(plugin).to receive(:file_exist?).with('/sys/devices/virtual/dmi/id/chassis_asset_tag').and_return(true)
+      @double_file = double('/sys/devices/virtual/dmi/id/chassis_asset_tag')
+      allow(@double_file).to receive(:each)
+        .and_yield('')
+      allow(plugin).to receive(:file_open).with('/sys/devices/virtual/dmi/id/chassis_asset_tag').and_return(@double_file)
+    end
+
+    it_behaves_like '!oci'
+  end
+
+  describe 'without oci hint file in OCI' do
+    before do
+      allow(plugin).to receive(:hint?).with('oci').and_return(false)
+      allow(plugin).to receive(:file_exist?).with('/sys/devices/virtual/dmi/id/chassis_asset_tag').and_return(true)
+      @double_file = double('/sys/devices/virtual/dmi/id/chassis_asset_tag')
+      allow(@double_file).to receive(:each)
+        .and_yield('OracleCloud.com')
+      allow(plugin).to receive(:file_open).with('/sys/devices/virtual/dmi/id/chassis_asset_tag').and_return(@double_file)
+    end
+
+    it_behaves_like 'oci'
+  end
+
+  describe 'with non-responsive metadata endpoint' do
+    before do
+      allow(plugin).to receive(:hint?).with('oci').and_return({})
+    end
+
+    it 'does not return metadata information' do
+      allow(plugin).to receive(:can_socket_connect?)
+        .with(Ohai::Mixin::OCIMetadata::OCI_METADATA_ADDR, 80)
+        .and_return(true)
+      allow(plugin).to receive(:parse_metadata).and_return(nil)
+
+      plugin.run
+      expect(plugin[:oci]).to have_key(:metadata)
+      expect(plugin[:oci][:metadata]).to be_nil
+    end
+  end
+
+  describe 'with responsive metadata endpoint' do
+    before do
+      allow(plugin).to receive(:hint?).with('oci').and_return({})
+      allow(plugin).to receive(:can_socket_connect?)
+        .with(Ohai::Mixin::OCIMetadata::OCI_METADATA_ADDR, 80)
+        .and_return(true)
+      allow(plugin).to receive(:parse_metadata).and_return(response_data)
+      plugin.run
+    end
+
+    it 'returns metadata compute information' do
+      expect(plugin[:oci][:metadata][:compute][:availabilityDomain]).to eq('EMIr:PHX-AD-1')
+      expect(plugin[:oci][:metadata][:compute][:compartmentId]).to eq('ocid1.tenancy.oc1..exampleuniqueID')
+      expect(plugin[:oci][:metadata][:compute][:faultDomain]).to eq('FAULT-DOMAIN-3')
+      expect(plugin[:oci][:metadata][:compute][:hostname]).to eq('my-hostname')
+      expect(plugin[:oci][:metadata][:compute][:image]).to eq('ocid1.image.oc1.phx.exampleuniqueID')
+      expect(plugin[:oci][:metadata][:compute][:region]).to eq('phx')
+      expect(plugin[:oci][:metadata][:compute][:shape]).to eq('VM.Standard.E3.Flex')
+      expect(plugin[:oci][:metadata][:compute][:state]).to eq('Running')
+    end
+
+    it 'returns metadata network information' do
+      expect(plugin[:oci][:metadata][:network][:interface][0][:macAddr]).to eq('00:00:00:00:00:01')
+      expect(plugin[:oci][:metadata][:network][:interface][0][:privateIp]).to eq('10.0.3.6')
+    end
+  end
+end


### PR DESCRIPTION
`ohai cloud` fail if the vm is in Oracle Cloud Infrastructure (OCI). This PR add support to this cloud provider to cloud plugin.

## Description
Ohai don't detect OCI has a cloud provider, so for cookbook thats require some changes related to the cloud provider, this is a issue.

Following the [OCI Metadata Documentation](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm) I build this change.

## Related Issue
#1779

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
