### PR TITLE
add myself to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*            @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners
+*            @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners @jaymzh
 .expeditor/  @chef/infra-packages
 *.md         @chef/docs-team


### PR DESCRIPTION
Adding myself to code-owners until Progress can figure out what is going on with access via groups for external contributors, which they nuked

Signed-off-by: Phil Dibowitz <phil@ipom.com>
