### PR TITLE
Calling yajl parser only once

### DIFF
--- a/lib/ohai/mixin/json_helper.rb
+++ b/lib/ohai/mixin/json_helper.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+#
+# Author:: Renato Covarrubias (<rnt@rnt.cl>)
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Ohai
+  module Mixin
+    module JsonHelper
+      # parse JSON data from a String to a Hash
+      #
+      # @param [String] response_body json as string to parse
+      # @param [Object] return_on_parse_error value to return if parsing fails
+      #
+      # @return [Hash]
+      def parse_json(response_body, return_on_parse_error = nil)
+        data = String(response_body)
+        parser = FFI_Yajl::Parser.new
+        parser.parse(data)
+      rescue FFI_Yajl::ParseError
+        return_on_parse_error
+      end
+    end
+  end
+end

--- a/spec/unit/mixin/oci_metadata_spec.rb
+++ b/spec/unit/mixin/oci_metadata_spec.rb
@@ -49,7 +49,7 @@ describe Ohai::Mixin::OCIMetadata do
       http_mock = double("http", { code: "404" })
       allow(mixin).to receive(:http_get).and_return(http_mock)
 
-      expect(mixin.logger).not_to receive(:warn)
+      expect(mixin.logger).to receive(:warn)
       vals = mixin.fetch_metadata
       expect(vals).to eq(nil)
     end


### PR DESCRIPTION
In some plugins, YAJL parser is called twice. That's really inefficient.

## Description
We definitely shouldn't fire off the YAJL parser twice if we don't need to.

_Originally posted by @jaymzh in https://github.com/chef/ohai/pull/1780#pullrequestreview-1288003393_

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Add cloud provider oci #1780  


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
