### PR TITLE
Pinning FFI to a looser version to overcome a problem on Windows

### DIFF
--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-config", ">= 14.12", "< 18"
   s.add_dependency "chef-utils", ">= 16.0", "< 18"
-  s.add_dependency "ffi"
+  s.add_dependency "ffi", "~> 1.9"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "ipaddress"
   s.add_dependency "mixlib-cli", ">= 1.7.0" # 1.7+ needed to support passing multiple options


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
When we pull in FFI 1.16.3 it does bad things to Windows. It causes registry monkey_patch to be overwritten by the base class so encoding fails on registry calls with glyphs in the key names (like having a key name like B@nch instead of Branch). 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
