### PR TITLE
Force encoding with timezones that include umlauts if zone encoding is IBM437

### DIFF
--- a/lib/ohai/plugins/timezone.rb
+++ b/lib/ohai/plugins/timezone.rb
@@ -35,7 +35,10 @@ Ohai.plugin(:Timezone) do
     # * [ISO/IEC 8859-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1)
     # * [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252)
     if time[:timezone].encoding == Encoding::IBM437
+      # Assume encoding is WINDOWS_1252
       time[:timezone] = time[:timezone].force_encoding(Encoding::WINDOWS_1252)
+      # Re-encode in UTF_8. Note: If other encodings have problems converting
+      # it might be worth re-encode everything in UTF_8.
       time[:timezone] = time[:timezone].encode(Encoding::UTF_8)
     end
   end

--- a/lib/ohai/plugins/timezone.rb
+++ b/lib/ohai/plugins/timezone.rb
@@ -21,5 +21,22 @@ Ohai.plugin(:Timezone) do
   collect_data(:default) do
     time Mash.new unless time
     time[:timezone] = Time.now.getlocal.zone
+
+    # Windows in German display language outputs LATIN1 bytes for .zone, but marks them as
+    # IBM437, which somehow fails any attempt at conversion to other encodings when
+    # ä is present, as in the timezone name "Mitteleuropäische Zeit" (Central Europe Time)
+    #
+    # Windows-1252 is the legacy encoding for Windows for German that actually
+    # translates (ISO-8859-1 works as well), but going with the more correct
+    # encoding name for Windows' implementation of Latin-1
+    #
+    # References
+    # * [Code Page 437/IBM437](https://en.wikipedia.org/wiki/Code_page_437)
+    # * [ISO/IEC 8859-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1)
+    # * [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252)
+    if time[:timezone].encoding == Encoding::IBM437
+      time[:timezone] = time[:timezone].force_encoding(Encoding::WINDOWS_1252)
+      time[:timezone] = time[:timezone].encode(Encoding::UTF_8)
+    end
   end
 end

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -53,6 +53,14 @@ Ohai.plugin(:VMware) do
         # to attribute "vmware[:<parameter>]"
         %w{hosttime speed sessionid balloon swap memlimit memres cpures cpulimit}.each do |param|
           vmware[param] = from_cmd([vmtools_path, "stat", param])
+          if param == 'hosttime' && vmtools_path =~ /Program Files/
+            # popen and %x return stdout encoded as IBM437 in Windows but in a string marked
+            # UTF-8. The string doesn't throw an exception when encoded to "UTF-8" but
+            # displays [?] character in Windows without this. .force_encoding(Encoding::ISO_8859_1)
+            # causes the character to be dropped and .force_encoding(Encoding::Windows_1252) displays
+            # the „ character in place of an ä.
+            vmware[param] = vmware[param].force_encoding(Encoding::IBM437).encode("UTF-8")
+          end
           if /UpdateInfo failed/.match?(vmware[param])
             vmware[param] = nil
           end

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -53,7 +53,7 @@ Ohai.plugin(:VMware) do
         # to attribute "vmware[:<parameter>]"
         %w{hosttime speed sessionid balloon swap memlimit memres cpures cpulimit}.each do |param|
           vmware[param] = from_cmd([vmtools_path, "stat", param])
-          if param == 'hosttime' && vmtools_path =~ /Program Files/
+          if param == "hosttime" && vmtools_path.include?("Program Files")
             # popen and %x return stdout encoded as IBM437 in Windows but in a string marked
             # UTF-8. The string doesn't throw an exception when encoded to "UTF-8" but
             # displays [?] character in Windows without this.
@@ -62,6 +62,10 @@ Ohai.plugin(:VMware) do
             # and .force_encoding(Encoding::Windows_1252) displays the „ character in place
             # of an ä. .force_encoding(Encoding::IBM437) allows for the correct characters
             # to be displayed.
+            #
+            # Note:
+            # * this is broken for at least Ruby 2.7 through 3.1.3
+            # * confirmed that this is broken on Windows Server 2022
             vmware[param] = vmware[param].force_encoding(Encoding::IBM437).encode("UTF-8")
           end
           if /UpdateInfo failed/.match?(vmware[param])

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -56,9 +56,12 @@ Ohai.plugin(:VMware) do
           if param == 'hosttime' && vmtools_path =~ /Program Files/
             # popen and %x return stdout encoded as IBM437 in Windows but in a string marked
             # UTF-8. The string doesn't throw an exception when encoded to "UTF-8" but
-            # displays [?] character in Windows without this. .force_encoding(Encoding::ISO_8859_1)
-            # causes the character to be dropped and .force_encoding(Encoding::Windows_1252) displays
-            # the „ character in place of an ä.
+            # displays [?] character in Windows without this.
+            #
+            # .force_encoding(Encoding::ISO_8859_1) causes the character to be dropped
+            # and .force_encoding(Encoding::Windows_1252) displays the „ character in place
+            # of an ä. .force_encoding(Encoding::IBM437) allows for the correct characters
+            # to be displayed.
             vmware[param] = vmware[param].force_encoding(Encoding::IBM437).encode("UTF-8")
           end
           if /UpdateInfo failed/.match?(vmware[param])


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Windows with German language display returns Windows-1252 encoded time zone descriptor in German which does not cleanly convert to Ruby's standard UTF-8, in part because it is described as IBM437 encoding.

* [Code Page 437/IBM437](https://en.wikipedia.org/wiki/Code_page_437)
* [ISO/IEC 8859-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1)
* [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252)

## Related Issue
[INFC-402](https://chefio.atlassian.net/browse/INFC-402) - Chef Infra Client: Due to german characters like "ä", "ö", "ü" the JSON convert of the audit results fails in the chef infra client.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).


[INFC-402]: https://chefio.atlassian.net/browse/INFC-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ