### PR TITLE
Adds status property to dpkg parsed packages

### DIFF
--- a/lib/ohai/plugins/packages.rb
+++ b/lib/ohai/plugins/packages.rb
@@ -33,13 +33,13 @@ Ohai.plugin(:Packages) do
     packages Mash.new
     case platform_family
     when "debian"
-      format = '${Package}\t${Version}\t${Architecture}\n'
+      format = '${Package}\t${Version}\t${Architecture}\t${db:Status-Status}\n'
       so = shell_out("dpkg-query -W -f='#{format}'")
       pkgs = so.stdout.lines
 
       pkgs.each do |pkg|
-        name, version, arch = pkg.split
-        packages[name] = { "version" => version, "arch" => arch }
+        name, version, arch, status = pkg.split
+        packages[name] = { "version" => version, "arch" => arch, "status" => status }
       end
 
     when "rhel", "fedora", "suse", "pld", "amazon"

--- a/spec/data/plugins/dpkg-query.output
+++ b/spec/data/plugins/dpkg-query.output
@@ -1,4 +1,10 @@
-adduser	3.113+nmu3	all
-libc-bin	2.19-18+deb8u3	amd64
-libc6	2.19-18+deb8u3	amd64
-tzdata	2015g-0+deb8u1	all
+adduser	3.113+nmu3	all	installed
+libc-bin	2.19-18+deb8u3	amd64	installed
+libc6	2.19-18+deb8u3	amd64	installed
+libnss-systemd	247.3-6	amd64	installed
+libpam-systemd	247.3-6	amd64	installed
+libsystemd0	247.3-6	amd64	installed
+systemd	247.3-6	amd64	installed
+systemd-sysv	247.3-6	amd64	installed
+systemd-timesyncd	247.3-6	amd64	config-files
+tzdata	2015g-0+deb8u1	all	installed

--- a/spec/unit/plugins/packages_spec.rb
+++ b/spec/unit/plugins/packages_spec.rb
@@ -27,7 +27,7 @@ describe Ohai::System, "plugin packages" do
       end
     end
 
-    let(:format) { '${Package}\t${Version}\t${Architecture}\n' }
+    let(:format) { '${Package}\t${Version}\t${Architecture}\t${db:Status-Status}\n' }
 
     let(:stdout) do
       File.read(File.join(SPEC_PLUGIN_PATH, "dpkg-query.output"))
@@ -51,11 +51,19 @@ describe Ohai::System, "plugin packages" do
     it "gets packages and versions - arch" do
       expect(plugin[:packages]["libc6"][:version]).to eq("2.19-18+deb8u3")
       expect(plugin[:packages]["libc6"][:arch]).to eq("amd64")
+      expect(plugin[:packages]["libc6"][:status]).to eq("installed")
     end
 
     it "gets packages and versions - noarch" do
       expect(plugin[:packages]["tzdata"][:version]).to eq("2015g-0+deb8u1")
       expect(plugin[:packages]["tzdata"][:arch]).to eq("all")
+      expect(plugin[:packages]["tzdata"][:status]).to eq("installed")
+    end
+
+    it "gets packages and versions - removed" do
+      expect(plugin[:packages]["systemd-timesyncd"][:version]).to eq("247.3-6")
+      expect(plugin[:packages]["systemd-timesyncd"][:arch]).to eq("amd64")
+      expect(plugin[:packages]["systemd-timesyncd"][:status]).to eq("config-files")
     end
   end
 


### PR DESCRIPTION
dpkg-query displays information about all packages on the system, meaning that removed (non-purged) packages that leave config-files are also in this list.

This makes it hard to identify actually installed
packages. By adding the `db:Status-Status` field to our package info hash, we have a lot more flexibility.

Slack discussion about this:
https://chefcommunity.slack.com/archives/C55FCUGBS/p1685438915205339.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
