### PR TITLE
Fix ohai binlink invocation failing with Gem::MissingSpecError on direct execution

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -114,6 +114,11 @@ export GEM_HOME="$pkg_prefix/vendor"
 # (~/.chef/ruby/VERSION/gems) so that both ohai's own runtime deps and plugins installed
 # via 'gem install' or 'chef gem install' are found at runtime.
 export GEM_PATH="$pkg_prefix/vendor:$pkg_prefix/vendor/ruby/${ruby_gem_version}:\${HOME}/.gem/ruby/${ruby_gem_version}:\${HOME}/.chef/ruby/${ruby_gem_version}/gems"
+# Without this, appbundler's own binstub guard (unless
+# ENV["APPBUNDLER_ALLOW_RVM"] == "true") nils out GEM_HOME/GEM_PATH above
+# whenever ohai is invoked directly (e.g. via "hab pkg binlink") instead of
+# through "hab pkg exec", which otherwise sets this from RUNTIME_ENVIRONMENT.
+export APPBUNDLER_ALLOW_RVM="true"
 
 exec $(pkg_path_for ${ruby_pkg})/bin/ruby $pkg_prefix/libexec/ohai "\$@"
 EOF


### PR DESCRIPTION
## Summary

Fixes `ohai` crashing with `Gem::MissingSpecError` when invoked directly (e.g. via `hab pkg binlink` / plain `ohai -v`) instead of through `hab pkg exec`. This affects any architecture/target, and was reproduced concretely on `aarch64-linux`.

## Problem

`habitat/plan.sh`'s `do_install` generates a `bin/ohai` bash wrapper that manually sets `GEM_HOME`/`GEM_PATH` to the package's vendored gem tree before `exec`'ing the appbundler-generated `libexec/ohai` Ruby binstub:

```bash
export GEM_HOME="$pkg_prefix/vendor"
export GEM_PATH="$pkg_prefix/vendor:..."

exec ruby $pkg_prefix/libexec/ohai "$@"
```

However, the appbundler-generated `libexec/ohai` binstub contains this defensive guard (standard appbundler boilerplate):

```ruby
unless defined?(Bundler) && Bundler.instance_variable_defined?("@load")
  ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
  ::Gem.clear_paths
  gem "appbundler", "= 0.13.4"
  ...
```

If `APPBUNDLER_ALLOW_RVM` isn't already `"true"` in the process environment, this guard **wipes `GEM_HOME`/`GEM_PATH` back to `nil`**, right after the `bin/ohai` wrapper carefully set them — falling back to RubyGems' default gem path, which doesn't contain the vendored dependency versions.

When `ohai` is run via `hab pkg exec`, this isn't visible because `hab pkg exec` loads the package's `RUNTIME_ENVIRONMENT` file first, which already contains `APPBUNDLER_ALLOW_RVM=true` (set via `do_setup_environment`'s `set_runtime_env`). But when `ohai` is invoked directly — e.g. after `hab pkg binlink chef/ohai <version>`, which just symlinks the binary into `/bin` without going through `hab pkg exec` — nothing sets `APPBUNDLER_ALLOW_RVM`, so the guard fires and the vendor `GEM_PATH` is lost.

### Reproduction (aarch64-linux)

```console
$ hab pkg exec chef/ohai/19.1.45/20260811221447 -- ohai -v
Ohai: 19.1.45                     # works — RUNTIME_ENVIRONMENT is loaded

$ sudo hab pkg binlink chef/ohai/19.1.45/20260811221447
★ Binlinked ohai ... to /bin/ohai

$ ohai -v
/hab/pkgs/core/ruby3_4/3.4.10/.../rubygems/dependency.rb:301:in 'Gem::Dependency#to_specs':
Could not find 'addressable' (= 2.9.0) among 87 total gem(s) (Gem::MissingSpecError)
Checked in 'GEM_PATH=/home/ubuntu/.local/share/gem/ruby/3.4.0:/hab/pkgs/core/ruby3_4/.../lib/ruby/gems/3.4.0'
    from .../rubygems/dependency.rb:313:in 'Gem::Dependency#to_spec'
    from .../rubygems/core_ext/kernel_gem.rb:56:in 'Kernel#gem'
    from /hab/pkgs/chef/ohai/19.1.45/20260811221447/libexec/ohai:26:in '<main>'
```

Note the failing `GEM_PATH` shown in the error contains **no vendor path at all** — confirming it was wiped by appbundler's own guard, not simply misconfigured.

This matters directly for `chef-workstation`, which relies on `hab pkg binlink` (not `hab pkg exec`) in its install hook to expose `ohai` (and other tools) on `PATH`.

## Fix

Export `APPBUNDLER_ALLOW_RVM="true"` directly inside the generated `bin/ohai` wrapper script, alongside the existing `GEM_HOME`/`GEM_PATH` exports:

```bash
export GEM_HOME="$pkg_prefix/vendor"
export GEM_PATH="$pkg_prefix/vendor:..."
export APPBUNDLER_ALLOW_RVM="true"

exec ruby $pkg_prefix/libexec/ohai "$@"
```

This makes the `bin/ohai` wrapper self-sufficient — it no longer depends on `RUNTIME_ENVIRONMENT` being loaded by `hab pkg exec` to avoid appbundler's guard, so it behaves correctly whether invoked via `hab pkg exec`, a `hab pkg binlink`'d symlink, or any other direct invocation.

## Testing performed

- Verified locally that this is the only place `bin/ohai` is generated (`habitat/plan.sh` `do_install`), and confirmed the appbundler guard logic present in the generated `libexec/ohai` binstub matches the reported failure exactly (missing vendor path in `GEM_PATH` at the point of failure).
- Reproduced the failure on an aarch64-linux EC2 instance using an existing published `chef/ohai/19.1.45` artifact via `hab pkg binlink` + direct `ohai -v` invocation, and confirmed `hab pkg exec ... -- ohai -v` succeeds on the same host/package, isolating the invocation method as the sole variable.
- This is a minimal, targeted change (5 lines added, comment + one `export`) to the existing wrapper heredoc; no other logic touched.

## Files changed

- `habitat/plan.sh` — added `export APPBUNDLER_ALLOW_RVM="true"` (with explanatory comment) to the `bin/ohai` wrapper heredoc in `do_install`.

---
This work was completed with AI assistance following Progress AI policies.
