### PR TITLE
[block_device] Record firmware revision of nvme block devices

### DIFF
--- a/lib/ohai/plugins/linux/block_device.rb
+++ b/lib/ohai/plugins/linux/block_device.rb
@@ -31,7 +31,7 @@ Ohai.plugin(:BlockDevice) do
             file_open("/sys/block/#{dir}/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
-        %w{model rev state timeout vendor queue_depth}.each do |check|
+        %w{model rev state timeout vendor queue_depth firmware_rev}.each do |check|
           if file_exist?("/sys/block/#{dir}/device/#{check}")
             file_open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end

--- a/spec/unit/plugins/linux/block_device_spec.rb
+++ b/spec/unit/plugins/linux/block_device_spec.rb
@@ -29,6 +29,13 @@ describe Ohai::System, "Linux Block Device Plugin" do
       "queue_depth" => "1",
       "vendor" => "ATA",
     },
+    "nvme0n1" => {
+      "size" => "500118192",
+      "removable" => "0",
+      "model" => "KXG50ZNV256G TOSHIBA",
+      "state" => "live",
+      "firmware_rev" => "AAGA4103",
+    },
     "dm-0" => {
       "size" => "7806976",
       "removable" => "0",


### PR DESCRIPTION
Enhancing the plugin to record the firmware of nvme block devices

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The sysfs end point for firmware in nvme block device differs from HDD. Added firmware_rev to the plugin check list to collect this information on servers with nvme block devices. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
