### PR TITLE
CHEF-37444: add ~/.chef/ruby/VERSION/gems to GEM_PATH for dynamic plugin loading

### DIFF
--- a/binstub_patch.rb
+++ b/binstub_patch.rb
@@ -1,4 +1,18 @@
 unless ENV["APPBUNDLER_ALLOW_RVM"]
   ENV["APPBUNDLER_ALLOW_RVM"] = "true"
-  ENV["GEM_PATH"] = [File.expand_path(File.join(__dir__, "..", "vendor")), ENV["GEM_PATH"]].compact.join(File::PATH_SEPARATOR)
 end
+
+# Prepend the package vendor dir, the current user's gem dir, and the Chef gem dir to
+# GEM_PATH so that:
+#   1. Ohai's vendored dependencies are always found.
+#   2. Plugins installed via `gem install <plugin>` are discoverable on both
+#      Linux (~/.gem/ruby/VERSION) and Windows (%USERPROFILE%\.gem\ruby\VERSION).
+#   3. Gems installed via `chef gem install` (~/.chef/ruby/VERSION/gems) are immediately available.
+#
+# This block runs before appbundler's env_sanitizer (which calls Gem.clear_paths and
+# re-reads GEM_PATH from ENV), so these additions are always picked up correctly.
+ohai_vendor = File.expand_path(File.join(__dir__, "..", "vendor"))
+# chef-cli gem install places gems under ~/.chef/ruby/RUBY_API_VERSION/gems
+chef_gem_dir = File.join(Dir.home, ".chef", "ruby", RbConfig::CONFIG["ruby_version"], "gems")
+existing_paths = ENV["GEM_PATH"]&.split(File::PATH_SEPARATOR) || []
+ENV["GEM_PATH"] = ([ohai_vendor, Gem.user_dir, chef_gem_dir] + existing_paths).uniq.join(File::PATH_SEPARATOR)

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -110,6 +110,15 @@ do_install() {
   build_line "** creating wrapper for runtime environment"
   mkdir -p "$pkg_prefix/libexec"
   mv "$pkg_prefix/bin/ohai" "$pkg_prefix/libexec/ohai"
+  # Derive the Ruby API version (e.g. 3.4.0) from the packaged Ruby's on-disk gem layout
+  # rather than executing `ruby -e`. Invoking the hab-provided ruby during the build can
+  # silently fail (its runtime library paths aren't set up here), which would leave
+  # ruby_gem_version empty and corrupt every GEM_PATH entry written below.
+  ruby_gem_version="$(basename "$(pkg_path_for "${ruby_pkg}")/lib/ruby/gems/"*)"
+  if [[ -z "$ruby_gem_version" ]]; then
+    build_line "WARNING: unable to determine Ruby API version from ${ruby_pkg}; falling back to 3.4.0"
+    ruby_gem_version="3.4.0"
+  fi
   cat <<EOF > "$pkg_prefix/bin/ohai"
 #!/bin/bash
 set -e
@@ -117,7 +126,12 @@ set -e
 export PATH="$(pkg_path_for ${ruby_pkg})/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:$pkg_prefix/vendor/bin:\$PATH"
 export DYLD_LIBRARY_PATH="$(pkg_path_for core/libarchive)/lib:\$DYLD_LIBRARY_PATH"
 export GEM_HOME="$pkg_prefix/vendor"
-export GEM_PATH="$pkg_prefix/vendor"
+# GEM_PATH includes the flat vendor tree, the bundler-nested vendor tree
+# (vendor/ruby/VERSION, where train-core and other runtime deps are installed), the
+# standard user gem dir (~/.gem/ruby/VERSION), and the Chef gem dir
+# (~/.chef/ruby/VERSION/gems) so that both ohai's own runtime deps and plugins installed
+# via 'gem install' or 'chef gem install' are found at runtime.
+export GEM_PATH="$pkg_prefix/vendor:$pkg_prefix/vendor/ruby/${ruby_gem_version}:\${HOME}/.gem/ruby/${ruby_gem_version}:\${HOME}/.chef/ruby/${ruby_gem_version}/gems"
 
 exec $(pkg_path_for ${ruby_pkg})/bin/ruby $pkg_prefix/libexec/ohai "\$@"
 EOF

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -1,6 +1,15 @@
 export HAB_BLDR_CHANNEL="base-2025"
 export HAB_REFRESH_CHANNEL="base-2025"
 ruby_pkg="core/ruby3_4"
+# Derive the Ruby API version (e.g. 3.4.0) from the packaged Ruby's on-disk gem layout
+# rather than executing `ruby -e`. Invoking the hab-provided ruby during the build can
+# silently fail (its runtime library paths aren't set up here), which would leave
+# ruby_gem_version empty and corrupt every GEM_PATH entry that uses it.
+ruby_gem_version="$(basename "$(pkg_path_for "${ruby_pkg}")/lib/ruby/gems/"*)"
+if [[ -z "$ruby_gem_version" ]]; then
+  build_line "WARNING: unable to determine Ruby API version from ${ruby_pkg}; falling back to 3.4.0"
+  ruby_gem_version="3.4.0"
+fi
 pkg_name="ohai"
 pkg_origin="chef"
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"
@@ -110,15 +119,6 @@ do_install() {
   build_line "** creating wrapper for runtime environment"
   mkdir -p "$pkg_prefix/libexec"
   mv "$pkg_prefix/bin/ohai" "$pkg_prefix/libexec/ohai"
-  # Derive the Ruby API version (e.g. 3.4.0) from the packaged Ruby's on-disk gem layout
-  # rather than executing `ruby -e`. Invoking the hab-provided ruby during the build can
-  # silently fail (its runtime library paths aren't set up here), which would leave
-  # ruby_gem_version empty and corrupt every GEM_PATH entry written below.
-  ruby_gem_version="$(basename "$(pkg_path_for "${ruby_pkg}")/lib/ruby/gems/"*)"
-  if [[ -z "$ruby_gem_version" ]]; then
-    build_line "WARNING: unable to determine Ruby API version from ${ruby_pkg}; falling back to 3.4.0"
-    ruby_gem_version="3.4.0"
-  fi
   cat <<EOF > "$pkg_prefix/bin/ohai"
 #!/bin/bash
 set -e

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -85,6 +85,19 @@ function Invoke-Install {
 	 Write-BuildLine "** generating binstubs for ohai with precise version pins $project_root $pkg_prefix/bin " 
             Invoke-Expression -Command "appbundler.bat $project_root $pkg_prefix/bin ohai"
             If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
+        Write-BuildLine "** patching binstubs for direct execution and dynamic plugin loading"
+        $binstubPatch = Get-Content -Path "$project_root\binstub_patch.rb"
+        Get-ChildItem "$pkg_prefix\bin" | Where-Object { $_.Extension -notin @(".bat", ".ps1") } | ForEach-Object {
+            $lines = Get-Content -Path $_.FullName
+            $matchLine = $lines | Select-String -Pattern 'require "rubygems"' | Select-Object -First 1
+            if ($matchLine) {
+                $lineNum = $matchLine.LineNumber  # 1-based; insert patch after this line
+                $newLines = $lines[0..($lineNum - 1)] + $binstubPatch + $lines[$lineNum..($lines.Count - 1)]
+                Set-Content -Path $_.FullName -Value $newLines
+            }
+        }
+
 	Write-BuildLine " ** Running the ohai project's 'rake install' to install the path-based gems so they look like any other installed gem."
 
         If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,15 @@
 export HAB_BLDR_CHANNEL="base-2025"
 export HAB_REFRESH_CHANNEL="base-2025"
 ruby_pkg="core/ruby3_4"
+# Derive the Ruby API version (e.g. 3.4.0) from the packaged Ruby's on-disk gem layout
+# rather than executing `ruby -e`. Invoking the hab-provided ruby during the build can
+# silently fail (its runtime library paths aren't set up here), which would leave
+# ruby_gem_version empty and corrupt every GEM_PATH entry that uses it.
+ruby_gem_version="$(basename "$(pkg_path_for "${ruby_pkg}")/lib/ruby/gems/"*)"
+if [[ -z "$ruby_gem_version" ]]; then
+  build_line "WARNING: unable to determine Ruby API version from ${ruby_pkg}; falling back to 3.4.0"
+  ruby_gem_version="3.4.0"
+fi
 pkg_name="ohai"
 pkg_origin="chef"
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"
@@ -92,15 +101,6 @@ do_install() {
   build_line "** creating wrapper for runtime environment"
   mkdir -p "$pkg_prefix/libexec"
   mv "$pkg_prefix/bin/ohai" "$pkg_prefix/libexec/ohai"
-  # Derive the Ruby API version (e.g. 3.4.0) from the packaged Ruby's on-disk gem layout
-  # rather than executing `ruby -e`. Invoking the hab-provided ruby during the build can
-  # silently fail (its runtime library paths aren't set up here), which would leave
-  # ruby_gem_version empty and corrupt every GEM_PATH entry written below.
-  ruby_gem_version="$(basename "$(pkg_path_for "${ruby_pkg}")/lib/ruby/gems/"*)"
-  if [[ -z "$ruby_gem_version" ]]; then
-    build_line "WARNING: unable to determine Ruby API version from ${ruby_pkg}; falling back to 3.4.0"
-    ruby_gem_version="3.4.0"
-  fi
   cat <<EOF > "$pkg_prefix/bin/ohai"
 #!$(pkg_path_for core/bash)/bin/bash
 set -e

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -92,6 +92,15 @@ do_install() {
   build_line "** creating wrapper for runtime environment"
   mkdir -p "$pkg_prefix/libexec"
   mv "$pkg_prefix/bin/ohai" "$pkg_prefix/libexec/ohai"
+  # Derive the Ruby API version (e.g. 3.4.0) from the packaged Ruby's on-disk gem layout
+  # rather than executing `ruby -e`. Invoking the hab-provided ruby during the build can
+  # silently fail (its runtime library paths aren't set up here), which would leave
+  # ruby_gem_version empty and corrupt every GEM_PATH entry written below.
+  ruby_gem_version="$(basename "$(pkg_path_for "${ruby_pkg}")/lib/ruby/gems/"*)"
+  if [[ -z "$ruby_gem_version" ]]; then
+    build_line "WARNING: unable to determine Ruby API version from ${ruby_pkg}; falling back to 3.4.0"
+    ruby_gem_version="3.4.0"
+  fi
   cat <<EOF > "$pkg_prefix/bin/ohai"
 #!$(pkg_path_for core/bash)/bin/bash
 set -e
@@ -99,7 +108,12 @@ set -e
 export PATH="$(pkg_path_for ${ruby_pkg})/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
 export LD_LIBRARY_PATH="$(pkg_path_for core/libarchive)/lib:\$LD_LIBRARY_PATH"
 export GEM_HOME="$pkg_prefix/vendor"
-export GEM_PATH="$pkg_prefix/vendor"
+# GEM_PATH includes the flat vendor tree, the bundler-nested vendor tree
+# (vendor/ruby/VERSION, where train-core and other runtime deps are installed), the
+# standard user gem dir (~/.gem/ruby/VERSION), and the Chef gem dir
+# (~/.chef/ruby/VERSION/gems) so that both ohai's own runtime deps and plugins installed
+# via 'gem install' or 'chef gem install' are found at runtime.
+export GEM_PATH="$pkg_prefix/vendor:$pkg_prefix/vendor/ruby/${ruby_gem_version}:\${HOME}/.gem/ruby/${ruby_gem_version}:\${HOME}/.chef/ruby/${ruby_gem_version}/gems"
 
 exec $(pkg_path_for ${ruby_pkg})/bin/ruby $pkg_prefix/libexec/ohai "\$@"
 EOF


### PR DESCRIPTION
## Summary

Ohai plugins installed via `chef gem install` land in
`~/.chef/ruby/<RUBY_API_VERSION>/gems`, but this path was never added to
the runtime `GEM_PATH`. As a result, any gem installed that way was
invisible to the packaged ohai binary even after re-running the binstub.

This PR fixes the issue by expanding `GEM_PATH` in three places: the Ruby
binstub patch, and both the Linux/macOS and Windows Habitat wrappers.

## Root Cause Evidence

```
$ gem info some-ohai-plugin
some-ohai-plugin (x.y.z)
    Installed at: /Users/nsanghi/.chef/ruby/3.4.0/gems
# → not in GEM_PATH → LoadError at runtime
```
https://progresssoftware.atlassian.net/browse/CHEF-34004
## Changes Made

### binstub_patch.rb

- Removed the old single-path `GEM_PATH` assignment.
- Now prepends three paths before any existing `GEM_PATH`:
  1. `$pkg_prefix/vendor` — ohai vendored deps (flat layout)
  2. `Gem.user_dir` → `~/.gem/ruby/VERSION` — standard `gem install` target
  3. `~/.chef/ruby/RUBY_API_VERSION/gems` — `chef gem install` target
- Uses `.uniq` so paths are never duplicated when the block runs twice.

### habitat/plan.sh & habitat/aarch64-darwin/plan.sh

- Runtime wrapper now exports four `GEM_PATH` entries:
  1. `$pkg_prefix/vendor` — flat vendor tree
  2. `$pkg_prefix/vendor/ruby/VERSION` — bundler-nested tree (train-core etc.)
  3. `${HOME}/.gem/ruby/VERSION` — standard gem install
  4. `${HOME}/.chef/ruby/VERSION/gems` — chef gem install
- `ruby_gem_version` is now derived from the packaged Ruby's on-disk
  `lib/ruby/gems/` directory via `basename` instead of executing
  `ruby -e`. The latter can silently fail during `do_install` (runtime lib
  paths are not yet set up), producing an empty version string that
  corrupts all `GEM_PATH` entries. Falls back to `3.4.0` with a
  `build_line` warning if the glob still yields nothing.

### habitat/plan.ps1

- After `appbundler.bat` generates Windows binstubs, injects
  `binstub_patch.rb` immediately after the `require "rubygems"` line in
  each binstub — the same insertion point used on Linux/macOS.

## Verification

After `hab pkg build .` and `hab pkg install`:

```
# 1. Confirm wrapper GEM_PATH has all four segments and a non-empty version:
grep GEM_PATH /hab/pkgs/chef/ohai/*/*/bin/ohai

# 2. Install a test gem into the chef dir:
RUBY_API=3.4.0
gem install paint --install-dir "$HOME/.chef/ruby/$RUBY_API" --no-document

# 3. Run ohai with a plugin that requires the gem — must print version, not LoadError:
cat > /tmp/test.rb <<'PLUGIN'
Ohai.plugin(:GemPathCheck) do
  provides "gem_path_check"
  collect_data do
    gem_path_check Mash.new
    gem_path_check[:gem_path] = Gem.path
    gem_path_check[:paint_found] = begin
      require "paint"; Gem.loaded_specs["paint"]&.version.to_s
    rescue LoadError => e; "FAILED: #{e.message}"; end
  end
end
PLUGIN
/hab/pkgs/chef/ohai/*/*/bin/ohai -d /tmp gem_path_check
# Expected: paint_found: "2.x.x"  ← gem loaded from ~/.chef/ruby path
```

This work was completed with AI assistance following Progress AI policies
