### PR TITLE
Update ffi lock

### DIFF
--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -24,8 +24,34 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      # Note that ruby 3.0 is a special-case where the bundler is new-enough
+      # that ruby-setup won't force a newer version, but old enough to not
+      # honor BUNDLED_WITH in Gemfile.lock, and thus everything breaks.
+      #
+      # So, for Ruby 3.0 ONLY, we setup ruby wit bundler-cache set to false
+      # then manually update bundler before installing the bundle
+      - name: ruby-setup for most cases
+        if: matrix.ruby != '3.0'
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: ruby-setup for 3.0
+        if: matrix.ruby == '3.0'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: false
+      - name: work around for ruby 3.0 bundler
+        if: matrix.ruby == '3.0'
+        run: |
+          gem install bundler -v 2.5.22 --user-install
+          echo "GEM_PATH=$(ruby -e 'puts Gem.user_dir'):$GEM_PATH" >> $GITHUB_ENV
+          echo "BUNDLE_PATH=$(ruby -e 'puts Gem.user_dir')/bin" >> $GITHUB_ENV
+          echo "BUNDLE_BIN=$(ruby -e 'puts Gem.user_dir')/bin" >> $GITHUB_ENV
+          echo "$(ruby -e 'puts Gem.user_dir')/bin" >> $GITHUB_PATH
+      - name: bundle install for 3.0
+        if: matrix.ruby == '3.0'
+        run: bundle install
+        shell: bash
       - run: bundle exec ohai

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,8 +26,34 @@ jobs:
       RUBYOPT: '--disable-error_highlight'
     steps:
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      # Note that ruby 3.0 is a special-case where the bundler is new-enough
+      # that ruby-setup won't force a newer version, but old enough to not
+      # honor BUNDLED_WITH in Gemfile.lock, and thus everything breaks.
+      #
+      # So, for Ruby 3.0 ONLY, we setup ruby wit bundler-cache set to false
+      # then manually update bundler before installing the bundle
+      - name: ruby-setup for most cases
+        if: matrix.ruby != '3.0'
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: ruby-setup for 3.0
+        if: matrix.ruby == '3.0'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: false
+      - name: work around ruby 3.0 bundler
+        if: matrix.ruby == '3.0'
+        run: |
+          gem install bundler -v 2.5.22 --user-install
+          echo "GEM_PATH=$(ruby -e 'puts Gem.user_dir'):$GEM_PATH" >> $GITHUB_ENV
+          echo "BUNDLE_PATH=$(ruby -e 'puts Gem.user_dir')/bin" >> $GITHUB_ENV
+          echo "BUNDLE_BIN=$(ruby -e 'puts Gem.user_dir')/bin" >> $GITHUB_ENV
+          echo "$(ruby -e 'puts Gem.user_dir')/bin" >> $GITHUB_PATH
+      - name: bundle install for 3.0
+        if: matrix.ruby == '3.0'
+        run: bundle install
+        shell: bash
       - run: bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem "appbundler"
 gem "chef-config", git: "https://github.com/chef/chef", branch: "main", glob: "chef-config/chef-config.gemspec"
 gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "chef-utils/chef-utils.gemspec"
+gem "ffi", "~> 1.17", force_ruby_platform: true
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
   gem "cookstyle", ">= 7.32.8"

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-config", ">= 14.12", "< 20"
   s.add_dependency "chef-utils", ">= 16.0", "< 20"
-  s.add_dependency "ffi", ">= 1.15.5", "< 1.17.0"
+  s.add_dependency "ffi", ">= 1.15.5"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "ipaddress"
   s.add_dependency "mixlib-cli", ">= 1.7.0" # 1.7+ needed to support passing multiple options


### PR DESCRIPTION
Per https://github.com/ffi/ffi/issues/1139#issuecomment-2632381142

```shell
$ bundle update --conservative ffi
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Resolving dependencies...
Bundler attempted to update ffi but its version stayed the same
Bundle updated!
```

