### PR TITLE
CHEF-37334: Add Linux ARM Habitat test workflow

### DIFF
--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -21,6 +21,20 @@ steps:
           environment:
             - HAB_AUTH_TOKEN
 
+  - label: ":linux: Arm64 Validate Habitat Builds of ohai"
+    commands:
+      - .expeditor/buildkite/artifact.habitat.test.sh
+    agents:
+      queue: default-privileged-aarch64
+    plugins:
+      - docker#v3.5.0:
+          image: ruby:3.4.2-bullseye
+          privileged: true
+          propagate-environment: true
+          environment:
+            - HAB_AUTH_TOKEN
+            - BUILD_PKG_TARGET: "aarch64-linux"
+
   - label: ":windows: Validate Habitat Builds of ohai"
     commands:
       - .expeditor/buildkite/artifact.habitat.test.ps1

--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -1,0 +1,2 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../plan.sh"
+# Reuse the default Linux plan for Linux ARM (aarch64) builds.


### PR DESCRIPTION

## Summary
This PR adds Linux ARM Habitat validation through the Expeditor/Buildkite pipeline for ohai.

## What Changed
- Added an ARM64 Habitat validation step in `.expeditor/habitat-test.pipeline.yml`.
- Configured the ARM64 step to run on Buildkite queue `default-privileged-aarch64`.
- Configured the Docker plugin to use `ruby:3.4.2-bullseye` with `BUILD_PKG_TARGET` set to `aarch64-linux`.
- Uses the existing Habitat validation script to build and validate for Linux ARM in pipeline execution.

## Result
- Linux ARM Habitat validation is now handled in Expeditor/Buildkite pipeline flow.
- This aligns ARM validation with the repository’s pipeline pattern for Habitat tests.

## Jira
- CHEF-37334
