### PR TITLE
fix: Constrain ffi-yajl to < 3.0 for Ruby 3.2+ compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     # don't automatically rebase on every single time we're out of date with
     # base (whith is always) because it kills CI capacity
     rebase-strategy: disabled
+    ignore:
+      - dependency-name: "ffi-yajl"
+        # Locking to 2.x until ffi-yajl 3.x gets the allocator fix https://github.com/chef/ffi-yajl/pull/126 fail-after:2026-08-22
+        versions: ["3.x"]
 
   - package-ecosystem: bundler
     directory: "/"

--- a/.github/workflows/chronoguard.yml
+++ b/.github/workflows/chronoguard.yml
@@ -1,0 +1,35 @@
+---
+name: chronoguard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  chronoguard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check for expired fail-after dates
+        run: |
+          failed=0
+          while IFS= read -r line; do
+            file=$(echo "$line" | cut -d: -f1)
+            date=$(echo "$line" | grep -oP 'fail-after:\K[0-9]{4}-[0-9]{2}-[0-9]{2}')
+            if [ -n "$date" ]; then
+              if [ "$(date +%Y-%m-%d)" \> "$date" ] || [ "$(date +%Y-%m-%d)" = "$date" ]; then
+                echo "::error file=${file}::Chronoguard: fail-after date ${date} has passed. Please review this pin."
+                failed=1
+              else
+                echo "✓ ${file}: fail-after ${date} not yet reached"
+              fi
+            fi
+          done < <(grep -rn "fail-after:" .github/dependabot.yml)
+          if [ "$failed" -eq 1 ]; then
+            exit 1
+          fi

--- a/.github/workflows/chronoguard.yml
+++ b/.github/workflows/chronoguard.yml
@@ -1,35 +1,18 @@
 ---
-name: chronoguard
+name: Chronoguard
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
-
-permissions:
-  contents: read
+    branches: [ main, chef-18 ]
 
 jobs:
   chronoguard:
     runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
     steps:
-      - uses: actions/checkout@v7
-      - name: Check for expired fail-after dates
-        run: |
-          failed=0
-          while IFS= read -r line; do
-            file=$(echo "$line" | cut -d: -f1)
-            date=$(echo "$line" | grep -oP 'fail-after:\K[0-9]{4}-[0-9]{2}-[0-9]{2}')
-            if [ -n "$date" ]; then
-              if [ "$(date +%Y-%m-%d)" \> "$date" ] || [ "$(date +%Y-%m-%d)" = "$date" ]; then
-                echo "::error file=${file}::Chronoguard: fail-after date ${date} has passed. Please review this pin."
-                failed=1
-              else
-                echo "✓ ${file}: fail-after ${date} not yet reached"
-              fi
-            fi
-          done < <(grep -rn "fail-after:" .github/dependabot.yml)
-          if [ "$failed" -eq 1 ]; then
-            exit 1
-          fi
+      - uses: actions/checkout@v6
+      - uses: jaymzh/chronoguard@main
+        with:
+          files: .github/workflows/allchecks.yml, .github/dependabot.yml

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "appbundler"
 gem "chef-config", git: "https://github.com/chef/chef", branch: "main", glob: "chef-config/chef-config.gemspec"
 gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "chef-utils/chef-utils.gemspec"
 gem "ffi", "~> 1.17", force_ruby_platform: true
-gem "unicode-display_width", force_ruby_platform: true
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
   gem "cookstyle", ">= 7.32.8"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "appbundler"
 gem "chef-config", git: "https://github.com/chef/chef", branch: "main", glob: "chef-config/chef-config.gemspec"
 gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "chef-utils/chef-utils.gemspec"
 gem "ffi", "~> 1.17", force_ruby_platform: true
+gem "unicode-display_width", force_ruby_platform: true
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
   gem "cookstyle", ">= 7.32.8"

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-config", ">= 14.12", "< 20"
   s.add_dependency "chef-utils", ">= 16.0", "< 20"
   s.add_dependency "ffi", ">= 1.15.5"
-  s.add_dependency "ffi-yajl", ">= 2.2", "< 4.0"
+  s.add_dependency "ffi-yajl", ">= 2.2", "< 3.0"
   s.add_dependency "ipaddress"
   s.add_dependency "mixlib-cli", ">= 1.7.0" # 1.7+ needed to support passing multiple options
   s.add_dependency "mixlib-config", ">= 2.0", "< 4.0"


### PR DESCRIPTION
## Summary
Constrain ffi-yajl to version < 3.0 to ensure compatibility with Ruby 3.2+.

## Why
The ffi-yajl 3.0.0 release doesn't include a fix for Ruby 3.2+ allocator warnings that was implemented in ffi-yajl 2.7.x. By pinning to < 3.0, we use the fixed 2.7.x versions.

## Changes
- Updated ffi-yajl dependency constraint from '< 4.0' to '< 3.0' in ohai.gemspec

## References
- [ffi-yajl PR #126](https://github.com/chef/ffi-yajl/pull/126)
- [Ruby bug #18007](https://bugs.ruby-lang.org/issues/18007)

---
This work was completed with AI assistance following Progress AI policies.