### PR TITLE
chore: Configure Dependabot to ignore ffi-yajl 3.0.0+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     # don't automatically rebase on every single time we're out of date with
     # base (whith is always) because it kills CI capacity
     rebase-strategy: disabled
+    ignore:
+      - dependency-name: "ffi-yajl"
+        versions: ["3.x"]
 
   - package-ecosystem: bundler
     directory: "/"
@@ -24,6 +27,9 @@ updates:
     # don't automatically rebase on every single time we're out of date with
     # base (whith is always) because it kills CI capacity
     rebase-strategy: disabled
+    ignore:
+      - dependency-name: "ffi-yajl"
+        versions: ["3.x"]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Summary
Configure Dependabot to ignore ffi-yajl 3.x versions for both main and 18-stable branches.

## Why
Only ffi-yajl 2.x versions work correctly with Ruby 3.2+ due to the allocator warning fix in ffi-yajl 2.7.x. Versions 3.0.0+ lack this fix and should not be used.

## Changes
- Added ignore rules for ffi-yajl 3.x in Dependabot config
- Applied to both main and 18-stable branches

This work was completed with AI assistance following Progress AI policies.