### PR TITLE
Add support for macOS Rapid Security Response updates

### DIFF
--- a/lib/ohai/plugins/darwin/platform.rb
+++ b/lib/ohai/plugins/darwin/platform.rb
@@ -18,7 +18,7 @@
 #
 
 Ohai.plugin(:Platform) do
-  provides "platform", "platform_version", "platform_build", "platform_family"
+  provides "platform", "platform_version", "platform_version_extra", "platform_build", "platform_family"
 
   collect_data(:darwin) do
     so = shell_out(Ohai.abs_path( "/usr/bin/sw_vers" ).to_s)
@@ -26,6 +26,8 @@ Ohai.plugin(:Platform) do
       case line
       when /^ProductVersion:\s+(.+)$/
         platform_version $1
+      when /^ProductVersionExtra:\s+(.+)$/
+        platform_version_extra $1
       when /^BuildVersion:\s+(.+)$/
         platform_build $1
       end

--- a/spec/unit/plugins/darwin/platform_spec.rb
+++ b/spec/unit/plugins/darwin/platform_spec.rb
@@ -19,36 +19,54 @@
 require "spec_helper"
 
 describe Ohai::System, "Darwin plugin platform" do
+  SW_VERS = "/usr/bin/sw_vers".freeze
+
   before do
     @plugin = get_plugin("darwin/platform")
     allow(@plugin).to receive(:collect_os).and_return(:darwin)
-    @stdout = "ProductName:	Mac OS X\nProductVersion:	10.15.6\nBuildVersion:	19G46c"
-    allow(@plugin).to receive(:shell_out).with("/usr/bin/sw_vers").and_return(mock_shell_out(0, @stdout, ""))
+    @stdout = <<~SW_VERS
+      ProductName:         macOS
+      ProductVersion:      13.3
+      BuildVersion:        22E252
+    SW_VERS
+    allow(@plugin).to receive(:shell_out).with("#{SW_VERS}").and_return(mock_shell_out(0, @stdout, ""))
   end
 
   it "runs sw_vers" do
-    expect(@plugin).to receive(:shell_out).with("/usr/bin/sw_vers").and_return(mock_shell_out(0, @stdout, ""))
+    expect(@plugin).to receive(:shell_out).with("#{SW_VERS}").and_return(mock_shell_out(0, @stdout, ""))
     @plugin.run
   end
 
-  it "sets platform to ProductName, downcased with _ for \\s" do
+  it "sets platform to mac_os_x" do
     @plugin.run
     expect(@plugin[:platform]).to eq("mac_os_x")
   end
 
   it "sets platform_version to ProductVersion" do
     @plugin.run
-    expect(@plugin[:platform_version]).to eq("10.15.6")
+    expect(@plugin[:platform_version]).to eq("13.3")
+  end
+
+  it "sets plaform_version_extra to nil if no ProductVersionExtra" do
+    @plugin.run
+    expect(@plugin[:platform_version_extra]).to be_nil
   end
 
   it "sets platform_version_extra to ProductVersionExtra" do
+    @stdout = <<~SW_VERS
+      ProductName:         macOS
+      ProductVersion:      13.3
+      ProductVersionExtra: (a)
+      BuildVersion:        22E252
+    SW_VERS
+    allow(@plugin).to receive(:shell_out).with("#{SW_VERS}").and_return(mock_shell_out(0, @stdout, ""))
     @plugin.run
-    expect(@plugin[:platform_version_extra]).to eq("(a)").or be_nil
+    expect(@plugin[:platform_version_extra]).to eq("(a)")
   end
 
   it "sets platform_build to BuildVersion" do
     @plugin.run
-    expect(@plugin[:platform_build]).to eq("19G46c")
+    expect(@plugin[:platform_build]).to eq("22E252")
   end
 
   it "sets platform_family to mac_os_x" do

--- a/spec/unit/plugins/darwin/platform_spec.rb
+++ b/spec/unit/plugins/darwin/platform_spec.rb
@@ -41,6 +41,11 @@ describe Ohai::System, "Darwin plugin platform" do
     expect(@plugin[:platform_version]).to eq("10.15.6")
   end
 
+  it "sets platform_version_extra to ProductVersionExtra" do
+    @plugin.run
+    expect(@plugin[:platform_version_extra]).to eq("(a)").or be_nil
+  end
+
   it "sets platform_build to BuildVersion" do
     @plugin.run
     expect(@plugin[:platform_build]).to eq("19G46c")


### PR DESCRIPTION
## Description
Apple is adding a new update type to macOS called Rapid Security Responses. These updates change the build version, but not the OS version reported by `sw_vers`. Instead, a new `ProductVersionExtra` key is returned to denote a specific supplemental version only when a RSR is installed. If no RSR is installed the key is not present. 

```
$ sw_vers
ProductName: macOS
ProductVersion: 13.3
ProductVersionExtra: (a)
BuildVersion: 22E7752300f
```

https://support.apple.com/guide/deployment/rapid-security-responses-dep93ff7ea78/web

This PR adds support for reporting on the RSR version when a patch is installed. The information is important to Mac admins since it gives a full picture of current OS build, whether a security vulnerability has been patched, and, depending on Apple's future plans, if there is functionality change which could impact Chef. I'll admit the spec test isn't totally useful, especially since most machines running tests likely won't have an RSR, but it does match real world scenarios. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
