### PR TITLE
[lspci] Fix handling of more than one PCIe domain

### DIFF
--- a/lib/ohai/plugins/linux/lspci.rb
+++ b/lib/ohai/plugins/linux/lspci.rb
@@ -51,10 +51,14 @@ Ohai.plugin(:Lspci) do
 
       case dev[0]
       when "Device" # There are two different Device tags
-        if ( tmp = dev[1].match(/(#{hh}:#{hh}.#{h})/) )
+        if ( tmp = dev[1].match(/(#{hhhh}:)?(#{hh}:#{hh}\.#{h})/) )
           # We have a device id
           d_id = tmp[0] # From now on we will need this id
           devices[d_id] = Mash.new
+          if tmp[1]
+            # We have a root complex
+            devices[d_id]["root_port"] = tmp[1][0..-2]
+          end
         else
           standard_form(devices, d_id, hhhh, "device", dev[1])
         end

--- a/spec/unit/plugins/linux/lspci_spec.rb
+++ b/spec/unit/plugins/linux/lspci_spec.rb
@@ -86,6 +86,14 @@ describe Ohai::System, "Linux lspci plugin" do
       Driver:	nvme
       Module:	nvme
       NUMANode:	0
+
+      Device:	0005:00:00.0
+      Class:  PCI bridge [0604]
+      Vendor: Intel Corporation [8086]
+      Device: C620 Series Chipset Family PCI Express Root Port #1 [a190]
+      Rev:    f9
+      Driver: pcieport
+      NUMANode:       0
     LSPCI
     allow(plugin).to receive(:shell_out).with("lspci -vnnmk").and_return(
       mock_shell_out(0, @stdout, "")
@@ -96,7 +104,7 @@ describe Ohai::System, "Linux lspci plugin" do
     it "lists all devices" do
       plugin.run
       expect(plugin[:pci].keys).to eq(
-        ["00:1f.3", "00:1f.4", "00:1f.6", "02:00.0", "04:00.0", "05:00.0"]
+        ["00:1f.3", "00:1f.4", "00:1f.6", "02:00.0", "04:00.0", "05:00.0", "0005:00:00.0"]
       )
     end
 
@@ -128,6 +136,12 @@ describe Ohai::System, "Linux lspci plugin" do
       plugin.run
       expect(plugin[:pci]["04:00.0"]["driver"]).to eq(["iwlwifi"])
       expect(plugin[:pci]["04:00.0"]["module"]).to eq(["iwlwifi"])
+    end
+
+    it "populates the root port field" do
+      plugin.run
+      expect(plugin[:pci]["0005:00:00.0"]["driver"]).to eq(["pcieport"])
+      expect(plugin[:pci]["0005:00:00.0"]["root_port"]).to eq("0005")
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
(sorry, I'm using domain and root port interchangeably. Maybe domain is more correct, if so I can update the code to use that instead of `root_port`)

I'm guessing most machines only have one PCIe root port, but things like ARM hosts tend to have more, and that breaks as it creates collisions.

As we want to keep backwards compatibility, and `lspci` is run with the defaults that doesn't show the root port if it's `0000`, only add it when it's non-zero, and also add it as a new extra field called `root_port` to denote the fact that there is one (useful when using the BDF to find files on disk, as when there is no `root_port`, one needs to add the extra `0000:`.

More detailed explanation I wrote on the slack channel: On Linux, we run `lspci -vnnmk`, which will show the BDF in the first `Device:` field. So the first bug is that the regular expression on https://github.com/chef/ohai/blob/main/lib/ohai/plugins/linux/lspci.rb#L54 is missing a `\` before the `.`, therefore will will match `0001:02:03.4` as `01:02:03` which is plain broken. But fixing that we end up with `02:03.4` which is also plain wrong as it loses the root complex. I see a few ways we could fix this:

1. Highly disruptive: we add -D to lspci, which means we'll always get the root complex even when it's 0000 . This is terrible 'cause it will basically break everything
2. We do this but only with an option in ohai. Less terrible, but means people have to know about that option
3. We do this but only when we notice more than one root complex. That's not really doable
4. We add a new field, root_complex in the PCI structure, which is 0000 by default and the actual root complex for everything else

I like 4 the most, as it mirrors closely what lspci does (https://github.com/pciutils/pciutils/blob/master/lspci.c#L285) or maybe
5. We do it the same way lspci does it: if the root complex is 0, we just store the BDF as the ID, if it's not, we store the root complex + BDF we can't really do 4 'cause we might have collisions... Like if you have 0000:01:02.3 and 0001:01:02.3 then they have to be stored differently. So we can either do: Option A: 01:02.3 and 0001:01:02.3 (this can co-exist with everything today) Option B: 00000:1:02.3 and 0001:01:02.3 (this most likely needs to become pci2)


Test Plan:
Before:
```
$ ohai | jq .pci\|keys
[
  "00:00.0",
  "01:00.0",
  "01:00.1",
  "02:00:0",
  "04:00:0",
  "08:00:0",
  "08:01:0",
  "08:02:0",
  "08:03:0",
  "08:04:0",
  "08:05:0",
  "09:00:0",
  "09:01:0"
]
```

After:
```
$ ohai | jq .pci\|keys
[
  "0002:00:00.0",
  "0004:00:00.0",
  "0008:00:00.0",
  "0008:01:00.0",
  "0008:02:01.0",
  "0008:02:02.0",
  "0008:03:00.0",
  "0008:04:00.0",
  "0008:05:00.0",
  "0009:00:00.0",
  "0009:01:00.0",
  "00:00.0",
  "01:00.0",
  "01:00.1"
]
```

## Related Issue
pci collection should always include the domain #1693

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
