### PR TITLE
fix: isolate cookstyle to fix flaky Ruby 3.4 Windows unit-test CI

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       RUBYOPT: '--disable-error_highlight'
+      # cookstyle/rubocop (the :lint group) is not needed to run rspec and
+      # can trigger transitive dependency-resolution conflicts (e.g.
+      # unicode-display_width) on some platforms; skip installing it here.
+      BUNDLE_WITHOUT: lint
     steps:
       - uses: actions/checkout@v7
       - name: Setup ruby

--- a/Gemfile
+++ b/Gemfile
@@ -11,13 +11,22 @@ gem "chef-utils", git: "https://github.com/chef/chef", branch: "main", glob: "ch
 gem "ffi", "~> 1.17", force_ruby_platform: true
 # NOTE: do not submit PRs to add pry as a dep, add to your Gemfile.local
 group :development do
-  gem "cookstyle", ">= 7.32.8"
   gem "ipaddr_extensions"
   gem "rake", ">= 10.1.0"
   gem "rspec-collection_matchers", "~> 1.0"
   gem "rspec-core", "~> 3.0"
   gem "rspec-expectations", "~> 3.0"
   gem "rspec-mocks", "~> 3.0"
+end
+
+# cookstyle (and its rubocop dependency) is only needed for `rake style` and
+# is intentionally kept out of :development so `bundle install --without lint`
+# (used by the unit test CI job) doesn't need to resolve it. This avoids a
+# transitive unicode-display_width version conflict between rubocop and
+# other gems (e.g. via chef-licensing/inspec-core) that can occur on some
+# platforms/gem index states.
+group :lint do
+  gem "cookstyle", ">= 7.32.8"
 end
 
 group :debug do


### PR DESCRIPTION
<h2>Summary</h2>
<p>The <code>windows-latest</code> + Ruby <code>3.4</code> unit test job (see <a href="https://github.com/chef/ohai/actions/runs/31402269204/job/93499897406?pr=1963">this failing run on PR #1963</a>) intermittently fails during the <code>Setup ruby</code> step with a <code>bundle install</code> dependency resolution conflict (exit code 6), not an actual test failure:</p>
<pre>
Because every version of cookstyle depends on rubocop = 1.86.1
  and every version of rubocop depends on unicode-display_width &gt;= 2.4.0, &lt; 4.0 ...
And because unicode-display_width &gt;= 2.4.0, &lt; 3.0 could not be found in rubygems
repository ... for platforms (x64-mingw-ucrt) ...
Because strings &gt;= 0.2.1 depends on unicode-display_width &gt;= 1.5, &lt; 3.0 ...
version solving has failed.
</pre>
<p>This only affects the windows + Ruby 3.4 matrix cell and is intermittent (the same branch passed this exact job earlier the same day, and <code>main</code>'s Ruby 3.4/windows job passed around the same time), which points to a dependency-graph conflict triggered by <code>cookstyle</code>'s <code>rubocop</code> requirement clashing with unrelated transitive gems, rather than a real Ruby 3.4 incompatibility in ohai's own code.</p>

<h2>Root Cause</h2>
<p><code>cookstyle</code> is only required by the <code>rake style</code> task (run by <code>lint.yml</code>) — it is not needed by <code>rake spec</code> (run by <code>unit.yml</code>). However it previously lived in the shared <code>:development</code> Gemfile group along with <code>rspec-*</code>/<code>rake</code>, so the unit test job's <code>bundle install</code> was forced to resolve <code>cookstyle</code>/<code>rubocop</code> and their entire dependency subtree unnecessarily, exposing it to this conflict.</p>

<h2>Changes Made</h2>
<ul>
  <li>Moved <code>cookstyle</code> out of the shared <code>:development</code> Gemfile group into its own new <code>:lint</code> group.</li>
  <li>Added <code>BUNDLE_WITHOUT: lint</code> to <code>.github/workflows/unit.yml</code>'s test job so the unit-test <code>bundle install</code> skips the <code>:lint</code> group entirely.</li>
  <li><code>.github/workflows/lint.yml</code> is unchanged — it performs a full <code>bundle install</code> with no <code>--without</code> flag, so it continues to install <code>cookstyle</code> and <code>rake style</code> keeps working as before.</li>
</ul>

<h2>Testing</h2>
<ul>
  <li>Validated <code>Gemfile</code> parses correctly via <code>Bundler::Dsl</code> and that <code>cookstyle</code> now resolves to the <code>:lint</code> group only (all other gems unaffected).</li>
  <li>Validated <code>.github/workflows/unit.yml</code> YAML syntax.</li>
  <li>No changes to test code; existing unit/lint suites are unaffected in scope.</li>
</ul>

<p>This work was completed with AI assistance following Progress AI policies.</p>
