### PR TITLE
remove development and debug group gems

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -41,7 +41,7 @@ function Invoke-Build {
         $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
 
         Write-BuildLine " ** Configuring bundler for this build environment"
-        bundle config --local without integration deploy maintenance
+        bundle config --local without integration deploy maintenance development debug
         bundle config --local jobs 4
         bundle config --local retry 5
         bundle config --local silence_root_warning 1

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -42,7 +42,7 @@ do_build() {
 
     build_line "Setting GEM_PATH=$GEM_HOME"
     export GEM_PATH="$GEM_HOME"
-    bundle config --local without integration deploy maintenance
+    bundle config --local without integration deploy maintenance development debug
     bundle config --local jobs 4
     bundle config --local retry 5
     bundle config --local silence_root_warning 1


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
remove development and debug group gems from habitat plan file
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
