### PR TITLE
fp/Adjusting IPROUTE_INT_REGEX to match interfaces with an underscore

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -700,7 +700,7 @@ Ohai.plugin(:Network) do
     # Match the lead line for an interface from iproute2
     # 3: eth0.11@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP
     # The '@eth0:' portion doesn't exist on primary interfaces and thus is optional in the regex
-    IPROUTE_INT_REGEX ||= /^(\d+): ([0-9a-zA-Z@:\.\-_]*?)(@[0-9a-zA-Z]+|):\s/.freeze
+    IPROUTE_INT_REGEX ||= /^(\d+): ([0-9a-zA-Z@:\.\-_]*?)(@[0-9a-zA-Z\-_]+|):\s/.freeze
 
     if which("ip")
       # families to get default routes from


### PR DESCRIPTION
## Description
Adjusting IPROUTE_INT_REGEX to match interfaces with an underscore and/or dash after the arobase

This would now match: 11: mgmt_team.73@mgmt_team: ...

## Types of changes
- Bug fix (non-breaking change which fixes an issue)


