### PR TITLE
The filesystem plugin transition is finally over

### DIFF
--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -744,10 +744,6 @@ Ohai.plugin(:Filesystem) do
     fs_data["by_mountpoint"] = by_mountpoint
     fs_data["by_pair"] = by_pair
 
-    # Chef 16 added 'filesystem2'
-    # In Chef 17 we made 'filesystem' and 'filesystem2' match (both new-style)
-    # In Chef 18 we will drop 'filesystem2'
     filesystem fs_data
-    filesystem2 fs_data
   end
 end

--- a/spec/unit/plugins/windows/filesystem_spec.rb
+++ b/spec/unit/plugins/windows/filesystem_spec.rb
@@ -91,8 +91,6 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
         }.each do |k, v|
           expect(plugin[:filesystem]["by_pair"][",C:"][k]).to eq(v)
           expect(plugin[:filesystem]["by_pair"][",D:"][k]).to eq(v)
-          expect(plugin[:filesystem2]["by_pair"][",C:"][k]).to eq(v)
-          expect(plugin[:filesystem2]["by_pair"][",D:"][k]).to eq(v)
         end
       end
 
@@ -106,7 +104,6 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "encryption_status" => "FullyDecrypted",
         }.each do |k, v|
           expect(plugin[:filesystem]["by_pair"][",C:"][k]).to eq(v)
-          expect(plugin[:filesystem2]["by_pair"][",C:"][k]).to eq(v)
         end
 
         {
@@ -118,7 +115,6 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "encryption_status" => "EncryptionInProgress",
         }.each do |k, v|
           expect(plugin[:filesystem]["by_pair"][",D:"][k]).to eq(v)
-          expect(plugin[:filesystem2]["by_pair"][",D:"][k]).to eq(v)
         end
       end
     end
@@ -141,8 +137,6 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
         }.each do |k, v|
           expect(plugin[:filesystem]["by_pair"]["volume 0,C:"][k]).to eq(v)
           expect(plugin[:filesystem]["by_pair"]["volume 1,D:"][k]).to eq(v)
-          expect(plugin[:filesystem2]["by_pair"]["volume 0,C:"][k]).to eq(v)
-          expect(plugin[:filesystem2]["by_pair"]["volume 1,D:"][k]).to eq(v)
         end
       end
 
@@ -156,7 +150,6 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "encryption_status" => "FullyDecrypted",
         }.each do |k, v|
           expect(plugin[:filesystem]["by_pair"]["volume 0,C:"][k]).to eq(v)
-          expect(plugin[:filesystem2]["by_pair"]["volume 0,C:"][k]).to eq(v)
         end
 
         {
@@ -168,7 +161,6 @@ describe Ohai::System, "Windows Filesystem Plugin", :windows_only do
           "encryption_status" => "EncryptionInProgress",
         }.each do |k, v|
           expect(plugin[:filesystem]["by_pair"]["volume 1,D:"][k]).to eq(v)
-          expect(plugin[:filesystem2]["by_pair"]["volume 1,D:"][k]).to eq(v)
         end
       end
     end


### PR DESCRIPTION
In 2015, I wrote a new filesystem plugin (#559), because the original
one used non-unique keys and so the data was not only incomplete but
inconsistent. Since it was backwards incompatible, we called it
`filesystem2`, and agreed to a migration path.

That original PR only implemented it for linux, however, and it shortly
followed with #564 for Darwin/OSX.

The plan was, at that time to keep both for one major version (give
people the chance to migrate to fs2), then for one major version make
both names (`filesystem` and `filesystem2`) so that people could move
back to the name `filesystem`, and then we'd finally drop the
`filesystem2` name.

Unfortunately, other platforms never got FS2 support, so this got hairy.

In 2018 I wrote #181 which unified the various platforms' plugins so it
was easier to implement fs2 on more platforms. Shortly there after I
wrote #1266 that implemented fs2 for the rest of the unixes. And
finally, I wrote #1267 implemented Windows to filesystem2.

This was all still before Chef 17. For Chef 17 I wrote #1662 which
finally made windows have the new data in the original name, the
second-to-last-step. The plan being that in 18 we'd finally remove
the `filesystem2` name... but we forgot to do that.

This, is the final bit - remove all references to filesystem2.

Closes #1872

Signed-off-by: Phil Dibowitz <phil@ipom.com>
