### PR TITLE
fix: Revert ffi-yajl constraint to < 4.0 now that 3.x has the allocator fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,6 @@ updates:
     # don't automatically rebase on every single time we're out of date with
     # base (whith is always) because it kills CI capacity
     rebase-strategy: disabled
-    ignore:
-      - dependency-name: "ffi-yajl"
-        # Locking to 2.x until ffi-yajl 3.x gets the allocator fix https://github.com/chef/ffi-yajl/pull/126 fail-after:2026-08-22
-        versions: ["3.x"]
 
   - package-ecosystem: bundler
     directory: "/"

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-config", ">= 14.12", "< 20"
   s.add_dependency "chef-utils", ">= 16.0", "< 20"
   s.add_dependency "ffi", ">= 1.15.5"
-  s.add_dependency "ffi-yajl", ">= 2.2", "< 3.0"
+  s.add_dependency "ffi-yajl", ">= 2.2", "< 4.0"
   s.add_dependency "ipaddress"
   s.add_dependency "mixlib-cli", ">= 1.7.0" # 1.7+ needed to support passing multiple options
   s.add_dependency "mixlib-config", ">= 2.0", "< 4.0"

--- a/spec/unit/plugins/cloud_spec.rb
+++ b/spec/unit/plugins/cloud_spec.rb
@@ -66,7 +66,7 @@ describe "CloudAttrs object" do
 
   it "throws exception with ipv4 address passed to ipv6" do
     @cloud_attr_obj = ::CloudAttrs.new
-    expect {  @cloud_attr_obj.add_ipv6_addr("1.2.3.4", :public) }.to raise_error(RuntimeError)
+    expect { @cloud_attr_obj.add_ipv6_addr("1.2.3.4", :public) }.to raise_error(RuntimeError)
   end
 
 end


### PR DESCRIPTION
<h2>Summary</h2>
<p>Revert the temporary ffi-yajl constraint now that version 3.0.0+ includes the fix for Ruby 3.2+ allocator warnings.</p>

<h2>Why</h2>
<p>PR #1955 temporarily constrained ffi-yajl to < 3.0 because version 3.0.0 didn't include the allocator fix. The fix is now available in ffi-yajl 3.x, so we can revert to the original constraint of < 4.0.</p>

<h2>Changes Made</h2>
<ul>
  <li>Reverted ffi-yajl dependency constraint from '< 3.0' to '< 4.0' in ohai.gemspec</li>
  <li>Removed ffi-yajl version ignore rule from .github/dependabot.yml</li>
</ul>

<h2>Testing</h2>
<ul>
  <li>No new code added - only constraint changes</li>
  <li>Allows Dependabot to update ffi-yajl to 3.x versions automatically</li>
</ul>

<h2>Related Issue</h2>
<p>Related to PR #1955</p>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>