### PR TITLE
CHEF-38086 - fix: rename cleanup_lint_roller to cleanup_gem_lockfiles and fix rdoc CVE false positive

### DIFF
--- a/cleanup_gem_lockfiles.rb
+++ b/cleanup_gem_lockfiles.rb
@@ -3,7 +3,7 @@
 require "rubygems"
 
 # List of gems that ship with Gemfile.lock files that should be removed
-GEMS_WITH_LOCKFILES = %w{lint_roller stackprof-webnav ohai}.freeze
+GEMS_WITH_LOCKFILES = %w{lint_roller stackprof-webnav ohai unicode-emoji}.freeze
 
 def cleanup_gem_lockfile(gem_name)
   puts "Cleaning up #{gem_name} Gemfile.lock..."

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -74,7 +74,7 @@ do_build() {
   bundle config --local retry 5
   bundle config --local silence_root_warning 1
   bundle install
-  ruby ./cleanup_lint_roller.rb
+  ruby ./cleanup_gem_lockfiles.rb
   ruby ./post-bundle-install.rb
   gem build ohai.gemspec
 }

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -53,7 +53,7 @@ function Invoke-Build {
 	    gem install ohai-*.gem --no-document
         
         Write-BuildLine " ** Cleaning up lint_roller Gemfile.lock"
-        ruby ./cleanup_lint_roller.rb
+        ruby ./cleanup_gem_lockfiles.rb
         ruby ./post-bundle-install.rb
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
     } finally {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -76,7 +76,7 @@ do_build() {
   bundle config --local retry 5
   bundle config --local silence_root_warning 1
   bundle install
-  ruby ./cleanup_lint_roller.rb
+  ruby ./cleanup_gem_lockfiles.rb
   ruby ./post-bundle-install.rb
   gem build ohai.gemspec
 }
@@ -96,7 +96,7 @@ do_install() {
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
   gem install ohai-*.gem --no-document
-  ruby ./cleanup_lint_roller.rb
+  ruby ./cleanup_gem_lockfiles.rb
 
   build_line "** fixing binstub shebangs"
   fix_interpreter "${pkg_prefix}/vendor/bin/*" "$ruby_pkg" bin/ruby


### PR DESCRIPTION
<h2>Summary</h2>
<p>Renames <code>cleanup_lint_roller.rb</code> to <code>cleanup_gem_lockfiles.rb</code> for clarity, and fixes a false-positive CVE scan finding (GHSA-592j-995h-p23j, rdoc 6.5.0) caused by a stray <code>Gemfile.lock</code> bundled inside the vendored <code>unicode-emoji</code> gem.</p>

<h2>Changes Made</h2>
<ul>
  <li>Renamed <code>cleanup_lint_roller.rb</code> &rarr; <code>cleanup_gem_lockfiles.rb</code> (git history preserved via rename)</li>
  <li>Updated references to the script in <code>habitat/plan.sh</code>, <code>habitat/aarch64-darwin/plan.sh</code>, and <code>habitat/plan.ps1</code></li>
  <li>Added <code>unicode-emoji</code> to the <code>GEMS_WITH_LOCKFILES</code> list so its bundled <code>Gemfile.lock</code> is removed at build time, eliminating the false-positive rdoc CVE flagged by scanners</li>
</ul>

<h2>Testing</h2>
<ul>
  <li>Manually verified script contents and all references were updated</li>
  <li>No existing automated tests cover this build-time cleanup script (shell/build config change only)</li>
</ul>

Fixes - https://progresssoftware.atlassian.net/browse/CHEF-38086

<p>This work was completed with AI assistance following Progress AI policies.</p>