### PR TITLE
Fixing network detection when using multipath route

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -578,6 +578,8 @@ Ohai.plugin(:Network) do
 
   # returns the macaddress for interface from a hash of interfaces (iface elsewhere in this file)
   def get_mac_for_interface(interfaces, interface)
+    return '00:00:00:00:00:00' if interfaces[interface][:flags].include?("LOOPBACK")
+
     interfaces[interface][:addresses].find { |k, v| v["family"] == "lladdr" }.first unless interfaces[interface][:addresses].nil? || interfaces[interface][:flags].include?("NOARP")
   end
 

--- a/spec/unit/plugins/linux/network_spec.rb
+++ b/spec/unit/plugins/linux/network_spec.rb
@@ -1260,6 +1260,48 @@ describe Ohai::System, "Linux Network Plugin" do
         end
       end
 
+      describe "when there're multipath default routes with a loopback src" do
+        let(:linux_ip_route) do
+          <<~EOM
+          default nhid 18 proto bgp src 10.116.201.76 metric 20 \\ nexthop via 10.117.201.1 dev eth0 weight 1 \\ nexthop via 10.117.202.1 dev eth1 weight 1
+          EOM
+        end
+
+        let(:linux_ip_addr) do
+          <<~EOM
+      1: lo: <LOOPBACK,UP,LOWER_UP> mtu 16436 qdisc noqueue state UNKNOWN
+          link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+          inet 127.0.0.1/8 scope host lo
+          inet 10.116.201.76/32 scope global lo
+          inet6 ::1/128 scope host
+             valid_lft forever preferred_lft forever
+      2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+          link/ether 12:31:3d:02:be:a2 brd ff:ff:ff:ff:ff:ff
+          inet 10.117.201.76/24 brd 10.117.201.255 scope global eth0
+          inet6 fe80::1031:3dff:fe02:bea2/64 scope link
+             valid_lft forever preferred_lft forever
+         inet6 2001:44b8:4160:8f00:a00:27ff:fe13:eacd/64 scope global dynamic
+             valid_lft 6128sec preferred_lft 2526sec
+      3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP
+          link/ether 00:aa:bb:cc:dd:ee brd ff:ff:ff:ff:ff:ff
+          inet 10.117.202.76/24 brd 10.117.202.255 scope global eth1
+          inet6 fe80::2e0:81ff:fe2b:48e7/64 scope link
+          inet6 1111:2222:3333:4444::2/64 scope global
+             valid_lft forever preferred_lft forever
+          inet6 1111:2222:3333:4444::3/64 scope global
+             valid_lft forever preferred_lft forever
+          EOM
+        end
+
+        before do
+          plugin.run
+        end
+
+        it 'finds the default interface' do
+          expect(plugin['network']['default_interface']).to eq('lo')
+        end
+      end
+
       describe "when there's a source field in a local route entry but it isnt in the default route" do
         let(:linux_ip_route) do
           <<~EOM


### PR DESCRIPTION
Some setup could have a multipath route with a src assigned to the loopback
In this situation, it fails to find a mac because there is none found on the loopback
Better early return 00:00:00:00:00:00 when checking for a mac on lo

## Description
In a setup with BGP and multipath routes with a src address defined on the loopback interface, `ohai network` returns an empty `interfaces` set
It fails in `get_mac_for_interface` raising an error because there is no `lladdr` address.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
