### PR TITLE
Detect QEMU virtualization on Darwin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For information on contributing to this project see <https://github.com/chef/che
 
 1. Fork it
 1. Create your feature branch (git checkout -b my-new-feature)
-1. Commit your changes (git commit -am 'Add some feature')
+1. Commit your changes (git commit -am 'Add some feature' --signoff)
 1. Run the tests `bundle exec rake spec`
 1. Run the style tests `bundle exec rake style`
 1. Push to the branch (git push origin my-new-feature)

--- a/lib/ohai/plugins/darwin/virtualization.rb
+++ b/lib/ohai/plugins/darwin/virtualization.rb
@@ -43,6 +43,10 @@ Ohai.plugin(:Virtualization) do
     which("docker")
   end
 
+  def sysctl_exists?
+    which("sysctl")
+  end
+
   collect_data(:darwin) do
     virtualization Mash.new unless virtualization
     virtualization[:systems] ||= Mash.new
@@ -75,6 +79,11 @@ Ohai.plugin(:Virtualization) do
       virtualization[:system] = "vmware"
       virtualization[:role] = "guest"
       virtualization[:systems][:vmware] = "guest"
+    end
+
+    if sysctl_exists? && shell_out("sysctl -in kern.hv_vmm_present").stdout.strip.to_i == 1
+      virtualization[:system] = "qemu"
+      virtualization[:role] = "guest"
     end
 
     if ioreg_exists? && shell_out("ioreg -l").stdout.include?("pci1ab8,4000")

--- a/spec/unit/plugins/darwin/virtualization_spec.rb
+++ b/spec/unit/plugins/darwin/virtualization_spec.rb
@@ -76,6 +76,7 @@ describe Ohai::System, "Darwin virtualization platform" do
     allow(plugin).to receive(:collect_os).and_return(:darwin)
     allow(plugin).to receive(:prlctl_exists?).and_return(false)
     allow(plugin).to receive(:ioreg_exists?).and_return(false)
+    allow(plugin).to receive(:sysctl_exists?).and_return(false)
     allow(plugin).to receive(:vboxmanage_exists?).and_return(false)
     allow(plugin).to receive(:fusion_exists?).and_return(false)
     allow(plugin).to receive(:docker_exists?).and_return(false)
@@ -111,6 +112,14 @@ describe Ohai::System, "Darwin virtualization platform" do
       expect(plugin[:virtualization][:system]).to eq("vmware")
       expect(plugin[:virtualization][:role]).to eq("guest")
       expect(plugin[:virtualization][:systems][:vmware]).to eq("guest")
+    end
+
+    it "sets qemu guest if kern.hv_vmm_present equals 1" do
+      allow(plugin).to receive(:sysctl_exists?).and_return(true)
+      allow(plugin).to receive(:shell_out).with("sysctl -in kern.hv_vmm_present").and_return(mock_shell_out(0, "1\n", ""))
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("qemu")
+      expect(plugin[:virtualization][:role]).to eq("guest")
     end
 
     it "sets vbox host if /usr/local/bin/VBoxManage exists" do


### PR DESCRIPTION
This PR adds a check for whether a Darwin machine is running as a QEMU guest.

## Description

Apple added a [Virtualization Framework](https://developer.apple.com/documentation/virtualization) based on QEMU to recent releases of macOS. This has resulted in many more options, such as [UTM](https://github.com/utmapp/UTM) for organizations looking to run virtual macOS machines on Apple hardware.

One such organization appears to be Github, which seems to be adding Veertu VMs to their Github Actions runners. Unfortunately, Chef's `virtual?` helper fails to detect these machines as guests, since `ohai` isn't setting the role for QEMU VMs.

The XNU kernel added an Object ID named [kern.hv_vmm_present](https://github.com/apple/darwin-xnu/blob/main/bsd/kern/kern_sysctl.c#L4652), which returns 0 for physical hardware and 1 for virtual machines. This OID is present on x86 devices running macOS Big Sur (version 11) and all Apple ARM macOS devices. By shelling out to `sysctl`, we can use this OID to detect VMs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
