### PR TITLE
[backport #1909][18-stable] strip hostnamectl icons

### DIFF
--- a/lib/ohai/plugins/linux/hostnamectl.rb
+++ b/lib/ohai/plugins/linux/hostnamectl.rb
@@ -25,9 +25,17 @@ Ohai.plugin(:Hostnamectl) do
 
     hostnamectl_path = which("hostnamectl")
     if hostnamectl_path
+      re = /[^\p{ASCII}]/u
+
       shell_out(hostnamectl_path).stdout.split("\n").each do |line|
         key, val = line.split(": ", 2)
-        hostnamectl[key.chomp.lstrip.tr(" ", "_").downcase] = val
+
+        key = key.chomp.lstrip.tr(" ", "_").downcase
+
+        # strip visual icons produced by newer versions of systemd
+        val = val.gsub(re, "").squeeze(" ").strip
+
+        hostnamectl[key] = val
       end
     end
   end

--- a/spec/unit/plugins/linux/cpu_spec.rb
+++ b/spec/unit/plugins/linux/cpu_spec.rb
@@ -18,9 +18,7 @@
 
 require "spec_helper"
 
-shared_examples "Common cpu info" do |default_cpu, total_cpu, real_cpu, ls_cpu, architecture, cpu_opmodes, byte_order, cpus,
-  cpus_online, threads_per_core, cores_per_socket, sockets, numa_nodes, vendor_id, model, model_name, bogomips,
-  l1d_cache, l1i_cache, l2_cache, l3_cache, flags, numa_node_cpus|
+shared_examples "Common cpu info" do |default_cpu, total_cpu, real_cpu, ls_cpu, architecture, cpu_opmodes, byte_order, cpus, cpus_online, threads_per_core, cores_per_socket, sockets, numa_nodes, vendor_id, model, model_name, bogomips, l1d_cache, l1i_cache, l2_cache, l3_cache, flags, numa_node_cpus|
   describe "cpu" do
     it "has cpu[:total] equals to #{total_cpu}" do
       plugin.run
@@ -297,8 +295,7 @@ shared_examples "arm64 processor info" do |cpu_no, bogomips, features|
   end
 end
 
-shared_examples "ppc64le processor info" do |cpu_no, model_name, model, mhz, timebase, platform, machine_model,
-  machine, firmware, mmu|
+shared_examples "ppc64le processor info" do |cpu_no, model_name, model, mhz, timebase, platform, machine_model, machine, firmware, mmu|
   describe "ppc64le processor" do
     it "has model_name for cpu #{cpu_no}" do
       plugin.run


### PR DESCRIPTION
## Description
backport of #1909 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
