### PR TITLE
determine if we are an Apple Virtualization Framework guest

### DIFF
--- a/lib/ohai/plugins/darwin/virtualization.rb
+++ b/lib/ohai/plugins/darwin/virtualization.rb
@@ -96,7 +96,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:systems][:parallels] = "host"
     end
 
-    if hardware['machine_model'].include? 'VirtualMac'
+    if hardware["machine_model"].include? "VirtualMac"
       virtualization[:system] = "apple"
       virtualization[:role] = "guest"
     end

--- a/lib/ohai/plugins/darwin/virtualization.rb
+++ b/lib/ohai/plugins/darwin/virtualization.rb
@@ -95,5 +95,10 @@ Ohai.plugin(:Virtualization) do
       virtualization[:role] = "host"
       virtualization[:systems][:parallels] = "host"
     end
+
+    if hardware['machine_model'].include? 'VirtualMac'
+      virtualization[:system] = "apple"
+      virtualization[:role] = "guest"
+    end
   end
 end

--- a/spec/unit/plugins/darwin/virtualization_spec.rb
+++ b/spec/unit/plugins/darwin/virtualization_spec.rb
@@ -82,6 +82,7 @@ describe Ohai::System, "Darwin virtualization platform" do
     allow(plugin).to receive(:docker_exists?).and_return(false)
     plugin[:hardware] = Mash.new
     plugin[:hardware][:boot_rom_version] = "not_a_vm"
+    plugin[:hardware][:machine_model] = "not_a_vm"
   end
 
   describe "when detecting OS X virtualization" do
@@ -180,6 +181,13 @@ describe Ohai::System, "Darwin virtualization platform" do
       allow(plugin).to receive(:shell_out).with("ioreg -l").and_return(shellout)
       plugin.run
       expect(plugin[:virtualization]).to eq({ "systems" => {} })
+    end
+
+    it "sets apple guest if hardware attributes mention VirtualMac" do
+      plugin[:hardware][:machine_model] = "VirtualMac2,1"
+      plugin.run
+      expect(plugin[:virtualization][:system]).to eq("apple")
+      expect(plugin[:virtualization][:role]).to eq("guest")
     end
   end
 end


### PR DESCRIPTION
Determine if we are an Apple Virtualization Framework guest based on `machine_model` data.

## Description
Apple provides a virtualization framework that supports arm64 and x86_64 guests depending on the host hardware. The `virtual?` method does not work if we are outside the Vagrant paradigm, so this change looks for the specific substring Apple sets in `machine_model` when creating guest hardware. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
