### PR TITLE
Backport #1964: Fix Encoding::CompatibilityError in hostnamectl plugin

### DIFF
--- a/lib/ohai/plugins/linux/hostnamectl.rb
+++ b/lib/ohai/plugins/linux/hostnamectl.rb
@@ -27,7 +27,7 @@ Ohai.plugin(:Hostnamectl) do
     if hostnamectl_path
       re = /[^\p{ASCII}]/u
 
-      shell_out(hostnamectl_path).stdout.split("\n").each do |line|
+      shell_out(hostnamectl_path).stdout.dup.force_encoding("UTF-8").scrub.split("\n").each do |line|
         key, val = line.split(": ", 2)
 
         key = key.chomp.lstrip.tr(" ", "_").downcase

--- a/spec/unit/plugins/linux/hostnamectl_spec.rb
+++ b/spec/unit/plugins/linux/hostnamectl_spec.rb
@@ -39,7 +39,7 @@ describe Ohai::System, "Linux hostnamectl plugin" do
     HOSTNAMECTL_OUT
 
     allow(plugin).to receive(:which).with("hostnamectl").and_return("/bin/hostnamectl")
-    allow(plugin).to receive(:shell_out).with("/bin/hostnamectl").and_return(mock_shell_out(0, hostnamectl_out, ""))
+    allow(plugin).to receive(:shell_out).with("/bin/hostnamectl").and_return(mock_shell_out(0, hostnamectl_out.b, ""))
     plugin.run
     expect(plugin[:hostnamectl].to_hash).to eq({
       "static_hostname" => "foo",
@@ -54,6 +54,8 @@ describe Ohai::System, "Linux hostnamectl plugin" do
     })
   end
 
+  # Mixlib::ShellOut returns stdout as ASCII-8BIT, so the fixtures must be
+  # binary too; UTF-8 fixtures don't exercise the encoding path at all.
   {
     "laptop" => "💻",
     "desktop" => "🖥️",
@@ -78,7 +80,7 @@ describe Ohai::System, "Linux hostnamectl plugin" do
       HOSTNAMECTL_OUT
 
       allow(plugin).to receive(:which).with("hostnamectl").and_return("/bin/hostnamectl")
-      allow(plugin).to receive(:shell_out).with("/bin/hostnamectl").and_return(mock_shell_out(0, hostnamectl_out, ""))
+      allow(plugin).to receive(:shell_out).with("/bin/hostnamectl").and_return(mock_shell_out(0, hostnamectl_out.b, ""))
       plugin.run
       expect(plugin[:hostnamectl].to_hash).to eq({
         "static_hostname" => "foo",


### PR DESCRIPTION
<h2>Summary</h2>
<p>Backport of #1964 to <code>18-stable</code>. Clean cherry-pick, no conflicts.</p>

<h2>Changes Made</h2>
<ul>
<li>Cherry-picked commit 54b17dd3 (coerce hostnamectl stdout to UTF-8 with scrub before regexp)</li>
<li>Spec fixtures made binary so emoji regression cases actually exercise the encoding path</li>
</ul>

<h2>Testing</h2>
<ul>
<li>spec/unit/plugins/linux/hostnamectl_spec.rb: 10 examples, 0 failures</li>
</ul>

<p>This work was completed with AI assistance following Progress AI policies</p>