### PR TITLE
Reverting FFI because 1.16.3 breaks Windows Registry monkey patches

### DIFF
--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
-        ruby: ['2.7', '3.0']
+        ruby: ['3.0']
     name: Exec Ohai on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.0
         bundler-cache: true
     - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
     - run: bundle exec chefstyle

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        ruby: ['2.7', '3.0']
+        ruby: ['3.0']
     name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-config", ">= 14.12", "< 18"
   s.add_dependency "chef-utils", ">= 16.0", "< 18"
-  s.add_dependency "ffi"
+  s.add_dependency "ffi", ">= 1.15.5"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "ipaddress"
   s.add_dependency "mixlib-cli", ">= 1.7.0" # 1.7+ needed to support passing multiple options

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-config", ">= 14.12", "< 18"
   s.add_dependency "chef-utils", ">= 16.0", "< 18"
-  s.add_dependency "ffi", ">= 1.15.5"
+  s.add_dependency "ffi", "~> 1.9"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "ipaddress"
   s.add_dependency "mixlib-cli", ">= 1.7.0" # 1.7+ needed to support passing multiple options


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We updated the FFI dependency here to 1.16.3. That required updating Chef-17 to use FFI 1.16.3. As a consequence of that update in Chef-17, the windows registry monkey patch stopped loading and that lead to a recurrence of the error that the monkey patch was fixing to begin with. We spent a fair bit of time trying to debug the issue and ultimately decided to fall back since Chef-17 was going to EOL in 6 months. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
