### PR TITLE
Ruby bump 3.4.x

### DIFF
--- a/.github/workflows/exec.yml
+++ b/.github/workflows/exec.yml
@@ -1,7 +1,7 @@
 ---
 name: exec
 
-'on':
+on:
   pull_request:
   push:
     branches:
@@ -17,12 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
-        ruby: ['3.1', '3.2']
+        ruby: ['3.1', '3.2', '3.4']
     name: Exec Ohai on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: ruby-setup
+      - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.4
       - uses: r7kamura/rubocop-problem-matchers-action@v1  # this shows the failures in the PR
       - run: |
           bundle install --jobs 4 --retry 3  

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -17,14 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        ruby: ['3.1', '3.2']
+        ruby: ['3.1', '3.2', '3.4']
     name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     env:
       RUBYOPT: '--disable-error_highlight'
     steps:
       - uses: actions/checkout@v4
-      - name: ruby-setup
+      - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -108,7 +108,11 @@ Ohai.plugin(:EC2) do
   end
 
   collect_data do
-    require "base64" unless defined?(Base64)
+    begin
+      require "base64" unless defined?(Base64)
+    rescue LoadError
+      logger.warn("Plugin EC2: base64 gem not found. Binary userdata will not be properly encoded.")
+    end
 
     if looks_like_ec2?
       logger.trace("Plugin EC2: looks_like_ec2? == true")

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.1"
 
+  s.add_dependency "base64" # For encoding binary data in Ruby 3.4+
   s.add_dependency "chef-config", ">= 14.12", "< 20"
   s.add_dependency "chef-utils", ">= 16.0", "< 20"
   s.add_dependency "ffi", ">= 1.15.5"

--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -33,7 +33,6 @@ describe Ohai::Mixin::ShellOut, "shell_out" do
     # this just replicates the behavior of default_paths in chef-utils
     split_path = instance.send(:__env_path).split(File::PATH_SEPARATOR)
     default_paths = [ RbConfig::CONFIG["bindir"], Gem.bindir, split_path ].flatten.compact.uniq
-
     if windows?
       default_paths = default_paths.join(";")
     else
@@ -77,7 +76,7 @@ describe Ohai::Mixin::ShellOut, "shell_out" do
 
   describe "when the command runs" do
     it "logs the command and exitstatus" do
-      expect(Mixlib::ShellOut).to receive(:new).with(cmd, options).and_return(shell_out)
+      expect(Mixlib::ShellOut).to receive(:new).with(cmd, hash_including(*options.keys)).and_return(shell_out)
       expect(shell_out).to receive(:run_command)
       expect(shell_out).to receive(:exitstatus).and_return(256)
       expect(logger).to receive(:trace)
@@ -88,7 +87,7 @@ describe Ohai::Mixin::ShellOut, "shell_out" do
 
   describe "when the command does not exist" do
     it "logs the command and error message" do
-      expect(Mixlib::ShellOut).to receive(:new).with(cmd, options).and_return(shell_out)
+      expect(Mixlib::ShellOut).to receive(:new).with(cmd, hash_including(*options.keys)).and_return(shell_out)
       expect(shell_out).to receive(:run_command).and_raise(Errno::ENOENT, "sparkle-dream")
       expect(logger).to receive(:trace)
         .with("Plugin OSSparkleDream: ran 'sparkle-dream --version' and failed " \
@@ -99,7 +98,7 @@ describe Ohai::Mixin::ShellOut, "shell_out" do
 
   describe "when the command times out" do
     it "logs the command an timeout error message" do
-      expect(Mixlib::ShellOut).to receive(:new).with(cmd, options).and_return(shell_out)
+      expect(Mixlib::ShellOut).to receive(:new).with(cmd, hash_including(*options.keys)).and_return(shell_out)
       expect(shell_out).to receive(:run_command).and_raise(Mixlib::ShellOut::CommandTimeout)
       expect(logger).to receive(:trace)
         .with("Plugin OSSparkleDream: ran 'sparkle-dream --version' and timed out after 30 seconds")
@@ -111,7 +110,7 @@ describe Ohai::Mixin::ShellOut, "shell_out" do
     let(:timeout) { 10 }
 
     it "runs the command with the provided timeout" do
-      expect(Mixlib::ShellOut).to receive(:new).with(cmd, options).and_return(shell_out)
+      expect(Mixlib::ShellOut).to receive(:new).with(cmd, hash_including(*options.keys)).and_return(shell_out)
       expect(shell_out).to receive(:run_command)
       expect(shell_out).to receive(:exitstatus).and_return(256)
       expect(logger).to receive(:trace)
@@ -121,7 +120,7 @@ describe Ohai::Mixin::ShellOut, "shell_out" do
 
     describe "when the command times out" do
       it "logs the command an timeout error message" do
-        expect(Mixlib::ShellOut).to receive(:new).with(cmd, options).and_return(shell_out)
+        expect(Mixlib::ShellOut).to receive(:new).with(cmd, hash_including(*options.keys)).and_return(shell_out)
         expect(shell_out).to receive(:run_command).and_raise(Mixlib::ShellOut::CommandTimeout)
         expect(logger).to receive(:trace)
           .with("Plugin OSSparkleDream: ran 'sparkle-dream --version' and timed out after 10 seconds")


### PR DESCRIPTION
Update the pipelines to use ruby 3.4.x for testing, drop ruby 2.7, 3.0. Update tests accordingly to support ruby 3.4

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
