### PR TITLE
Fix gce metadata recursion issue #1796

### DIFF
--- a/lib/ohai/mixin/gce_metadata.rb
+++ b/lib/ohai/mixin/gce_metadata.rb
@@ -40,7 +40,7 @@ module Ohai
 
       def fetch_metadata(id = "")
         url = "#{GCE_METADATA_URL}/#{id}"
-        url << "?recursive=true" if url.end_with?("/")
+        url = "#{url}?recursive=true" if url.end_with?("/")
         response = http_get(url)
         if response.code == "200"
           json_data = parse_json(response.body)

--- a/lib/ohai/mixin/gce_metadata.rb
+++ b/lib/ohai/mixin/gce_metadata.rb
@@ -26,7 +26,7 @@ module Ohai
 
       # Trailing dot to host is added to avoid DNS search path
       GCE_METADATA_ADDR ||= "metadata.google.internal."
-      GCE_METADATA_URL ||= "/computeMetadata/v1/?recursive=true"
+      GCE_METADATA_URL ||= "/computeMetadata/v1"
 
       # fetch the meta content with a timeout and the required header
       def http_get(uri)
@@ -39,7 +39,9 @@ module Ohai
       end
 
       def fetch_metadata(id = "")
-        response = http_get("#{GCE_METADATA_URL}/#{id}")
+        url = "#{GCE_METADATA_URL}/#{id}"
+        url << "?recursive=true" if url.end_with?("/")
+        response = http_get(url)
         if response.code == "200"
           json_data = parse_json(response.body)
           if json_data.nil?


### PR DESCRIPTION
Only append `?recursive=true` is the generated url is a directory.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Previously the api calls would be:

	/computeMetadata/v1/?recursive=true/
	/computeMetadata/v1/?recursive=true/instance/
	/computeMetadata/v1/?recursive=true/instance/instance/

until #<SystemStackError: stack level too deep>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#1796 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
