### PR TITLE
Updating FFI support

### DIFF
--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2']
     name: Exec Ohai on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.0
         bundler-cache: true
     - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
     - run: bundle exec rake style

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2']
     name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-performance
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Exclude:
     - "spec/data/**/*"
     - "vendor/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "ch
 group :development do
   install_if -> { Gem::Version.new("3.3.0").to_s >= (RUBY_VERSION).to_s } do
     gem "racc", "~> 1.8.0"
+    gem "base64"
   end
   gem "cookstyle", ">= 7.32.8"
   gem "ipaddr_extensions"

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "ch
 group :development do
   install_if -> { Gem::Version.new("3.3.0").to_s >= (RUBY_VERSION).to_s } do
     gem "racc", "~> 1.8.0"
+  end
+  install_if -> { Gem::Version.new("3.4.0").to_s >= (RUBY_VERSION).to_s } do
+    gem "racc", "~> 1.8.0"
     gem "base64"
   end
   gem "cookstyle", ">= 7.32.8"

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ gem "chef-config", git: "https://github.com/chef/chef", branch: "main", glob: "c
 gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "chef-utils/chef-utils.gemspec"
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
+  install_if -> { Gem::Version.new("3.3.0") >= (RUBY_VERSION) } do
+    gem "racc", "~> 1.8.0"
+  end
   gem "cookstyle", ">= 7.32.8"
   gem "ipaddr_extensions"
   gem "rake", ">= 10.1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "chef-config", git: "https://github.com/chef/chef", branch: "main", glob: "c
 gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "chef-utils/chef-utils.gemspec"
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
-  install_if -> { Gem::Version.new("3.3.0") >= (RUBY_VERSION) } do
+  install_if -> { Gem::Version.new("3.3.0").to_i >= (RUBY_VERSION).to_i } do
     gem "racc", "~> 1.8.0"
   end
   gem "cookstyle", ">= 7.32.8"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "chef-config", git: "https://github.com/chef/chef", branch: "main", glob: "c
 gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "chef-utils/chef-utils.gemspec"
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
-  install_if -> { Gem::Version.new("3.3.0").to_i >= (RUBY_VERSION).to_i } do
+  install_if -> { Gem::Version.new("3.3.0").to_s >= (RUBY_VERSION).to_s } do
     gem "racc", "~> 1.8.0"
   end
   gem "cookstyle", ">= 7.32.8"

--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,12 @@ gem "chef-config", git: "https://github.com/chef/chef", branch: "main", glob: "c
 gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "chef-utils/chef-utils.gemspec"
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
-  install_if -> { Gem::Version.new("3.3.0").to_s >= (RUBY_VERSION).to_s } do
-    gem "racc", "~> 1.8.0"
-  end
-  install_if -> { Gem::Version.new("3.4.0").to_s >= (RUBY_VERSION).to_s } do
+  install_if -> { Gem::Version.new(">= 3.4.0").to_s >= (RUBY_VERSION).to_s } do
     gem "racc", "~> 1.8.0"
     gem "base64"
+  end
+  install_if -> { Gem::Version.new(">= 3.3.0").to_s >= (RUBY_VERSION).to_s } do
+    gem "racc", "~> 1.8.0"
   end
   gem "cookstyle", ">= 7.32.8"
   gem "ipaddr_extensions"

--- a/Gemfile
+++ b/Gemfile
@@ -10,11 +10,11 @@ gem "chef-config", git: "https://github.com/chef/chef", branch: "main", glob: "c
 gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "chef-utils/chef-utils.gemspec"
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
-  install_if -> { Gem::Version.new(">= 3.4.0").to_s >= (RUBY_VERSION).to_s } do
+  install_if -> { Gem::Version.new("3.4").to_s >= (RUBY_VERSION).to_s } do
     gem "racc", "~> 1.8.0"
     gem "base64"
   end
-  install_if -> { Gem::Version.new(">= 3.3.0").to_s >= (RUBY_VERSION).to_s } do
+  install_if -> { Gem::Version.new("3.3").to_s >= (RUBY_VERSION).to_s } do
     gem "racc", "~> 1.8.0"
   end
   gem "cookstyle", ">= 7.32.8"

--- a/Rakefile
+++ b/Rakefile
@@ -22,8 +22,8 @@ begin
   RuboCop::RakeTask.new(:style) do |task|
     task.options += ["--display-cop-names", "--no-color"]
   end
-rescue LoadError
-  puts "cookstyle gem is not installed. bundle install first to make sure all dependencies are installed."
+  rescue LoadError => e
+    puts e.message
 end
 
 task :console do

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-config", ">= 14.12", "< 20"
   s.add_dependency "chef-utils", ">= 16.0", "< 20"
-  s.add_dependency "ffi", ">= 1.15.5", "<= 1.17.0"
+  s.add_dependency "ffi", ">= 1.15.5", "< 1.17.0"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "ipaddress"
   s.add_dependency "mixlib-cli", ">= 1.7.0" # 1.7+ needed to support passing multiple options
   s.add_dependency "mixlib-config", ">= 2.0", "< 4.0"
   s.add_dependency "mixlib-log", ">= 2.0.1", "< 4.0"
-  s.add_dependency "mixlib-shellout", "~> 3.2", ">= 3.2.5"
+  s.add_dependency "mixlib-shellout", "~> 3.3.6"
   s.add_dependency "plist", "~> 3.1"
   s.add_dependency "train-core"
   s.add_dependency "wmi-lite", "~> 1.0"

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://github.com/chef/ohai/"
 
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.0"
 
   s.add_dependency "chef-config", ">= 14.12", "< 20"
   s.add_dependency "chef-utils", ">= 16.0", "< 20"
-  s.add_dependency "ffi", "~> 1.9"
+  s.add_dependency "ffi", ">= 1.15.5", "<= 1.17.0"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "ipaddress"
   s.add_dependency "mixlib-cli", ">= 1.7.0" # 1.7+ needed to support passing multiple options


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Ohai hasn't been updated in a bit. It's current dependency on a stale version of ffi is causing errors in Chef-19. We also needed to update the supported Ruby versions

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
