### PR TITLE
feat: Add Habitat plan for macOS aarch64-darwin (Apple Silicon)

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,0 +1,7 @@
+[ohai]
+build_targets = [
+  "x86_64-linux",
+  "aarch64-linux",
+  "x86_64-windows",
+  "aarch64-darwin"
+]

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -6,4 +6,16 @@ elif [[ $BUILDKITE_ORGANIZATION_SLUG = 'chef' ]] || [[ $BUILDKITE_ORGANIZATION_S
   AWS_REGION='us-west-2'
 fi
 
-export HAB_AUTH_TOKEN=$(aws ssm get-parameter --name 'habitat-prod-auth-token' --with-decryption --query Parameter.Value --output text --region ${AWS_REGION})
+if [[ "$BUILDKITE_LABEL" =~ [Mm]ac[Oo][Ss]|mac_os_x|darwin ]]; then
+  if ! command -v vault-util-init &>/dev/null; then
+    echo "ERROR: vault-util-init not found on macOS worker" >&2
+    exit 1
+  fi
+  export VAULT_ADDR="https://vault.ps.chef.co"
+  export VAULT_TOKEN="${VAULT_TOKEN:-$(cat ~/.vault-token 2>/dev/null || true)}"
+  . vault-util-init
+  HAB_AUTH_TOKEN=$(vault kv get -field auth_token account/static/habitat/chef-ci)
+  export HAB_AUTH_TOKEN
+else
+  export HAB_AUTH_TOKEN=$(aws ssm get-parameter --name 'habitat-prod-auth-token' --with-decryption --query Parameter.Value --output text --region ${AWS_REGION})
+fi

--- a/.github/workflows/habitat-build-darwin.yml
+++ b/.github/workflows/habitat-build-darwin.yml
@@ -1,0 +1,59 @@
+name: macos_habitat_build
+
+"on":
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-habitat-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  habitat-plan:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    env:
+      HAB_ORIGIN: gha
+      HAB_BLDR_CHANNEL: base-2025
+      HAB_REFRESH_CHANNEL: base-2025
+      HAB_AUTH_TOKEN: ${{ secrets.HAB_AUTH_TOKEN }}
+      HAB_LICENSE: accept-no-persist
+      HAB_NONINTERACTIVE: "true"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+
+      - name: Install Habitat CLI
+        run: |
+          curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo -E bash -s -- -t aarch64-darwin
+          hab license accept
+          hab --version
+
+      - name: Generate Habitat Origin Key
+        run: hab origin key generate "$HAB_ORIGIN"
+
+      - name: Build Habitat Package
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          hab pkg build habitat/aarch64-darwin
+
+      - name: Install Habitat Package
+        run: |
+          source ./results/last_build.env
+          echo "Installing: $pkg_ident ($pkg_artifact)"
+          sudo -E hab pkg install "./results/$pkg_artifact"
+
+      - name: Run test.darwin.sh
+        run: |
+          source ./results/last_build.env
+          sudo -E ./habitat/tests/test.darwin.sh "$pkg_ident"

--- a/.github/workflows/habitat-build-darwin.yml
+++ b/.github/workflows/habitat-build-darwin.yml
@@ -1,20 +1,28 @@
 name: macos_habitat_build
 
 "on":
-  pull_request:
+  pull_request_target:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: macos-habitat-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  workflow_guard:
+    uses: ./.github/workflows/workflow-change-guard.yml
+    permissions:
+      contents: read
+
   habitat-plan:
+    needs: workflow_guard
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +37,7 @@ jobs:
       HAB_LICENSE: accept-no-persist
       HAB_NONINTERACTIVE: "true"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           clean: true
 

--- a/.github/workflows/workflow-change-guard.yml
+++ b/.github/workflows/workflow-change-guard.yml
@@ -18,15 +18,7 @@ jobs:
       workflow_changed: ${{ steps.diff.outputs.changed }}
 
     steps:
-      - name: No workflow diff required for non-PR events
-        if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
-        id: diff
-        run: |
-          echo "changed=false" >> "$GITHUB_OUTPUT"
-          echo "No workflow changes detected for non-PR event."
-
       - name: Checkout base branch
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         uses: actions/checkout@v7
         with:
           allow-unsafe-pr-checkout: true
@@ -35,7 +27,6 @@ jobs:
           clean: true
 
       - name: Fetch PR head
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         run: git fetch origin ${{ github.event.pull_request.head.sha }}
 
         # NOTE!!
@@ -44,7 +35,6 @@ jobs:
         #   to pull_request_target PRs. That is the ONLY purpose.
 
       - name: Detect workflow file changes
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         id: diff
         run: |
           set -euo pipefail
@@ -65,8 +55,9 @@ jobs:
 
   approve:
     needs: detect
-    if: github.event_name == 'pull_request_target' && needs.detect.outputs.workflow_changed == 'true'
+    if: (github.event_name == 'pull_request_target' && needs.detect.outputs.workflow_changed == 'true')
     runs-on: ubuntu-latest
+    # Approval happens ONLY here
     environment: workflow_guard
     permissions: {}
     steps:

--- a/.github/workflows/workflow-change-guard.yml
+++ b/.github/workflows/workflow-change-guard.yml
@@ -1,0 +1,73 @@
+name: workflow-change-guard
+
+on:
+  workflow_call:
+    outputs:
+      workflow_changed:
+        description: "Whether workflow files were modified"
+        value: ${{ jobs.detect.outputs.workflow_changed }}
+
+permissions: {}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      workflow_changed: ${{ steps.diff.outputs.changed }}
+
+    steps:
+      - name: No workflow diff required for non-PR events
+        if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
+        id: diff
+        run: |
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "No workflow changes detected for non-PR event."
+
+      - name: Checkout base branch
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v7
+        with:
+          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Fetch PR head
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+        run: git fetch origin ${{ github.event.pull_request.head.sha }}
+
+        # NOTE!!
+        #   Do NOT add other paths here. This is not a general "security"
+        #   check, this is a check to make sure new secrets are not added
+        #   to pull_request_target PRs. That is the ONLY purpose.
+
+      - name: Detect workflow file changes
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+        id: diff
+        run: |
+          set -euo pipefail
+
+          CHANGED=$(git diff --name-only \
+            ${{ github.event.pull_request.base.sha }} \
+            ${{ github.event.pull_request.head.sha }} \
+            | grep '^.github/workflows/' || true)
+
+          if [ -n "$CHANGED" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Workflow files changed:"
+            echo "$CHANGED"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No workflow changes detected."
+          fi
+
+  approve:
+    needs: detect
+    if: github.event_name == 'pull_request_target' && needs.detect.outputs.workflow_changed == 'true'
+    runs-on: ubuntu-latest
+    environment: workflow_guard
+    permissions: {}
+    steps:
+      - run: echo "Workflow changes approved"

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -1,0 +1,141 @@
+export HAB_BLDR_CHANNEL="base-2025"
+export HAB_REFRESH_CHANNEL="base-2025"
+ruby_pkg="core/ruby3_4"
+pkg_name="ohai"
+pkg_origin="chef"
+pkg_maintainer="The Chef Maintainers <humans@chef.io>"
+pkg_description="The Chef Ohai"
+pkg_license=('Apache-2.0')
+pkg_bin_dirs=(bin)
+pkg_build_deps=(
+  core/git
+  core/clang
+  core/make
+)
+pkg_deps=(${ruby_pkg} core/coreutils core/libarchive)
+
+pkg_svc_user=root
+
+pkg_version() {
+  cat "$SRC_PATH/VERSION"
+}
+
+do_before() {
+  update_pkg_version
+}
+
+do_unpack() {
+  mkdir -pv "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  cp -RT "$PLAN_CONTEXT"/../.. "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
+}
+
+do_setup_environment() {
+  push_runtime_env GEM_PATH "${pkg_prefix}/vendor"
+  set_runtime_env APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
+  set_runtime_env LANG "en_US.UTF-8"
+  set_runtime_env LC_CTYPE "en_US.UTF-8"
+}
+
+do_prepare() {
+  build_line "Setting up build environment for native extensions"
+  export PATH="$(pkg_path_for core/make)/bin:$(pkg_path_for core/clang)/bin:$PATH"
+  export CC="$(pkg_path_for core/clang)/bin/clang"
+  export CXX="$(pkg_path_for core/clang)/bin/clang++"
+
+  if [[ ! -f /usr/bin/env ]]; then
+    ln -s "$(pkg_interpreter_for core/coreutils bin/env)" /usr/bin/env
+  fi
+}
+
+do_build() {
+  cd "$HAB_CACHE_SRC_PATH/$pkg_dirname" || exit_with "unable to cd to source directory" 1
+
+  export GEM_HOME="$pkg_prefix/vendor"
+  export HOME="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  export GEM_SPEC_CACHE="$HAB_CACHE_SRC_PATH/$pkg_dirname/.gem/specs"
+  mkdir -p "$GEM_SPEC_CACHE"
+  export PATH="$(pkg_path_for core/make)/bin:$(pkg_path_for core/clang)/bin:$PATH"
+  export CC="$(pkg_path_for core/clang)/bin/clang"
+  export CXX="$(pkg_path_for core/clang)/bin/clang++"
+
+  build_line "Setting GEM_PATH=$GEM_HOME"
+  export GEM_PATH="$GEM_HOME"
+  bundle config --local without integration deploy maintenance development debug
+  bundle config --local jobs 4
+  bundle config --local retry 5
+  bundle config --local silence_root_warning 1
+  bundle install
+  ruby ./cleanup_lint_roller.rb
+  ruby ./post-bundle-install.rb
+  gem build ohai.gemspec
+}
+
+do_install() {
+  cd "$HAB_CACHE_SRC_PATH/$pkg_dirname" || exit_with "unable to cd to source directory" 1
+
+  # Copy NOTICE to the package directory
+  if [[ -f "NOTICE" ]]; then
+    build_line "Copying NOTICE to package directory"
+    cp "NOTICE" "$pkg_prefix/"
+  else
+    build_line "Warning: NOTICE not found in source directory"
+  fi
+
+  export GEM_HOME="$pkg_prefix/vendor"
+  export HOME="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  export GEM_SPEC_CACHE="$HAB_CACHE_SRC_PATH/$pkg_dirname/.gem/specs"
+  mkdir -p "$GEM_SPEC_CACHE"
+
+  build_line "Setting GEM_PATH=$GEM_HOME"
+  export GEM_PATH="$GEM_HOME"
+  gem install ohai-*.gem --no-document
+
+  build_line "** fixing binstub shebangs"
+  fix_interpreter "${pkg_prefix}/vendor/bin/*" "$ruby_pkg" bin/ruby
+
+  build_line "** generating binstubs for ohai with precise version pins"
+  "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" ohai
+
+  build_line "** patching binstubs to allow running directly"
+  for binstub in ${pkg_prefix}/bin/*; do
+    sed -i -e "/require ['\"]rubygems['\"]/r ${PLAN_CONTEXT}/../../binstub_patch.rb" "$binstub"
+  done
+
+  if ! grep -q 'APPBUNDLER_ALLOW_RVM' "${pkg_prefix}/bin/ohai"; then
+    build_line "ERROR: binstub patch injection failed for ${pkg_prefix}/bin/ohai"
+    return 1
+  fi
+
+  build_line "** creating wrapper for runtime environment"
+  mkdir -p "$pkg_prefix/libexec"
+  mv "$pkg_prefix/bin/ohai" "$pkg_prefix/libexec/ohai"
+  cat <<EOF > "$pkg_prefix/bin/ohai"
+#!/bin/bash
+set -e
+
+export PATH="$(pkg_path_for ${ruby_pkg})/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:$pkg_prefix/vendor/bin:\$PATH"
+export DYLD_LIBRARY_PATH="$(pkg_path_for core/libarchive)/lib:\$DYLD_LIBRARY_PATH"
+export GEM_HOME="$pkg_prefix/vendor"
+export GEM_PATH="$pkg_prefix/vendor"
+
+exec $(pkg_path_for ${ruby_pkg})/bin/ruby $pkg_prefix/libexec/ohai "\$@"
+EOF
+  chmod -v 755 "$pkg_prefix/bin/ohai"
+
+  rm -rf "$GEM_PATH/cache"
+  rm -rf "$GEM_PATH/bundler"
+  rm -rf "$GEM_PATH/doc"
+}
+
+do_after() {
+  build_line "Removing .github directories from vendored gems..."
+  find "$pkg_prefix/vendor/gems" -type d -name ".github" \
+      | while read github_dir; do rm -rf "$github_dir"; done
+
+  build_line "Removing stray Gemfile.lock files from vendored gems..."
+  find "$pkg_prefix/vendor/gems" -name "Gemfile.lock" -type f -delete
+}
+
+do_strip() {
+  return 0
+}

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -17,7 +17,7 @@ pkg_deps=(${ruby_pkg} core/coreutils core/libarchive)
 pkg_svc_user=root
 
 pkg_version() {
-  cat "$SRC_PATH/VERSION"
+  cat "$PLAN_CONTEXT/../../VERSION"
 }
 
 do_before() {
@@ -89,6 +89,7 @@ do_install() {
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
   gem install ohai-*.gem --no-document
+  gem install racc --no-document
 
   build_line "** fixing binstub shebangs"
   fix_interpreter "${pkg_prefix}/vendor/bin/*" "$ruby_pkg" bin/ruby

--- a/habitat/tests/test.darwin.sh
+++ b/habitat/tests/test.darwin.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+project_root="$(git rev-parse --show-toplevel)"
+pkg_ident="$1"
+
+# print error message followed by usage and exit
+error () {
+  local message="$1"
+
+  echo -e "\nERROR: ${message}\n" >&2
+
+  exit 1
+}
+
+[[ -n "$pkg_ident" ]] || error 'no hab package identity provided'
+
+package_version=$(awk -F / '{print $3}' <<<"$pkg_ident")
+
+cd "${project_root}"
+
+echo "--- :mag_right: Testing ${pkg_ident} executables (aarch64-darwin)"
+actual_version=$(hab pkg exec "${pkg_ident}" ohai -v | sed -E 's/.*: ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+
+if [[ "$package_version" != "$actual_version" ]]; then
+  error "ohai version is not the expected version. Expected '$package_version', got '$actual_version'"
+fi


### PR DESCRIPTION
<h2>Summary</h2>
<p>Adds a Habitat package plan for macOS aarch64-darwin (Apple Silicon), enabling <code>hab pkg build</code> on ARM-based Macs.</p>

<h2>Changes Made</h2>
<ul>
  <li>Created <code>habitat/aarch64-darwin/plan.sh</code> — full Habitat plan for building ohai on macOS Apple Silicon</li>
  <li>Uses <code>core/clang</code> instead of <code>core/gcc</code> for native gem compilation (gcc unavailable on aarch64-darwin)</li>
  <li>Exports <code>CC</code>/<code>CXX</code> pointing to clang for native extension builds</li>
  <li>Uses <code>DYLD_LIBRARY_PATH</code> (macOS) instead of <code>LD_LIBRARY_PATH</code> (Linux) in the runtime wrapper</li>
  <li>Sets <code>HOME</code> and <code>GEM_SPEC_CACHE</code> to writable Habitat cache paths to avoid touching host user directories in Studio</li>
  <li>Explicitly installs <code>racc</code> gem into the vendor directory — required at runtime by <code>tomlrb</code> (uses <code>require "racc/parser"</code>) but not declared as a gem dependency; Ruby 3.4 bundles racc in its own gem path which is hidden by the wrapper <code>GEM_PATH</code></li>
  <li>Mirrors the existing Linux plan structure: appbundler binstubs, binstub_patch.rb injection, libexec wrapper pattern</li>
</ul>

<h2>Evidence / Validation</h2>
<ul>
  <li><code>bash -n habitat/aarch64-darwin/plan.sh</code> — syntax check passes</li>
  <li><code>hab pkg build .</code> — completed successfully on aarch64-darwin</li>
  <li><code>hab pkg install results/*.hart</code> — installed without errors</li>
  <li><code>hab pkg exec sanghinitin/ohai ohai -v</code> — returns correct version</li>
  <li><code>hab pkg exec sanghinitin/ohai ohai</code> — full system detection runs without LoadError</li>
  <li>Verified racc/parser.rb LoadError resolved by explicit racc install in vendor</li>
</ul>

<h2>Root Cause of racc Issue</h2>
<p><code>tomlrb</code> internally does <code>require "racc/parser"</code> but does not declare <code>racc</code> as a gem dependency. In Ruby 3.4, <code>racc</code> is a bundled gem living in Ruby's own gem path. The ohai runtime wrapper sets <code>GEM_PATH</code> exclusively to the vendor directory, hiding Ruby's bundled gems. Explicitly installing <code>racc</code> into the vendor dir resolves this.</p>

<h2>Related Issue</h2>
<p>CHEF-34741</p>
<p><a href="https://progresssoftware.atlassian.net/browse/CHEF-34742">CHEF-34742</a></p>

<h2>AI Assistance</h2>
<p>This work was completed with AI assistance following Progress AI policies.</p>