### PR TITLE
Add getnameinfo as a fall through case for fqdn resolution

### DIFF
--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -65,7 +65,7 @@ module Ohai
         # However, we have found that Windows hosts that are not joined to a domain
         # can return a non-qualified hostname).
         # Use a '.' in the canonname as indicator of FQDN
-        return canonname if /\./.match?(canonname)
+        return canonname if canonname.include?(".")
 
         # If we got a non-qualified name, then we do a standard reverse resolve
         # which, assuming DNS is working, will work around that windows bug

--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -41,7 +41,7 @@ module Ohai
       # Addrinfo#ip*? methods return true on AI_CANONNAME Addrinfo records that match
       # the ipv* scheme and #ip? always returns true unless a non tcp Addrinfo
       def ip?(hostname)
-        !!(canonname =~ Resolv::IPv4::Regex) || !!(canonname =~ Resolv::IPv6::Regex)
+        Resolv::IPv4::Regex.match?(hostname) || Resolv::IPv6::Regex.match?(hostname)
       end
 
       # This does a forward and reverse lookup on the hostname to return what should be
@@ -65,7 +65,7 @@ module Ohai
         # However, we have found that Windows hosts that are not joined to a domain
         # can return a non-qualified hostname).
         # Use a '.' in the canonname as indicator of FQDN
-        return canonname if canonname =~ /\./
+        return canonname if /\./.match?(canonname)
 
         # If we got a non-qualified name, then we do a standard reverse resolve
         # which, assuming DNS is working, will work around that windows bug

--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -38,9 +38,10 @@ module Ohai
         dec
       end
 
+      # Addrinfo#ip*? methods return true on AI_CANONNAME Addrinfo records that match
+      # the ipv* scheme and #ip? always returns true unless a non tcp Addrinfo
       def ip?(hostname)
         !!(canonname =~ Resolv::IPv4::Regex) || !!(canonname =~ Resolv::IPv6::Regex)
-
       end
 
       # This does a forward and reverse lookup on the hostname to return what should be
@@ -62,8 +63,9 @@ module Ohai
         # This API is preferred as it never gives us an IP address for broken DNS
         # (see https://github.com/chef/ohai/pull/1705)
         # However, we have found that Windows hosts that are not joined to a domain
-        # can return a non-qualified hostname)
-        return canonname unless ip?(canonname)
+        # can return a non-qualified hostname).
+        # Use a '.' in the canonname as indicator of FQDN
+        return canonname if canonname =~ /\./
 
         # If we got a non-qualified name, then we do a standard reverse resolve
         # which, assuming DNS is working, will work around that windows bug

--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -51,8 +51,9 @@ module Ohai
           .getaddrinfo(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME)
           .first
 
+        canonname = ai&.canonname
         # use canonname
-        return ai&.canonname if (ai&.canonname != hostname || !ChefUtils.windows?)
+        return canonname if (canonname != hostname || !ChefUtils.windows?)
 
         # canonname does not fully qualify the hostname if on Windows node that
         # is not joined to a domain, but getnameinfo does.

--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -53,7 +53,7 @@ module Ohai
 
         canonname = ai&.canonname
         # use canonname
-        return canonname if (canonname != hostname || !ChefUtils.windows?)
+        return canonname if canonname != hostname || !ChefUtils.windows?
 
         # canonname does not fully qualify the hostname if on Windows node that
         # is not joined to a domain, but getnameinfo does.

--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -47,12 +47,15 @@ module Ohai
       # server), and the method should return the hostname and not the IP address.
       #
       def canonicalize_hostname(hostname)
+        ai = Addrinfo.
+          getaddrinfo(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME).
+          first
+
+        return ai&.canonname if ai&.canonname != hostname
+
         # canonname does not fully qualify the hostname if on Windows node that
         # is not joined to a domain, but getnameinfo does.
-        Addrinfo.
-          getaddrinfo(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME).
-          first&.
-          getnameinfo&.[](0) || hostname
+        ai&.getnameinfo&.[](0) || hostname
       end
 
       def canonicalize_hostname_with_retries(hostname)

--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -47,7 +47,12 @@ module Ohai
       # server), and the method should return the hostname and not the IP address.
       #
       def canonicalize_hostname(hostname)
-        Addrinfo.getaddrinfo(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first.canonname
+        # canonname does not fully qualify the hostname if on Windows node that
+        # is not joined to a domain, but getnameinfo does.
+        Addrinfo.
+          getaddrinfo(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME).
+          first&.
+          getnameinfo&.[](0) || hostname
       end
 
       def canonicalize_hostname_with_retries(hostname)

--- a/lib/ohai/mixin/network_helper.rb
+++ b/lib/ohai/mixin/network_helper.rb
@@ -47,11 +47,12 @@ module Ohai
       # server), and the method should return the hostname and not the IP address.
       #
       def canonicalize_hostname(hostname)
-        ai = Addrinfo.
-          getaddrinfo(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME).
-          first
+        ai = Addrinfo
+          .getaddrinfo(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME)
+          .first
 
-        return ai&.canonname if ai&.canonname != hostname
+        # use canonname
+        return ai&.canonname if (ai&.canonname != hostname || !ChefUtils.windows?)
 
         # canonname does not fully qualify the hostname if on Windows node that
         # is not joined to a domain, but getnameinfo does.

--- a/spec/unit/mixin/network_helper_spec.rb
+++ b/spec/unit/mixin/network_helper_spec.rb
@@ -55,7 +55,7 @@ describe Ohai::Mixin::NetworkHelper, "Network Helper Mixin" do
         canonname: "hostnameip", # totally contrived
         nameinfo: "192.168.1.1",
         final_hostname: "hostnameip.example.com",
-      }
+      },
     ].each do |example_hash|
       # this is a brittle set of tests deliberately intended to discourage modifying
       # this API (see the note in the code on the necessity of manual testing)

--- a/spec/unit/mixin/network_helper_spec.rb
+++ b/spec/unit/mixin/network_helper_spec.rb
@@ -36,6 +36,7 @@ describe Ohai::Mixin::NetworkHelper, "Network Helper Mixin" do
       addrinfo = instance_double(Addrinfo)
       expect(Addrinfo).to receive(:getaddrinfo).with(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME).and_return([addrinfo])
       expect(addrinfo).to receive(:canonname).and_return(hostname)
+      expect(addrinfo).to receive(:getnameinfo).and_return([hostname, "0"]) if windows?
       expect(mixin.canonicalize_hostname(hostname)).to eql(hostname)
     end
   end

--- a/spec/unit/mixin/network_helper_spec.rb
+++ b/spec/unit/mixin/network_helper_spec.rb
@@ -29,15 +29,53 @@ describe Ohai::Mixin::NetworkHelper, "Network Helper Mixin" do
   end
 
   describe "canonicalize hostname" do
-    # this is a brittle test deliberately intended to discourage modifying this API
-    # (see the node in the code on the necessity of manual testing)
-    it "uses the correct ruby API" do
-      hostname = "broken.example.org"
-      addrinfo = instance_double(Addrinfo)
-      expect(Addrinfo).to receive(:getaddrinfo).with(hostname, nil, nil, nil, nil, Socket::AI_CANONNAME).and_return([addrinfo])
-      expect(addrinfo).to receive(:canonname).and_return(hostname)
-      expect(addrinfo).to receive(:getnameinfo).and_return([hostname, "0"]) if windows?
-      expect(mixin.canonicalize_hostname(hostname)).to eql(hostname)
+    [
+      {
+        desc: "canonname == initial hostname returns those",
+        initial_hostname: "fullhostname.example.com",
+        canonname: "fullhostname.example.com",
+        final_hostname: "fullhostname.example.com",
+      },
+      {
+        desc: "canonname(hostname) => fqdn returns fqdn",
+        initial_hostname: "hostnamepart",
+        canonname: "hostnamepart.example.com",
+        final_hostname: "hostnamepart.example.com",
+      },
+      {
+        desc: "hostname only canonname, getnameinfo is tried and succeeds",
+        initial_hostname: "hostnamepart2",
+        canonname: "hostnamepart2",
+        nameinfo: "hostnamepart2.example.com",
+        final_hostname: "hostnamepart2.example.com",
+      },
+      {
+        desc: "hostname only canonname, getnameinfo returns ip => original hostname",
+        initial_hostname: "hostnameip.example.com",
+        canonname: "hostnameip", # totally contrived
+        nameinfo: "192.168.1.1",
+        final_hostname: "hostnameip.example.com",
+      }
+    ].each do |example_hash|
+      # this is a brittle set of tests deliberately intended to discourage modifying
+      # this API (see the note in the code on the necessity of manual testing)
+      example example_hash[:desc] do
+        addrinfo = instance_double(Addrinfo)
+        expect(Addrinfo).to receive(:getaddrinfo)
+          .with(example_hash[:initial_hostname], nil, nil, nil, nil, Socket::AI_CANONNAME)
+          .and_return([addrinfo])
+        expect(addrinfo).to receive(:canonname).and_return(example_hash[:canonname])
+
+        # only expect this call if :nameinfo key is set, otherwise code should not
+        # fall through to getnameinfo
+        if example_hash[:nameinfo]
+          expect(addrinfo).to receive(:getnameinfo).and_return([example_hash[:nameinfo], "0"])
+        end
+
+        # the actual input and output for #canonicalize_hostname method
+        expect(mixin.canonicalize_hostname(example_hash[:initial_hostname]))
+          .to eql(example_hash[:final_hostname])
+      end
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
node['fqdn'] missing the DNS Suffix on windows nodes

If `canonname` includes multiple parts (`'.'`), then assume that that is a FQDN and return.

Otherwise, use `getnameinfo` as a fallback. If that return value is not an IP, return it.

If all else fails, just return what we originally received as an argument.

## Related Issue
Internal issue: CHEF-605

Broken in PR [#1705](https://github.com/chef/ohai/pull/1705)

Fixes [#1733](https://github.com/chef/ohai/issues/1733)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
