### PR TITLE
cpu: Fix issues with newer versions of lscpu

### DIFF
--- a/spec/data/plugins/cpuinfo-aarch64-guest-kvm-rhel9.output
+++ b/spec/data/plugins/cpuinfo-aarch64-guest-kvm-rhel9.output
@@ -1,0 +1,18 @@
+processor	: 0
+BogoMIPS	: 80.00
+Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
+CPU implementer	: 0x50
+CPU architecture: 8
+CPU variant	: 0x3
+CPU part	: 0x000
+CPU revision	: 2
+
+processor	: 1
+BogoMIPS	: 80.00
+Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
+CPU implementer	: 0x50
+CPU architecture: 8
+CPU variant	: 0x3
+CPU part	: 0x000
+CPU revision	: 2
+

--- a/spec/data/plugins/cpuinfo-ppc64le-p9-guest-kvm-rhel9.output
+++ b/spec/data/plugins/cpuinfo-ppc64le-p9-guest-kvm-rhel9.output
@@ -1,0 +1,15 @@
+processor	: 0
+cpu		: POWER9 (architected), altivec supported
+clock		: 2200.000000MHz
+revision	: 2.2 (pvr 004e 1202)
+
+processor	: 1
+cpu		: POWER9 (architected), altivec supported
+clock		: 2200.000000MHz
+revision	: 2.2 (pvr 004e 1202)
+
+timebase	: 512000000
+platform	: pSeries
+model		: IBM pSeries (emulated by qemu)
+machine		: CHRP IBM pSeries (emulated by qemu)
+MMU		: Radix

--- a/spec/data/plugins/cpuinfo-x86-guest-kvm-nested-rhel9.output
+++ b/spec/data/plugins/cpuinfo-x86-guest-kvm-nested-rhel9.output
@@ -1,0 +1,55 @@
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 60
+model name      : Intel Core Processor (Haswell, no TSX, IBRS)
+stepping        : 1
+microcode       : 0x1
+cpu MHz         : 2394.454
+cache size      : 16384 KB
+physical id     : 0
+siblings        : 1
+core id         : 0
+cpu cores       : 1
+apicid          : 0
+initial apicid  : 0
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 13
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid tsc_known_freq pni pclmulqdq vmx ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt arat md_clear
+vmx flags       : vnmi preemption_timer posted_intr invvpid ept_x_only ept_ad ept_1gb flexpriority apicv tsc_offset vtpr mtf vapic ept vpid unrestricted_guest vapic_reg vid pml
+bugs            : cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit srbds mmio_unknown
+bogomips        : 4788.90
+clflush size    : 64
+cache_alignment : 64
+address sizes   : 46 bits physical, 48 bits virtual
+power management:
+
+processor       : 1
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 60
+model name      : Intel Core Processor (Haswell, no TSX, IBRS)
+stepping        : 1
+microcode       : 0x1
+cpu MHz         : 2394.454
+cache size      : 16384 KB
+physical id     : 1
+siblings        : 1
+core id         : 0
+cpu cores       : 1
+apicid          : 1
+initial apicid  : 1
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 13
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid tsc_known_freq pni pclmulqdq vmx ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt arat md_clear
+vmx flags       : vnmi preemption_timer posted_intr invvpid ept_x_only ept_ad ept_1gb flexpriority apicv tsc_offset vtpr mtf vapic ept vpid unrestricted_guest vapic_reg vid pml
+bugs            : cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit srbds mmio_unknown
+bogomips        : 4788.90
+clflush size    : 64
+cache_alignment : 64
+address sizes   : 46 bits physical, 48 bits virtual
+power management:

--- a/spec/data/plugins/lscpu-aarch64-guest-kvm-cores-rhel9.output
+++ b/spec/data/plugins/lscpu-aarch64-guest-kvm-cores-rhel9.output
@@ -1,0 +1,6 @@
+# The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting usually from zero.
+# CPU,Core,Socket
+0,0,0
+1,1,0

--- a/spec/data/plugins/lscpu-aarch64-guest-kvm-rhel9.output
+++ b/spec/data/plugins/lscpu-aarch64-guest-kvm-rhel9.output
@@ -1,0 +1,29 @@
+Architecture:                    aarch64
+CPU op-mode(s):                  32-bit, 64-bit
+Byte Order:                      Little Endian
+CPU(s):                          2
+On-line CPU(s) list:             0,1
+Vendor ID:                       APM
+BIOS Vendor ID:                  QEMU
+BIOS Model name:                 virt-rhel7.6.0
+Model:                           2
+Thread(s) per core:              1
+Core(s) per cluster:             2
+Socket(s):                       2
+Cluster(s):                      1
+Stepping:                        0x3
+BogoMIPS:                        80.00
+Flags:                           fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
+NUMA node(s):                    1
+NUMA node0 CPU(s):               0,1
+Vulnerability Itlb multihit:     Not affected
+Vulnerability L1tf:              Not affected
+Vulnerability Mds:               Not affected
+Vulnerability Meltdown:          Mitigation; PTI
+Vulnerability Mmio stale data:   Not affected
+Vulnerability Retbleed:          Not affected
+Vulnerability Spec store bypass: Vulnerable
+Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
+Vulnerability Spectre v2:        Vulnerable
+Vulnerability Srbds:             Not affected
+Vulnerability Tsx async abort:   Not affected

--- a/spec/data/plugins/lscpu-aarch64-host-rhel9.output
+++ b/spec/data/plugins/lscpu-aarch64-host-rhel9.output
@@ -1,0 +1,34 @@
+Architecture:                    aarch64
+CPU op-mode(s):                  32-bit, 64-bit
+Byte Order:                      Little Endian
+CPU(s):                          32
+On-line CPU(s) list:             0-31
+Vendor ID:                       APM
+BIOS Vendor ID:                  Ampere(TM)
+BIOS Model name:                 eMAG 
+Model:                           2
+Thread(s) per core:              1
+Core(s) per socket:              32
+Socket(s):                       1
+Stepping:                        0x3
+Frequency boost:                 disabled
+CPU max MHz:                     3000.0000
+CPU min MHz:                     375.0000
+BogoMIPS:                        80.00
+Flags:                           fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
+L1d cache:                       1 MiB (32 instances)
+L1i cache:                       1 MiB (32 instances)
+L2 cache:                        4 MiB (16 instances)
+NUMA node(s):                    1
+NUMA node0 CPU(s):               0-31
+Vulnerability Itlb multihit:     Not affected
+Vulnerability L1tf:              Not affected
+Vulnerability Mds:               Not affected
+Vulnerability Meltdown:          Mitigation; PTI
+Vulnerability Mmio stale data:   Not affected
+Vulnerability Retbleed:          Not affected
+Vulnerability Spec store bypass: Vulnerable
+Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
+Vulnerability Spectre v2:        Vulnerable
+Vulnerability Srbds:             Not affected
+Vulnerability Tsx async abort:   Not affected

--- a/spec/data/plugins/lscpu-ppc64le-p8-host-debian12.output
+++ b/spec/data/plugins/lscpu-ppc64le-p8-host-debian12.output
@@ -1,0 +1,34 @@
+Architecture:                    ppc64le
+Byte Order:                      Little Endian
+CPU(s):                          160
+On-line CPU(s) list:             0,8,16,24,32,40,48,56,64,72,80,88,96,104,112,120,128,136,144,152
+Off-line CPU(s) list:            1-7,9-15,17-23,25-31,33-39,41-47,49-55,57-63,65-71,73-79,81-87,89-95,97-103,105-111,11
+9,121-127,129-135,137-143,145-151,153-159
+Model name:                      POWER8E (raw), altivec supported
+Model:                           2.1 (pvr 004b 0201)
+Thread(s) per core:              1
+Core(s) per socket:              5
+Socket(s):                       4
+CPU(s) scaling MHz:              100%
+CPU max MHz:                     3690.0000
+CPU min MHz:                     2061.0000
+L1d cache:                       1.3 MiB (20 instances)
+L1i cache:                       640 KiB (20 instances)
+L2 cache:                        10 MiB (20 instances)
+L3 cache:                        160 MiB (20 instances)
+NUMA node(s):                    4
+NUMA node0 CPU(s):               0,8,16,24,32
+NUMA node1 CPU(s):               40,48,56,64,72
+NUMA node16 CPU(s):              80,88,96,104,112
+NUMA node17 CPU(s):              120,128,136,144,152
+Vulnerability Itlb multihit:     Not affected
+Vulnerability L1tf:              Not affected
+Vulnerability Mds:               Not affected
+Vulnerability Meltdown:          Mitigation; RFI Flush
+Vulnerability Mmio stale data:   Not affected
+Vulnerability Retbleed:          Not affected
+Vulnerability Spec store bypass: Mitigation; Kernel entry/exit barrier (hwsync)
+Vulnerability Spectre v1:        Mitigation; __user pointer sanitization, ori31 speculation barrier enabled
+Vulnerability Spectre v2:        Mitigation; Indirect branch cache disabled, Software link stack flush
+Vulnerability Srbds:             Not affected
+Vulnerability Tsx async abort:   Not affected

--- a/spec/data/plugins/lscpu-ppc64le-p9-guest-kvm-cores-rhel9.output
+++ b/spec/data/plugins/lscpu-ppc64le-p9-guest-kvm-cores-rhel9.output
@@ -1,0 +1,6 @@
+# The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting usually from zero.
+# CPU,Core,Socket
+0,0,0
+1,1,1

--- a/spec/data/plugins/lscpu-ppc64le-p9-guest-kvm-rhel9.output
+++ b/spec/data/plugins/lscpu-ppc64le-p9-guest-kvm-rhel9.output
@@ -1,0 +1,26 @@
+Architecture:                    ppc64le
+Byte Order:                      Little Endian
+CPU(s):                          2
+On-line CPU(s) list:             0,1
+Model name:                      POWER9 (architected), altivec supported
+Model:                           2.2 (pvr 004e 1202)
+Thread(s) per core:              1
+Core(s) per socket:              1
+Socket(s):                       2
+Hypervisor vendor:               KVM
+Virtualization type:             para
+L1d cache:                       64 KiB (2 instances)
+L1i cache:                       64 KiB (2 instances)
+NUMA node(s):                    1
+NUMA node0 CPU(s):               0,1
+Vulnerability Itlb multihit:     Not affected
+Vulnerability L1tf:              Mitigation; RFI Flush
+Vulnerability Mds:               Not affected
+Vulnerability Meltdown:          Mitigation; RFI Flush
+Vulnerability Mmio stale data:   Not affected
+Vulnerability Retbleed:          Not affected
+Vulnerability Spec store bypass: Mitigation; Kernel entry/exit barrier (eieio)
+Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
+Vulnerability Spectre v2:        Vulnerable
+Vulnerability Srbds:             Not affected
+Vulnerability Tsx async abort:   Not affected

--- a/spec/data/plugins/lscpu-ppc64le-p9-host-rhel9.output
+++ b/spec/data/plugins/lscpu-ppc64le-p9-host-rhel9.output
@@ -1,0 +1,34 @@
+Architecture:                    ppc64le
+Byte Order:                      Little Endian
+CPU(s):                          128
+On-line CPU(s) list:             0-127
+Model name:                      POWER9, altivec supported
+Model:                           2.3 (pvr 004e 1203)
+Thread(s) per core:              4
+Core(s) per socket:              16
+Socket(s):                       2
+Frequency boost:                 enabled
+CPU max MHz:                     3800.0000
+CPU min MHz:                     2300.0000
+L1d cache:                       1 MiB (32 instances)
+L1i cache:                       1 MiB (32 instances)
+L2 cache:                        8 MiB (16 instances)
+L3 cache:                        160 MiB (16 instances)
+NUMA node(s):                    6
+NUMA node0 CPU(s):               0-63
+NUMA node8 CPU(s):               64-127
+NUMA node252 CPU(s):             
+NUMA node253 CPU(s):             
+NUMA node254 CPU(s):             
+NUMA node255 CPU(s):             
+Vulnerability Itlb multihit:     Not affected
+Vulnerability L1tf:              Not affected
+Vulnerability Mds:               Not affected
+Vulnerability Meltdown:          Mitigation; RFI Flush, L1D private per thread
+Vulnerability Mmio stale data:   Not affected
+Vulnerability Retbleed:          Not affected
+Vulnerability Spec store bypass: Mitigation; Kernel entry/exit barrier (eieio)
+Vulnerability Spectre v1:        Mitigation; __user pointer sanitization, ori31 speculation barrier enabled
+Vulnerability Spectre v2:        Mitigation; Software count cache flush (hardware accelerated), Software link stack flush
+Vulnerability Srbds:             Not affected
+Vulnerability Tsx async abort:   Not affected

--- a/spec/data/plugins/lscpu-x86-guest-kvm-nested-cores-rhel9.output
+++ b/spec/data/plugins/lscpu-x86-guest-kvm-nested-cores-rhel9.output
@@ -1,0 +1,6 @@
+# The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting usually from zero.
+# CPU,Core,Socket
+0,0,0
+1,1,1

--- a/spec/data/plugins/lscpu-x86-guest-kvm-nested-rhel9.output
+++ b/spec/data/plugins/lscpu-x86-guest-kvm-nested-rhel9.output
@@ -1,0 +1,38 @@
+Architecture:                    x86_64
+CPU op-mode(s):                  32-bit, 64-bit
+Address sizes:                   46 bits physical, 48 bits virtual
+Byte Order:                      Little Endian
+CPU(s):                          2
+On-line CPU(s) list:             0,1
+Vendor ID:                       GenuineIntel
+BIOS Vendor ID:                  Red Hat
+Model name:                      Intel Core Processor (Haswell, no TSX, IBRS)
+BIOS Model name:                 RHEL 7.6.0 PC (i440FX + PIIX, 1996)
+CPU family:                      6
+Model:                           60
+Thread(s) per core:              1
+Core(s) per socket:              1
+Socket(s):                       2
+Stepping:                        1
+BogoMIPS:                        4788.90
+Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid tsc_known_freq pni pclmulqdq vmx ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt arat md_clear
+Virtualization:                  VT-x
+Hypervisor vendor:               KVM
+Virtualization type:             full
+L1d cache:                       64 KiB (2 instances)
+L1i cache:                       64 KiB (2 instances)
+L2 cache:                        8 MiB (2 instances)
+L3 cache:                        32 MiB (2 instances)
+NUMA node(s):                    1
+NUMA node0 CPU(s):               0,1
+Vulnerability Itlb multihit:     KVM: Mitigation: VMX disabled
+Vulnerability L1tf:              Mitigation; PTE Inversion; VMX conditional cache flushes, SMT disabled
+Vulnerability Mds:               Mitigation; Clear CPU buffers; SMT Host state unknown
+Vulnerability Meltdown:          Mitigation; PTI
+Vulnerability Mmio stale data:   Unknown: No mitigations
+Vulnerability Retbleed:          Not affected
+Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl
+Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
+Vulnerability Spectre v2:        Mitigation; Retpolines, IBPB conditional, IBRS_FW, STIBP disabled, RSB filling, PBRSB-eIBRS Not affected
+Vulnerability Srbds:             Unknown: Dependent on hypervisor status
+Vulnerability Tsx async abort:   Not affected

--- a/spec/data/plugins/lscpu-x86-host-rhel9.output
+++ b/spec/data/plugins/lscpu-x86-host-rhel9.output
@@ -1,0 +1,38 @@
+Architecture:                    x86_64
+CPU op-mode(s):                  32-bit, 64-bit
+Address sizes:                   40 bits physical, 48 bits virtual
+Byte Order:                      Little Endian
+CPU(s):                          12
+On-line CPU(s) list:             0-11
+Vendor ID:                       GenuineIntel
+Model name:                      Intel(R) Xeon(R) CPU           X5680  @ 3.33GHz
+CPU family:                      6
+Model:                           44
+Thread(s) per core:              1
+Core(s) per socket:              6
+Socket(s):                       2
+Stepping:                        2
+Frequency boost:                 enabled
+CPU max MHz:                     3326.0000
+CPU min MHz:                     1596.0000
+BogoMIPS:                        6649.64
+Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 popcnt aes lahf_lm epb pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid dtherm ida arat flush_l1d
+Virtualization:                  VT-x
+L1d cache:                       384 KiB (12 instances)
+L1i cache:                       384 KiB (12 instances)
+L2 cache:                        3 MiB (12 instances)
+L3 cache:                        24 MiB (2 instances)
+NUMA node(s):                    2
+NUMA node0 CPU(s):               0,2,4,6,8,10
+NUMA node1 CPU(s):               1,3,5,7,9,11
+Vulnerability Itlb multihit:     KVM: Mitigation: VMX disabled
+Vulnerability L1tf:              Mitigation; PTE Inversion; VMX conditional cache flushes, SMT disabled
+Vulnerability Mds:               Vulnerable: Clear CPU buffers attempted, no microcode; SMT disabled
+Vulnerability Meltdown:          Mitigation; PTI
+Vulnerability Mmio stale data:   Not affected
+Vulnerability Retbleed:          Not affected
+Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl
+Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
+Vulnerability Spectre v2:        Mitigation; Retpolines, IBPB conditional, IBRS_FW, RSB filling, PBRSB-eIBRS Not affected
+Vulnerability Srbds:             Not affected
+Vulnerability Tsx async abort:   Not affected


### PR DESCRIPTION
Starting in util-linux v2.36, the output of lscpu changed which introduced some bugs in some platforms. To work around this, the previous output can be retained if the lscpu command is piped to something else. To work around that, this just pipes the output to cat.

This fixes #1805

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
